### PR TITLE
Fixes #106 and #57

### DIFF
--- a/cx/adders.go
+++ b/cx/adders.go
@@ -70,7 +70,9 @@ func (arg *CXArgument) AddType(typ string) *CXArgument {
 		size := GetArgSize(typCode)
 		arg.Size = size
 		arg.TotalSize = size
-	}
+	} else {
+        arg.Type = TYPE_UNDEFINED
+    }
 
 	return arg
 }

--- a/cx/config.go
+++ b/cx/config.go
@@ -75,7 +75,8 @@ const (
 )
 
 const (
-	TYPE_AFF = iota
+	TYPE_UNDEFINED = iota
+	TYPE_AFF
 	TYPE_BOOL
 	TYPE_BYTE
 	TYPE_STR
@@ -92,7 +93,6 @@ const (
 
 	TYPE_THRESHOLD
 
-	TYPE_UNDEFINED
 	TYPE_CUSTOM
 	TYPE_POINTER
 	TYPE_IDENTIFIER
@@ -100,7 +100,7 @@ const (
 
 var TypeCounter int
 var TypeCodes map[string]int = map[string]int{
-	"identifier": TYPE_IDENTIFIER,
+	"ident":      TYPE_IDENTIFIER,
 	"aff":        TYPE_AFF,
 	"bool":       TYPE_BOOL,
 	"byte":       TYPE_BYTE,


### PR DESCRIPTION
Problem: 
The function AddType is not setting the Type field of the CXArgument when it's not a primary type. It's defaulting to the first value of the TYPE_* constants : TYPE_AFF.

Changes:
- Move the TYPE_UNDEFINED to the first place of the TYPE_* constants (to gracefully fallback if not initialized properly)
- Set .Type to TYPE_UNDEFINED when the CXArgument is not a primary type
- Renamed the TYPE_IDENTIFIER key value in the TypeCodes map to match the one in the TypeNames map