### PR TITLE
Revert "Revert "Some ogl bindings.""

### DIFF
--- a/cx/config.go
+++ b/cx/config.go
@@ -166,12 +166,14 @@ var NATIVE_FUNCTIONS = map[string]bool{
 	/*
 	   OpenGL
 	*/
-	"gl.Init": true, "gl.CreateProgram": true, "gl.LinkProgram": true,
+	"gl.Init": true, "gl.GetError": true, "gl.BindAttribLocation": true, "gl.GetAttribLocation": true,
+	"gl.CullFace": true, "gl.CreateProgram": true, "gl.DeleteProgram": true, "gl.LinkProgram": true,
 	"gl.Clear": true, "gl.UseProgram": true,
 
 	"gl.BindBuffer": true, "gl.BindVertexArray": true, "gl.EnableVertexAttribArray": true,
 	"gl.VertexAttribPointer": true, "gl.DrawArrays": true, "gl.GenBuffers": true,
-	"gl.BufferData": true, "gl.GenVertexArrays": true, "gl.CreateShader": true,
+	"gl.BufferData": true, "gl.GenVertexArrays": true,
+	"gl.CreateShader": true, "gl.DetachShader": true, "gl.DeleteShader": true,
 
 	"gl.Strs": true, "gl.Free": true, "gl.ShaderSource": true,
 	"gl.CompileShader": true, "gl.GetShaderiv": true, "gl.AttachShader": true,
@@ -199,6 +201,7 @@ var NATIVE_FUNCTIONS = map[string]bool{
 	"glfw.Init": true, "glfw.WindowHint": true, "glfw.CreateWindow": true,
 	"glfw.MakeContextCurrent": true, "glfw.ShouldClose": true, "glfw.SetShouldClose": true,
 	"glfw.PollEvents": true, "glfw.SwapBuffers": true, "glfw.GetFramebufferSize": true,
+	"glfw.SwapInterval": true,
 
 	"glfw.SetKeyCallback": true, "glfw.GetTime": true, "glfw.SetMouseButtonCallback": true,
 	"glfw.SetCursorPosCallback": true, "glfw.GetCursorPos": true, "glfw.SetInputMode": true,

--- a/cx/constcodes.go
+++ b/cx/constcodes.go
@@ -5,6 +5,16 @@ const (
 	// opengl
 	CONST_GL_FALSE = iota
 	CONST_GL_TRUE
+	CONST_GL_INVALID_ENUM
+	CONST_GL_INVALID_VALUE
+	CONST_GL_INVALID_OPERATION
+	CONST_GL_STACK_OVERFLOW
+	CONST_GL_STACK_UNDERFLOW
+	CONST_GL_OUT_OF_MEMORY
+	CONST_GL_CULL_FACE
+	CONST_GL_FRONT
+	CONST_GL_BACK
+	CONST_GL_FRONT_AND_BACK
 	CONST_GL_QUADS
 	CONST_GL_COLOR_BUFFER_BIT
 	CONST_GL_DEPTH_BUFFER_BIT
@@ -89,6 +99,16 @@ var ConstNames map[int]string = map[int]string{
 	// opengl
 	CONST_GL_FALSE:               "gl.FALSE",
 	CONST_GL_TRUE:                "gl.TRUE",
+	CONST_GL_INVALID_ENUM:        "gl.INVALID_ENUM",
+	CONST_GL_INVALID_VALUE:       "gl.INVALID_VALUE",
+	CONST_GL_INVALID_OPERATION:   "gl.INVALID_OPERATION",
+	CONST_GL_STACK_OVERFLOW:      "gl.STACK_OVERFLOW",
+	CONST_GL_STACK_UNDERFLOW:     "gl.STACK_UNDERFLOW",
+	CONST_GL_OUT_OF_MEMORY:       "gl.OUT_OF_MEMORY",
+	CONST_GL_CULL_FACE:           "gl.CULL_FACE",
+	CONST_GL_FRONT:               "gl.FRONT",
+	CONST_GL_BACK:                "gl.BACK",
+	CONST_GL_FRONT_AND_BACK:      "gl.FRONT_AND_BACK",
 	CONST_GL_QUADS:               "gl.QUADS",
 	CONST_GL_COLOR_BUFFER_BIT:    "gl.COLOR_BUFFER_BIT",
 	CONST_GL_DEPTH_BUFFER_BIT:    "gl.DEPTH_BUFFER_BIT",
@@ -173,6 +193,16 @@ var ConstCodes map[string]int = map[string]int{
 	// opengl
 	"gl.FALSE":               CONST_GL_FALSE,
 	"gl.TRUE":                CONST_GL_TRUE,
+	"gl.INVALID_ENUM":        CONST_GL_INVALID_ENUM,
+	"gl.INVALID_VALUE":       CONST_GL_INVALID_VALUE,
+	"gl.INVALID_OPERATION":   CONST_GL_INVALID_OPERATION,
+	"gl.STACK_OVERFLOW":      CONST_GL_STACK_OVERFLOW,
+	"gl.STACK_UNDERFLOW":     CONST_GL_STACK_UNDERFLOW,
+	"gl.OUT_OF_MEMORY":       CONST_GL_OUT_OF_MEMORY,
+	"gl.CULL_FACE":           CONST_GL_CULL_FACE,
+	"gl.FRONT":               CONST_GL_FRONT,
+	"gl.BACK":                CONST_GL_BACK,
+	"gl.FRONT_AND_BACK":      CONST_GL_FRONT_AND_BACK,
 	"gl.QUADS":               CONST_GL_QUADS,
 	"gl.COLOR_BUFFER_BIT":    CONST_GL_COLOR_BUFFER_BIT,
 	"gl.DEPTH_BUFFER_BIT":    CONST_GL_DEPTH_BUFFER_BIT,
@@ -257,6 +287,16 @@ var Constants map[int]CXConstant = map[int]CXConstant{
 	CONST_GL_FALSE: CXConstant{Type: TYPE_I32, Value: FromI32(0)},
 
 	CONST_GL_TRUE:                CXConstant{Type: TYPE_I32, Value: FromI32(1)},
+	CONST_GL_INVALID_ENUM:        CXConstant{Type: TYPE_I32, Value: FromI32(1280)},
+	CONST_GL_INVALID_VALUE:       CXConstant{Type: TYPE_I32, Value: FromI32(1281)},
+	CONST_GL_INVALID_OPERATION:   CXConstant{Type: TYPE_I32, Value: FromI32(1282)},
+	CONST_GL_STACK_OVERFLOW:      CXConstant{Type: TYPE_I32, Value: FromI32(1283)},
+	CONST_GL_STACK_UNDERFLOW:     CXConstant{Type: TYPE_I32, Value: FromI32(1284)},
+	CONST_GL_OUT_OF_MEMORY:       CXConstant{Type: TYPE_I32, Value: FromI32(1285)},
+	CONST_GL_CULL_FACE:           CXConstant{Type: TYPE_I32, Value: FromI32(2884)},
+	CONST_GL_FRONT:               CXConstant{Type: TYPE_I32, Value: FromI32(1028)},
+	CONST_GL_BACK:                CXConstant{Type: TYPE_I32, Value: FromI32(1029)},
+	CONST_GL_FRONT_AND_BACK:      CXConstant{Type: TYPE_I32, Value: FromI32(1032)},
 	CONST_GL_QUADS:               CXConstant{Type: TYPE_I32, Value: FromI32(7)},
 	CONST_GL_COLOR_BUFFER_BIT:    CXConstant{Type: TYPE_I32, Value: FromI32(16384)},
 	CONST_GL_DEPTH_BUFFER_BIT:    CXConstant{Type: TYPE_I32, Value: FromI32(256)},

--- a/cx/execute.go
+++ b/cx/execute.go
@@ -834,8 +834,18 @@ var isErrorPresent bool
 // 		// OpenGL
 // 	case "gl.Init":
 // 		err = gl_Init()
+//	case "gl.GetError":
+//		err = gl_GetError()
+//	case "gl.BindAttribLocation":
+//		err = gl.BindAttribLocation((*argsCopy)[0], (*argsCopy)[1], (*argsCopy)[2])
+//	case "gl.GetAttribLocation":
+//		err = gl.GetAttribLocation((*argsCopy)[0], (*argsCopy)[1])
+//	case "gl.CullFace":
+//		err = gl_CullFace()
 // 	case "gl.CreateProgram":
 // 		err = gl_CreateProgram(expr, call)
+//	case "gl.DeleteProgram":
+//		err = gl_DeleteProgram((*argsCopy)[0])
 // 	case "gl.LinkProgram":
 // 		err = gl_LinkProgram((*argsCopy)[0])
 // 	case "gl.Clear":
@@ -860,6 +870,10 @@ var isErrorPresent bool
 // 		err = gl_GenVertexArrays((*argsCopy)[0], (*argsCopy)[1])
 // 	case "gl.CreateShader":
 // 		err = gl_CreateShader((*argsCopy)[0], expr, call)
+//	case "gl.DetachShader":
+//		err = gl_DetachShader((*argsCopy)[0], (*argsCopy)[1])
+//	case "gl.DeleteShader":
+//		err = gl_DetachShader((*argsCopy)[0])
 // 	case "gl.Strs":
 // 		err = gl_Strs((*argsCopy)[0], (*argsCopy)[1])
 // 	case "gl.Free":
@@ -961,6 +975,8 @@ var isErrorPresent bool
 // 		err = glfw_GetTime(expr, call)
 // 	case "glfw.GetFramebufferSize":
 // 		err = glfw_GetFramebufferSize((*argsCopy)[0], expr, call)
+//	case "glfw.SwapInterval":
+//		err = glfw_SwapInterval((*argsCopy)[0])
 // 	case "glfw.SetKeyCallback":
 // 		err = glfw_SetKeyCallback((*argsCopy)[0], (*argsCopy)[1], expr, call)
 // 	case "glfw.SetMouseButtonCallback":

--- a/cx/op_glfw.go
+++ b/cx/op_glfw.go
@@ -59,6 +59,11 @@ func op_glfw_GetFramebufferSize(expr *CXExpression, fp int) {
 	WriteMemory(GetFinalOffset(fp, out2), FromI32(int32(height)))
 }
 
+func op_glfw_SwapInterval(expr *CXExpression, fp int) {
+	inp1 := expr.Inputs[0]
+	glfw.SwapInterval(int(ReadI32(fp, inp1)))
+}
+
 func op_glfw_PollEvents() {
 	glfw.PollEvents()
 }

--- a/cx/op_opengl.go
+++ b/cx/op_opengl.go
@@ -10,6 +10,7 @@ import (
 	_ "image/jpeg"
 	_ "image/gif"
 	"runtime"
+	"unsafe"
 	"strings"
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 )
@@ -22,10 +23,39 @@ func op_gl_Init() {
 	gl.Init()
 }
 
+func op_gl_GetError(expr *CXExpression, fp int) {
+	out1 := expr.Outputs[0]
+	outB1 := FromI32(int32(gl.GetError()))
+	WriteMemory(GetFinalOffset(fp, out1), outB1)
+}
+
+func op_gl_BindAttribLocation(expr *CXExpression, fp int) {
+	inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
+	xstr := cSources[ReadStr(fp, inp3)]
+	gl.BindAttribLocation(uint32(ReadI32(fp, inp1)), uint32(ReadI32(fp, inp2)), *xstr)
+}
+
+func op_gl_GetAttribLocation(expr *CXExpression, fp int) {
+	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
+	xstr := cSources[ReadStr(fp, inp2)]
+	outB1 := FromI32(gl.GetAttribLocation(uint32(ReadI32(fp, inp1)), *xstr))
+	WriteMemory(GetFinalOffset(fp, out1), outB1)
+}
+
+func op_gl_CullFace(expr *CXExpression, fp int) {
+    inp1 := expr.Inputs[0]
+    gl.CullFace(uint32(ReadI32(fp, inp1)))
+}
+
 func op_gl_CreateProgram(expr *CXExpression, fp int) {
 	out1 := expr.Outputs[0]
 	outB1 := FromI32(int32(gl.CreateProgram()))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
+}
+
+func op_gl_DeleteProgram(expr *CXExpression, fp int) {
+	inp1 := expr.Inputs[0]
+	gl.DeleteShader(uint32(ReadI32(fp, inp1)))
 }
 
 func op_gl_LinkProgram(expr *CXExpression, fp int) {
@@ -68,8 +98,8 @@ func op_gl_EnableVertexAttribArray(expr *CXExpression, fp int) {
 }
 
 func op_gl_VertexAttribPointer(expr *CXExpression, fp int) {
-	inp1, inp2, inp3, inp4, inp5 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Inputs[3], expr.Inputs[4]
-	gl.VertexAttribPointer(uint32(ReadI32(fp, inp1)), ReadI32(fp, inp2), uint32(ReadI32(fp, inp3)), ReadBool(fp, inp4), ReadI32(fp, inp5), nil)
+	inp1, inp2, inp3, inp4, inp5, inp6 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Inputs[3], expr.Inputs[4], expr.Inputs[5]
+	gl.VertexAttribPointer(uint32(ReadI32(fp, inp1)), ReadI32(fp, inp2), uint32(ReadI32(fp, inp3)), ReadBool(fp, inp4), ReadI32(fp, inp5), unsafe.Pointer(uintptr(ReadI32(fp, inp6))))
 }
 
 func op_gl_DrawArrays(expr *CXExpression, fp int) {
@@ -106,6 +136,16 @@ func op_gl_CreateShader(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromI32(int32(gl.CreateShader(uint32(ReadI32(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
+}
+
+func op_gl_DetachShader(expr *CXExpression, fp int) {
+	inp1, inp2 := expr.Inputs[0], expr.Inputs[1]
+	gl.DetachShader(uint32(ReadI32(fp, inp1)), uint32(ReadI32(fp, inp2)))
+}
+
+func op_gl_DeleteShader(expr *CXExpression, fp int) {
+	inp1 := expr.Inputs[0]
+	gl.DeleteShader(uint32(ReadI32(fp, inp1)))
 }
 
 func op_gl_Strs(expr *CXExpression, fp int) {

--- a/cx/op_und.go
+++ b/cx/op_und.go
@@ -6,7 +6,7 @@ import (
 	"bufio"
 	"os"
 	"strings"
-
+	"time"
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 )
 
@@ -557,4 +557,9 @@ func op_read(expr *CXExpression, fp int) {
 	off := encoder.SerializeAtomic(int32(heapOffset + OBJECT_HEADER_SIZE))
 
 	WriteMemory(out1Offset, off)
+}
+
+func op_sleep(expr *CXExpression, fp int) {
+	inp1 := expr.Inputs[0]
+	time.Sleep(time.Duration(ReadI64(fp, inp1)))
 }

--- a/cx/opcodes.go
+++ b/cx/opcodes.go
@@ -36,6 +36,7 @@ const (
 	OP_UND_PRINTF
 	OP_UND_SPRINTF
 	OP_UND_READ
+	OP_UND_SLEEP
 
 	OP_BOOL_PRINT
 
@@ -243,7 +244,12 @@ const (
 
 	// opengl
 	OP_GL_INIT
+	OP_GL_GET_ERROR
+	OP_GL_BIND_ATTRIB_LOCATION
+	OP_GL_GET_ATTRIB_LOCATION
+	OP_GL_CULL_FACE
 	OP_GL_CREATE_PROGRAM
+	OP_GL_DELETE_PROGRAM
 	OP_GL_LINK_PROGRAM
 	OP_GL_CLEAR
 	OP_GL_USE_PROGRAM
@@ -256,6 +262,8 @@ const (
 	OP_GL_BUFFER_DATA
 	OP_GL_GEN_VERTEX_ARRAYS
 	OP_GL_CREATE_SHADER
+	OP_GL_DETACH_SHADER
+	OP_GL_DELETE_SHADER
 	OP_GL_STRS
 	OP_GL_FREE
 	OP_GL_SHADER_SOURCE
@@ -306,6 +314,7 @@ const (
 	OP_GLFW_POLL_EVENTS
 	OP_GLFW_SWAP_BUFFERS
 	OP_GLFW_GET_FRAMEBUFFER_SIZE
+	OP_GLFW_SWAP_INTERVAL
 	OP_GLFW_SET_KEY_CALLBACK
 	OP_GLFW_GET_TIME
 	OP_GLFW_SET_MOUSE_BUTTON_CALLBACK
@@ -386,6 +395,8 @@ func execNative(prgrm *CXProgram) {
 		op_sprintf(expr, fp)
 	case OP_UND_READ:
 		op_read(expr, fp)
+	case OP_UND_SLEEP:
+		op_sleep(expr, fp)
 
 	case OP_BYTE_BYTE:
 		op_byte_byte(expr, fp)
@@ -736,12 +747,22 @@ func execNative(prgrm *CXProgram) {
 		op_aff_print(expr, fp)
 	case OP_AFF_QUERY:
 		op_aff_query(expr, fp)
-		
+
 		// opengl
 	case OP_GL_INIT:
 		op_gl_Init()
+	case OP_GL_GET_ERROR:
+		op_gl_GetError(expr, fp)
+	case OP_GL_BIND_ATTRIB_LOCATION:
+		op_gl_BindAttribLocation(expr, fp)
+	case OP_GL_GET_ATTRIB_LOCATION:
+		op_gl_GetAttribLocation(expr, fp)
+	case OP_GL_CULL_FACE:
+		op_gl_CullFace(expr, fp)
 	case OP_GL_CREATE_PROGRAM:
 		op_gl_CreateProgram(expr, fp)
+	case OP_GL_DELETE_PROGRAM:
+		op_gl_DeleteProgram(expr, fp)
 	case OP_GL_LINK_PROGRAM:
 		op_gl_LinkProgram(expr, fp)
 	case OP_GL_CLEAR:
@@ -766,6 +787,10 @@ func execNative(prgrm *CXProgram) {
 		op_gl_GenVertexArrays(expr, fp)
 	case OP_GL_CREATE_SHADER:
 		op_gl_CreateShader(expr, fp)
+	case OP_GL_DETACH_SHADER:
+		op_gl_DetachShader(expr, fp)
+	case OP_GL_DELETE_SHADER:
+		op_gl_DeleteShader(expr, fp)
 	case OP_GL_STRS:
 		op_gl_Strs(expr, fp)
 	case OP_GL_FREE:
@@ -862,6 +887,8 @@ func execNative(prgrm *CXProgram) {
 		op_glfw_SwapBuffers(expr, fp)
 	case OP_GLFW_GET_FRAMEBUFFER_SIZE:
 		op_glfw_GetFramebufferSize(expr, fp)
+	case OP_GLFW_SWAP_INTERVAL:
+		op_glfw_SwapInterval(expr, fp)
 	case OP_GLFW_SET_KEY_CALLBACK:
 		op_glfw_SetKeyCallback(expr, fp)
 	case OP_GLFW_GET_TIME:
@@ -922,6 +949,7 @@ var OpNames map[int]string = map[int]string{
 	OP_UND_PRINTF:   "printf",
 	OP_UND_SPRINTF:  "sprintf",
 	OP_UND_READ:     "read",
+	OP_UND_SLEEP:    "sleep",
 
 	OP_BYTE_BYTE: "byte.byte",
 	OP_BYTE_STR: "byte.str",
@@ -1097,7 +1125,12 @@ var OpNames map[int]string = map[int]string{
 
 	// opengl
 	OP_GL_INIT:                       "gl.Init",
+	OP_GL_GET_ERROR:                  "gl.GetError",
+	OP_GL_BIND_ATTRIB_LOCATION:       "gl.BindAttribLocation",
+	OP_GL_GET_ATTRIB_LOCATION:        "gl.GetAttribLocation",
+	OP_GL_CULL_FACE:                  "gl.CullFace",
 	OP_GL_CREATE_PROGRAM:             "gl.CreateProgram",
+	OP_GL_DELETE_PROGRAM:             "gl.DeleteProgram",
 	OP_GL_LINK_PROGRAM:               "gl.LinkProgram",
 	OP_GL_CLEAR:                      "gl.Clear",
 	OP_GL_USE_PROGRAM:                "gl.UseProgram",
@@ -1110,6 +1143,8 @@ var OpNames map[int]string = map[int]string{
 	OP_GL_BUFFER_DATA:                "gl.BufferData",
 	OP_GL_GEN_VERTEX_ARRAYS:          "gl.GenVertexArrays",
 	OP_GL_CREATE_SHADER:              "gl.CreateShader",
+	OP_GL_DETACH_SHADER:              "gl.DetachShader",
+	OP_GL_DELETE_SHADER:              "gl.DeleteShader",
 	OP_GL_STRS:                       "gl.Strs",
 	OP_GL_FREE:                       "gl.Free",
 	OP_GL_SHADER_SOURCE:              "gl.ShaderSource",
@@ -1159,6 +1194,7 @@ var OpNames map[int]string = map[int]string{
 	OP_GLFW_POLL_EVENTS:               "glfw.PollEvents",
 	OP_GLFW_SWAP_BUFFERS:              "glfw.SwapBuffers",
 	OP_GLFW_GET_FRAMEBUFFER_SIZE:      "glfw.GetFramebufferSize",
+	OP_GLFW_SWAP_INTERVAL:             "glfw.SwapInterval",
 	OP_GLFW_SET_KEY_CALLBACK:          "glfw.SetKeyCallback",
 	OP_GLFW_GET_TIME:                  "glfw.GetTime",
 	OP_GLFW_SET_MOUSE_BUTTON_CALLBACK: "glfw.SetMouseButtonCallback",
@@ -1206,6 +1242,7 @@ var OpCodes map[string]int = map[string]int{
 	"printf":   OP_UND_PRINTF,
 	"sprintf":  OP_UND_SPRINTF,
 	"read":     OP_UND_READ,
+	"sleep":    OP_UND_SLEEP,
 
 	"byte.byte":  OP_BYTE_BYTE,
 	"byte.str":   OP_BYTE_STR,
@@ -1382,7 +1419,12 @@ var OpCodes map[string]int = map[string]int{
 
 	// opengl
 	"gl.Init":                    OP_GL_INIT,
+	"gl.GetError":                OP_GL_GET_ERROR,
+	"gl.BindAttribLocation":      OP_GL_BIND_ATTRIB_LOCATION,
+	"gl.GetAttribLocation":       OP_GL_GET_ATTRIB_LOCATION,
+	"gl.CullFace":                OP_GL_CULL_FACE,
 	"gl.CreateProgram":           OP_GL_CREATE_PROGRAM,
+	"gl.DeleteProgram":           OP_GL_DELETE_PROGRAM,
 	"gl.LinkProgram":             OP_GL_LINK_PROGRAM,
 	"gl.Clear":                   OP_GL_CLEAR,
 	"gl.UseProgram":              OP_GL_USE_PROGRAM,
@@ -1395,6 +1437,8 @@ var OpCodes map[string]int = map[string]int{
 	"gl.BufferData":              OP_GL_BUFFER_DATA,
 	"gl.GenVertexArrays":         OP_GL_GEN_VERTEX_ARRAYS,
 	"gl.CreateShader":            OP_GL_CREATE_SHADER,
+	"gl.DetachShader":            OP_GL_DETACH_SHADER,
+	"gl.DeleteShader":            OP_GL_DELETE_SHADER,
 	"gl.Strs":                    OP_GL_STRS,
 	"gl.Free":                    OP_GL_FREE,
 	"gl.ShaderSource":            OP_GL_SHADER_SOURCE,
@@ -1444,6 +1488,7 @@ var OpCodes map[string]int = map[string]int{
 	"glfw.PollEvents":             OP_GLFW_POLL_EVENTS,
 	"glfw.SwapBuffers":            OP_GLFW_SWAP_BUFFERS,
 	"glfw.GetFramebufferSize":     OP_GLFW_GET_FRAMEBUFFER_SIZE,
+	"glfw.SwapInterval":           OP_GLFW_SWAP_INTERVAL,
 	"glfw.SetKeyCallback":         OP_GLFW_SET_KEY_CALLBACK,
 	"glfw.GetTime":                OP_GLFW_GET_TIME,
 	"glfw.SetMouseButtonCallback": OP_GLFW_SET_MOUSE_BUTTON_CALLBACK,
@@ -1490,6 +1535,7 @@ var Natives map[int]*CXFunction = map[int]*CXFunction{
 	OP_UND_PRINTF:   MakeNative(OP_UND_PRINTF, []int{TYPE_UNDEFINED}, []int{}),
 	OP_UND_SPRINTF:  MakeNative(OP_UND_SPRINTF, []int{TYPE_UNDEFINED}, []int{TYPE_STR}),
 	OP_UND_READ:     MakeNative(OP_UND_READ, []int{}, []int{TYPE_STR}),
+	OP_UND_SLEEP:    MakeNative(OP_UND_SLEEP, []int{TYPE_I64}, []int{}),
 
 	OP_BYTE_BYTE:   MakeNative(OP_BYTE_BYTE, []int{TYPE_BYTE}, []int{TYPE_BYTE}),
 	OP_BYTE_STR:    MakeNative(OP_BYTE_STR, []int{TYPE_BYTE}, []int{TYPE_STR}),
@@ -1666,19 +1712,26 @@ var Natives map[int]*CXFunction = map[int]*CXFunction{
 
 	// opengl
 	OP_GL_INIT:                       MakeNative(OP_GL_INIT, []int{}, []int{}),
+	OP_GL_GET_ERROR:                  MakeNative(OP_GL_GET_ERROR, []int{}, []int{TYPE_I32}),
+	OP_GL_BIND_ATTRIB_LOCATION:       MakeNative(OP_GL_BIND_ATTRIB_LOCATION, []int{TYPE_I32, TYPE_I32, TYPE_STR}, []int{}),
+	OP_GL_GET_ATTRIB_LOCATION:        MakeNative(OP_GL_GET_ATTRIB_LOCATION, []int{TYPE_I32, TYPE_STR}, []int{TYPE_I32}),
+	OP_GL_CULL_FACE:                  MakeNative(OP_GL_CULL_FACE, []int{TYPE_I32}, []int{}),
 	OP_GL_CREATE_PROGRAM:             MakeNative(OP_GL_CREATE_PROGRAM, []int{}, []int{TYPE_I32}),
+	OP_GL_DELETE_PROGRAM:             MakeNative(OP_GL_DELETE_PROGRAM, []int{TYPE_I32}, []int{}),
 	OP_GL_LINK_PROGRAM:               MakeNative(OP_GL_LINK_PROGRAM, []int{TYPE_I32}, []int{}),
 	OP_GL_CLEAR:                      MakeNative(OP_GL_CLEAR, []int{TYPE_I32}, []int{}),
 	OP_GL_USE_PROGRAM:                MakeNative(OP_GL_USE_PROGRAM, []int{TYPE_I32}, []int{}),
 	OP_GL_BIND_BUFFER:                MakeNative(OP_GL_BIND_BUFFER, []int{TYPE_I32, TYPE_I32}, []int{}),
 	OP_GL_BIND_VERTEX_ARRAY:          MakeNative(OP_GL_BIND_VERTEX_ARRAY, []int{TYPE_I32}, []int{}),
 	OP_GL_ENABLE_VERTEX_ATTRIB_ARRAY: MakeNative(OP_GL_ENABLE_VERTEX_ATTRIB_ARRAY, []int{TYPE_I32}, []int{}),
-	OP_GL_VERTEX_ATTRIB_POINTER:      MakeNative(OP_GL_VERTEX_ATTRIB_POINTER, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_BOOL, TYPE_I32}, []int{}),
+	OP_GL_VERTEX_ATTRIB_POINTER:      MakeNative(OP_GL_VERTEX_ATTRIB_POINTER, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_BOOL, TYPE_I32, TYPE_I32}, []int{}),
 	OP_GL_DRAW_ARRAYS:                MakeNative(OP_GL_DRAW_ARRAYS, []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{}),
 	OP_GL_GEN_BUFFERS:                MakeNative(OP_GL_GEN_BUFFERS, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
 	OP_GL_BUFFER_DATA:                MakeNative(OP_GL_BUFFER_DATA, []int{TYPE_I32, TYPE_I32, TYPE_F32, TYPE_I32}, []int{}),
 	OP_GL_GEN_VERTEX_ARRAYS:          MakeNative(OP_GL_GEN_VERTEX_ARRAYS, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
 	OP_GL_CREATE_SHADER:              MakeNative(OP_GL_CREATE_SHADER, []int{TYPE_I32}, []int{TYPE_I32}),
+	OP_GL_DETACH_SHADER:              MakeNative(OP_GL_DETACH_SHADER, []int{TYPE_I32, TYPE_I32}, []int{}),
+	OP_GL_DELETE_SHADER:              MakeNative(OP_GL_DELETE_SHADER, []int{TYPE_I32}, []int{}),
 	OP_GL_STRS:                       MakeNative(OP_GL_STRS, []int{TYPE_STR, TYPE_STR}, []int{}),
 	OP_GL_FREE:                       MakeNative(OP_GL_FREE, []int{TYPE_STR}, []int{}),
 	OP_GL_SHADER_SOURCE:              MakeNative(OP_GL_SHADER_SOURCE, []int{TYPE_I32, TYPE_I32, TYPE_STR}, []int{}),
@@ -1730,6 +1783,7 @@ var Natives map[int]*CXFunction = map[int]*CXFunction{
 	OP_GLFW_POLL_EVENTS:               MakeNative(OP_GLFW_POLL_EVENTS, []int{}, []int{}),
 	OP_GLFW_SWAP_BUFFERS:              MakeNative(OP_GLFW_SWAP_BUFFERS, []int{TYPE_STR}, []int{}),
 	OP_GLFW_GET_FRAMEBUFFER_SIZE:      MakeNative(OP_GLFW_GET_FRAMEBUFFER_SIZE, []int{TYPE_STR}, []int{TYPE_I32, TYPE_I32}),
+	OP_GLFW_SWAP_INTERVAL:             MakeNative(OP_GLFW_SWAP_INTERVAL, []int{TYPE_I32}, []int{}),
 	OP_GLFW_SET_KEY_CALLBACK:          MakeNative(OP_GLFW_SET_KEY_CALLBACK, []int{TYPE_STR, TYPE_STR}, []int{}),
 	OP_GLFW_GET_TIME:                  MakeNative(OP_GLFW_GET_TIME, []int{}, []int{TYPE_F64}),
 	OP_GLFW_SET_MOUSE_BUTTON_CALLBACK: MakeNative(OP_GLFW_SET_MOUSE_BUTTON_CALLBACK, []int{TYPE_STR, TYPE_STR}, []int{}),

--- a/examples/opengl/triangle-vao.cx
+++ b/examples/opengl/triangle-vao.cx
@@ -4,25 +4,25 @@
 
 package main
 
-// import "gl"
-// import "glfw"
+ import "gl"
+ import "glfw"
 
 var width i32 = 600
 var height i32 = 600
 
-var vertexShaderSource str = "
+var vertexShaderSource str = `
           #version 120
           void main() {
             gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * gl_Vertex;
           }
-"
+`
 
-var fragmentShaderSource str = "
+var fragmentShaderSource str = `
           #version 120
           void main() {
             gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
           }
-"
+`
 
 // var triangle []f32 = []f32{
 // 	0.0, 0.5, 0.0,
@@ -85,24 +85,24 @@ func initOpenGL () (program i32) {
 	
 	vertexShader = gl.CreateShader(gl.VERTEX_SHADER)
 	
-	gl.Strs("
+	gl.Strs(`
           #version 120
           void main() {
             gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * gl_Vertex;
           }
-", "csources")
+`, "csources")
 	gl.ShaderSource(vertexShader, 1, "csources")
 	gl.Free("csources")
 	gl.CompileShader(vertexShader)
 
 	fragmentShader = gl.CreateShader(gl.FRAGMENT_SHADER)
 
-	gl.Strs("
+	gl.Strs(`
           #version 120
           void main() {
             gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
           }
-", "csources")
+`, "csources")
 	gl.ShaderSource(fragmentShader, 1, "csources")
 	gl.Free("csources")
 	gl.CompileShader(fragmentShader)
@@ -118,17 +118,17 @@ func initOpenGL () (program i32) {
 
 func makeVao (points [9]f32) (vao i32) {
 	var vbo i32
-	gl.GenBuffers(1, vbo) // should be &vbo. to be fixed, but should work as it is
+	vbo = gl.GenBuffers(1, vbo) // should be &vbo. to be fixed, but should work as it is
 	gl.BindBuffer(gl.ARRAY_BUFFER, vbo)
-	gl.BufferData(gl.ARRAY_BUFFER, i32.mul(4, []f32.len(points)), points, gl.DYNAMIC_DRAW)
+	gl.BufferData(gl.ARRAY_BUFFER, i32.mul(4, 9/*[]f32.len(points)*/), points, gl.DYNAMIC_DRAW)
 
 	var vao i32
-	gl.GenVertexArrays(1, vao)
+	vao = gl.GenVertexArrays(1, vao)
 	
 	gl.BindVertexArray(vao)
 	gl.EnableVertexAttribArray(0)
 	gl.BindBuffer(gl.ARRAY_BUFFER, vbo)
-	gl.VertexAttribPointer(0, 3, gl.FLOAT, false, 0)
+	gl.VertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0)
 }
 
 func draw (vao i32, window str, program i32) () {
@@ -136,18 +136,14 @@ func draw (vao i32, window str, program i32) () {
 	gl.UseProgram(program)
 
 	gl.BindVertexArray(vao)
-	gl.DrawArrays(gl.TRIANGLES, 0, i32.div([]f32.len(triangle), 3))
+	gl.DrawArrays(gl.TRIANGLES, 0, i32.div(9/*[]f32.len(triangle)*/, 3))
 
 	glfw.PollEvents()
 	glfw.SwapBuffers("window")
 }
 
 func main () () {
-	triangle = [9]f32{
-		0.0, 0.5, 0.0,
-		-0.5, -0.5, 0.0,
-		0.5, -0.5, 0.0
-	}
+	triangle = [9]f32{0.0, 0.5, 0.0, -0.5, -0.5, 0.0, 0.5, -0.5, 0.0}
 	
 	initGlfw("window")
 
@@ -157,11 +153,11 @@ func main () () {
 	program = initOpenGL()
 	vao = makeVao(triangle)
 
-	var ratio f32
+//	var ratio f32
 
-	for not(glfw.ShouldClose("window")) {
-		bufferWidth, bufferHeight := glfw.GetFramebufferSize("window")
-		ratio = f32.div(i32.f32(bufferWidth), i32.f32(bufferHeight))
+	for glfw.ShouldClose("window") == false {
+		//bufferWidth, bufferHeight := glfw.GetFramebufferSize("window")
+//		ratio = f32.div(i32.f32(bufferWidth), i32.f32(bufferHeight))
 
 		draw(vao, "window", program)
 	}


### PR DESCRIPTION
Reverts skycoin/cx#21

For reference:

* Added : glGetError, glCullFace, glBindAttribLocation, glGetAttribLocation, glDeleteProgram, glDetachShader, glDeleteShader
glGetError is returning a GLenum which is typedefed as follows in <gl.h> :

```
typedef unsigned int GLenum;
```

Which could be ui32, ui64 depending of the underlying architecture, however GLenum are serialized as I32 in cx. There're could also be some int/uint overflow issues. Is this something you want to look at ?

* Modified op_gl_VertexAttribPointer to use the offset parameter (all calls to gl.VertexAttribPointer will break).