### PR TITLE
Refactored opcode declarations

### DIFF
--- a/cx/constcodes.go
+++ b/cx/constcodes.go
@@ -3,7 +3,7 @@ package base
 // constant codes
 const (
 	// https://www.khronos.org/registry/OpenGL/api/GL/glcorearb.h
-	/* gl_1_0 */
+	// gl_1_0
 	CONST_GL_DEPTH_BUFFER_BIT = iota
 	CONST_GL_STENCIL_BUFFER_BIT
 	CONST_GL_COLOR_BUFFER_BIT
@@ -68,23 +68,23 @@ const (
 	CONST_GL_TEXTURE_WRAP_T
 	CONST_GL_REPEAT
 
-	/* gl_1_1 */
+	// gl_1_1
 	CONST_GL_RGBA8
 	CONST_GL_VERTEX_ARRAY
 
-	/* gl_1_2 */
+	// gl_1_2
 	CONST_GL_TEXTURE_WRAP_R
 	CONST_GL_CLAMP_TO_EDGE
 
-	/* gl_1_3 */
+	// gl_1_3
 	CONST_GL_TEXTURE0
 	CONST_GL_MULTISAMPLE_ARB // remove _ARB
 	CONST_GL_CLAMP_TO_BORDER
 
-	/* gl_1_4 */
+	// gl_1_4
 	CONST_GL_MIRRORED_REPEAT
 
-	/* gl_1_5 */
+	// gl_1_5
 	CONST_GL_ARRAY_BUFFER
 	CONST_GL_STREAM_DRAW
 	CONST_GL_STREAM_READ
@@ -96,11 +96,11 @@ const (
 	CONST_GL_DYNAMIC_READ
 	CONST_GL_DYNAMIC_COPY
 
-	/* gl_2_0 */
+	// gl_2_0
 	CONST_GL_FRAGMENT_SHADER
 	CONST_GL_VERTEX_SHADER
 
-	/* gl_3_0 */
+	// gl_3_0
 	CONST_GL_FRAMEBUFFER_UNDEFINED
 	CONST_GL_FRAMEBUFFER_COMPLETE
 	CONST_GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT
@@ -115,13 +115,13 @@ const (
 	CONST_GL_RENDERBUFFER
 	CONST_GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE
 
-	/* gl_3_2 */
+	// gl_3_2
 	CONST_GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS
 
-	/* gl_4_4 */
+	// gl_4_4
 	CONST_GL_MIRROR_CLAMP_TO_EDGE
 
-	/* Fixed pipeline. Deprecated ? */
+	// Fixed pipeline. Deprecated ?
 	CONST_GL_POLYGON
 	CONST_GL_MODELVIEW
 	CONST_GL_PROJECTION
@@ -168,496 +168,177 @@ const (
 )
 
 // For the parser. These shouldn't be used in the runtime for performance reasons
-var ConstNames map[int]string = map[int]string{
-	/* gl_1_0 */
-	CONST_GL_DEPTH_BUFFER_BIT:       "gl.DEPTH_BUFFER_BIT",
-	CONST_GL_STENCIL_BUFFER_BIT:     "gl.STENCIL_BUFFER_BIT",
-	CONST_GL_COLOR_BUFFER_BIT:       "gl.COLOR_BUFFER_BIT",
-	CONST_GL_FALSE:                  "gl.FALSE",
-	CONST_GL_TRUE:                   "gl.TRUE",
-	CONST_GL_POINTS:                 "gl.POINTS",
-	CONST_GL_LINES:                  "gl.LINES",
-	CONST_GL_LINE_LOOP:              "gl.LINE_LOOP",
-	CONST_GL_LINE_STRIP:             "gl.LINE_STRIP",
-	CONST_GL_TRIANGLES:              "gl.TRIANGLES",
-	CONST_GL_TRIANGLE_STRIP:         "gl.TRIANGLE_STRIP",
-	CONST_GL_TRIANGLE_FAN:           "gl.TRIANGLE_FAN",
-	CONST_GL_QUADS:                  "gl.QUADS",
-	CONST_GL_LESS:                   "gl.LESS",
-	CONST_GL_EQUAL:                  "gl.EQUAL",
-	CONST_GL_LEQUAL:                 "gl.LEQUAL",
-	CONST_GL_GREATER:                "gl.GREATER",
-	CONST_GL_NOTEQUAL:               "gl.NOTEQUAL",
-	CONST_GL_GEQUAL:                 "gl.GEQUAL",
-	CONST_GL_ALWAYS:                 "gl.ALWAYS",
-	CONST_GL_SRC_ALPHA:              "gl.SRC_ALPHA",
-	CONST_GL_ONE_MINUS_SRC_ALPHA:    "gl.ONE_MINUS_SRC_ALPHA",
-	CONST_GL_FRONT:                  "gl.FRONT",
-	CONST_GL_BACK:                   "gl.BACK",
-	CONST_GL_FRONT_AND_BACK:         "gl.FRONT_AND_BACK",
-	CONST_GL_NO_ERROR:               "gl.NO_ERROR",
-	CONST_GL_INVALID_ENUM:           "gl.INVALID_ENUM",
-	CONST_GL_INVALID_VALUE:          "gl.INVALID_VALUE",
-	CONST_GL_INVALID_OPERATION:      "gl.INVALID_OPERATION",
-	CONST_GL_STACK_OVERFLOW:         "gl.STACK_OVERFLOW",
-	CONST_GL_STACK_UNDERFLOW:        "gl.STACK_UNDERFLOW",
-	CONST_GL_OUT_OF_MEMORY:          "gl.OUT_OF_MEMORY",
-	CONST_GL_LINE_SMOOTH:            "gl.LINE_SMOOTH",
-	CONST_GL_POLYGON_SMOOTH:         "gl.POLYGON_SMOOTH",
-	CONST_GL_CULL_FACE:              "gl.CULL_FACE",
-	CONST_GL_DEPTH_TEST:             "gl.DEPTH_TEST",
-	CONST_GL_DITHER:                 "gl.DITHER",
-	CONST_GL_BLEND:                  "gl.BLEND",
-	CONST_GL_SCISSOR_TEST:           "gl.SCISSOR_TEST",
-	CONST_GL_POLYGON_SMOOTH_HINT:    "gl.POLYGON_SMOOTH_HINT",
-	CONST_GL_TEXTURE_2D:             "gl.TEXTURE_2D",
-	CONST_GL_TEXTURE_WIDTH:          "gl.TEXTURE_WIDTH",
-	CONST_GL_TEXTURE_HEIGHT:         "gl.TEXTURE_HEIGHT",
-	CONST_GL_DONT_CARE:              "gl.DONT_CARE",
-	CONST_GL_UNSIGNED_BYTE:          "gl.UNSIGNED_BYTE",
-	CONST_GL_FLOAT:                  "gl.FLOAT",
-	CONST_GL_TEXTURE:                "gl.TEXTURE",
-	CONST_GL_COLOR:                  "gl.COLOR",
-	CONST_GL_DEPTH_COMPONENT:        "gl.DEPTH_COMPONENT",
-	CONST_GL_RGBA:                   "gl.RGBA",
-	CONST_GL_REPLACE:                "gl.REPLACE",
-	CONST_GL_NEAREST:                "gl.NEAREST",
-	CONST_GL_LINEAR:                 "gl.LINEAR",
-	CONST_GL_NEAREST_MIPMAP_NEAREST: "gl.NEAREST_MIPMAP_NEAREST",
-	CONST_GL_LINEAR_MIPMAP_NEAREST:  "gl.LINEAR_MIPMAP_NEAREST",
-	CONST_GL_NEAREST_MIPMAP_LINEAR:  "gl.NEAREST_MIPMAP_LINEAR",
-	CONST_GL_LINEAR_MIPMAP_LINEAR:   "gl.LINEAR_MIPMAP_LINEAR",
-	CONST_GL_TEXTURE_MAG_FILTER:     "gl.TEXTURE_MAP_FILTER",
-	CONST_GL_TEXTURE_MIN_FILTER:     "gl.TEXTURE_MIN_FILTER",
-	CONST_GL_TEXTURE_WRAP_S:         "gl.TEXTURE_WRAP_S",
-	CONST_GL_TEXTURE_WRAP_T:         "gl.TEXTURE_WRAP_T",
-	CONST_GL_REPEAT:                 "gl.REPEAT",
+var ConstNames map[int]string = map[int]string {}
+var ConstCodes map[string]int = map[string]int {}
+var Constants map[int]CXConstant = map[int]CXConstant {}
 
-	/* gl_1_1 */
-	CONST_GL_RGBA8:                  "gl.RGBA8",
-	CONST_GL_VERTEX_ARRAY:           "gl.VERTEX_ARRAY",
-
-	/* gl_1_2 */
-	CONST_GL_TEXTURE_WRAP_R:         "gl.TEXTURE_WRAP_R",
-	CONST_GL_CLAMP_TO_EDGE:          "gl.CLAMP_TO_EDGE",
-
-	/* gl_1_3 */
-	CONST_GL_TEXTURE0:               "gl.TEXTURE0",
-	CONST_GL_MULTISAMPLE_ARB:        "gl.MULTISAMPLE_ARB", // remove _ARB
-	CONST_GL_CLAMP_TO_BORDER:        "gl.CLAMP_TO_BORDER",
-
-	/* gl_1_4 */
-	CONST_GL_MIRRORED_REPEAT:        "gl.MIRRORED_REPEAT",
-
-	/* gl_1_5 */
-	CONST_GL_ARRAY_BUFFER:        "gl.ARRAY_BUFFER",
-	CONST_GL_STREAM_DRAW:         "gl.STREAM_DRAW",
-	CONST_GL_STREAM_READ:         "gl.STREAM_READ",
-	CONST_GL_STREAM_COPY:         "gl.STREAM_COPY",
-	CONST_GL_STATIC_DRAW:         "gl.STATIC_DRAW",
-	CONST_GL_STATIC_READ:         "gl.STATIC_READ",
-	CONST_GL_STATIC_COPY:         "gl.STATIC_COPY",
-	CONST_GL_DYNAMIC_DRAW:        "gl.DYNAMIC_DRAW",
-	CONST_GL_DYNAMIC_READ:        "gl.DYNAMIC_READ",
-	CONST_GL_DYNAMIC_COPY:        "gl.DYNAMIC_COPY",
-
-	/* gl_2_0 */
-	CONST_GL_FRAGMENT_SHADER:     "gl.FRAGMENT_SHADER",
-	CONST_GL_VERTEX_SHADER:       "gl.VERTEX_SHADER",
-
-	/* gl_3_0 */
-	CONST_GL_FRAMEBUFFER_UNDEFINED:                     "gl.FRAMEBUFFER_UNDEFINED",
-	CONST_GL_FRAMEBUFFER_COMPLETE:                      "gl.FRAMEBUFFER_COMPLETE",
-	CONST_GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT:         "gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT",
-	CONST_GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT: "gl.FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT",
-	CONST_GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER:        "gl.FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER",
-	CONST_GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER:        "gl.FRAMEBUFFER_INCOMPLETE_READ_BUFFER",
-	CONST_GL_FRAMEBUFFER_UNSUPPORTED:                   "gl.FRAMEBUFFER_UNSUPPORTED",
-	CONST_GL_COLOR_ATTACHMENT0:                         "gl.COLOR_ATTACHMENT0",
-	CONST_GL_DEPTH_ATTACHMENT:                          "gl.DEPTH_ATTACHMENT",
-	CONST_GL_STENCIL_ATTACHMENT:                        "gl.STENCIL_ATTACHMENT",
-	CONST_GL_FRAMEBUFFER:                               "gl.FRAMEBUFFER",
-	CONST_GL_RENDERBUFFER:                              "gl.RENDERBUFFER",
-	CONST_GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE:        "gl.FRAMEBUFFER_INCOMPLETE_MULTISAMPLE",
-
-	/* gl_3_2 */
-	CONST_GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS:      "gl.FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS",
-
-	/* gl_4_4 */
-	CONST_GL_MIRROR_CLAMP_TO_EDGE: "gl.MIRROR_CLAMP_TO_EDGE",
-
-	/* Fixed pipeline. Deprecated ? */
-	CONST_GL_POLYGON:             "gl.POLYGON",
-	CONST_GL_MODELVIEW:           "gl.MODELVIEW",
-	CONST_GL_PROJECTION:          "gl.PROJECTION",
-	CONST_GL_MODELVIEW_MATRIX:    "gl.MODELVIEW_MATRIX",
-	CONST_GL_LIGHTING:            "gl.LIGHTING",
-	CONST_GL_LIGHT0:              "gl.LIGHT0",
-	CONST_GL_AMBIENT:             "gl.AMBIENT",
-	CONST_GL_DIFFUSE:             "gl.DIFFUSE",
-	CONST_GL_POSITION:            "gl.POSITION",
-	CONST_GL_TEXTURE_ENV:         "gl.TEXTURE_ENV",
-	CONST_GL_TEXTURE_ENV_MODE:    "gl.TEXTURE_ENV_MODE",
-	CONST_GL_MODULATE:            "gl.MODULATE",
-	CONST_GL_DECAL:               "gl.DECAL",
-	CONST_GL_POINT_SMOOTH:        "gl.POINT_SMOOTH",
-
-	// glfw
-	CONST_GLFW_FALSE:                     "glfw.False",
-	CONST_GLFW_TRUE:                      "glfw.True",
-	CONST_GLFW_PRESS:                     "glfw.Press",
-	CONST_GLFW_RELEASE:                   "glfw.Release",
-	CONST_GLFW_REPEAT:                    "glfw.Repeat",
-	CONST_GLFW_KEY_UNKNOWN:               "glfw.KeyUnknown",
-	CONST_GLFW_CURSOR:                    "glfw.Cursor",
-	CONST_GLFW_STICKY_KEYS:               "glfw.StickyKeys",
-	CONST_GLFW_STICKY_MOUSE_BUTTONS:      "glfw.StickyMouseButtons",
-	CONST_GLFW_CURSOR_NORMAL:             "glfw.CursorNormal",
-	CONST_GLFW_CURSOR_HIDDEN:             "glfw.CursorHidden",
-	CONST_GLFW_CURSOR_DISABLED:           "glfw.CursorDisabled",
-	CONST_GLFW_RESIZABLE:                 "glfw.Resizable",
-	CONST_GLFW_CONTEXT_VERSION_MAJOR:     "glfw.ContextVersionMajor",
-	CONST_GLFW_CONTEXT_VERSION_MINOR:     "glfw.ContextVersionMinor",
-	CONST_GLFW_OPENGL_PROFILE:            "glfw.Opengl.Profile",
-	CONST_GLFW_OPENGL_COREPROFILE:        "glfw.Opengl.Coreprofile",
-	CONST_GLFW_OPENGL_FORWARD_COMPATIBLE: "glfw.Opengl.ForwardCompatible",
-	CONST_GLFW_MOUSE_BUTTON_LAST:         "glfw.MouseButtonLast",
-	CONST_GLFW_MOUSE_BUTTON_LEFT:         "glfw.MouseButtonLeft",
-	CONST_GLFW_MOUSE_BUTTON_RIGHT:        "glfw.MouseButtonRight",
-	CONST_GLFW_MOUSE_BUTTON_MIDDLE:       "glfw.MouseButtonMiddle",
-
-	// gltext
-	CONST_GLTEXT_LEFT_TO_RIGHT:           "gltext.LeftToRight",
-	CONST_GLTEXT_RIGHT_TO_LEFT:           "gltext.RightToLeft",
-	CONST_GLTEXT_TOP_TO_BOTTOM:           "gltext.TopToBottom",
+func AddConstCode(code int, name string, typ int, value []byte) {
+	ConstNames[code] = name
+	ConstCodes[name] = code
+	Constants[code] = CXConstant{Type: typ, Value: value}
 }
 
-// For the parser. These shouldn't be used in the runtime for performance reasons
-var ConstCodes map[string]int = map[string]int{
+func init() {
 	/* gl_1_0 */
-	"gl.DEPTH_BUFFER_BIT":       CONST_GL_DEPTH_BUFFER_BIT,
-	"gl.STENCIL_BUFFER_BIT":     CONST_GL_STENCIL_BUFFER_BIT,
-	"gl.COLOR_BUFFER_BIT":       CONST_GL_COLOR_BUFFER_BIT,
-	"gl.FALSE":                  CONST_GL_FALSE,
-	"gl.TRUE":                   CONST_GL_TRUE,
-	"gl.POINTS":                 CONST_GL_POINTS,
-	"gl.LINES":                  CONST_GL_LINES,
-	"gl.LINE_LOOP":              CONST_GL_LINE_LOOP,
-	"gl.LINE_STRIP":             CONST_GL_LINE_STRIP,
-	"gl.TRIANGLES":              CONST_GL_TRIANGLES,
-	"gl.TRIANGLE_STRIP":         CONST_GL_TRIANGLE_STRIP,
-	"gl.TRIANGLE_FAN":           CONST_GL_TRIANGLE_FAN,
-	"gl.QUADS":                  CONST_GL_QUADS,
-	"gl.LESS":                   CONST_GL_LESS,
-	"gl.EQUAL":                  CONST_GL_EQUAL,
-	"gl.LEQUAL":                 CONST_GL_LEQUAL,
-	"gl.GREATER":                CONST_GL_GREATER,
-	"gl.NOTEQUAL":               CONST_GL_NOTEQUAL,
-	"gl.GEQUAL":                 CONST_GL_GEQUAL,
-	"gl.ALWAYS":                 CONST_GL_ALWAYS,
-	"gl.SRC_ALPHA":              CONST_GL_SRC_ALPHA,
-	"gl.ONE_MINUS_SRC_ALPHA":    CONST_GL_ONE_MINUS_SRC_ALPHA,
-	"gl.FRONT":                  CONST_GL_FRONT,
-	"gl.BACK":                   CONST_GL_BACK,
-	"gl.FRONT_AND_BACK":         CONST_GL_FRONT_AND_BACK,
-	"gl.NO_ERROR":               CONST_GL_NO_ERROR,
-	"gl.INVALID_ENUM":           CONST_GL_INVALID_ENUM,
-	"gl.INVALID_VALUE":          CONST_GL_INVALID_VALUE,
-	"gl.INVALID_OPERATION":      CONST_GL_INVALID_OPERATION,
-	"gl.STACK_OVERFLOW":         CONST_GL_STACK_OVERFLOW,
-	"gl.STACK_UNDERFLOW":        CONST_GL_STACK_UNDERFLOW,
-	"gl.OUT_OF_MEMORY":          CONST_GL_OUT_OF_MEMORY,
-	"gl.LINE_SMOOTH":            CONST_GL_LINE_SMOOTH,
-	"gl.POLYGON_SMOOTH":         CONST_GL_POLYGON_SMOOTH,
-	"gl.CULL_FACE":              CONST_GL_CULL_FACE,
-	"gl.DEPTH_TEST":             CONST_GL_DEPTH_TEST,
-	"gl.DITHER":                 CONST_GL_DITHER,
-	"gl.BLEND":                  CONST_GL_BLEND,
-	"gl.SCISSOR_TEST":           CONST_GL_SCISSOR_TEST,
-	"gl.POLYGON_SMOOTH_HINT":    CONST_GL_POLYGON_SMOOTH_HINT,
-	"gl.TEXTURE_2D":             CONST_GL_TEXTURE_2D,
-	"gl.TEXTURE_WIDTH":          CONST_GL_TEXTURE_WIDTH,
-	"gl.TEXTURE_HEIGHT":         CONST_GL_TEXTURE_HEIGHT,
-	"gl.DONT_CARE":              CONST_GL_DONT_CARE,
-	"gl.UNSIGNED_BYTE":          CONST_GL_UNSIGNED_BYTE,
-	"gl.FLOAT":                  CONST_GL_FLOAT,
-	"gl.TEXTURE":                CONST_GL_TEXTURE,
-	"gl.COLOR":                  CONST_GL_COLOR,
-	"gl.DEPTH_COMPONENT":        CONST_GL_DEPTH_COMPONENT,
-	"gl.RGBA":                   CONST_GL_RGBA,
-	"gl.REPLACE":                CONST_GL_REPLACE,
-	"gl.NEREAST":                CONST_GL_NEAREST,
-	"gl.LINEAR":                 CONST_GL_LINEAR,
-	"gl.NEAREST_MIPMAP_NEAREST": CONST_GL_NEAREST_MIPMAP_NEAREST,
-	"gl.LINEAR_MIPMAP_NEAREST":  CONST_GL_LINEAR_MIPMAP_NEAREST,
-	"gl.NEAREST_MIPMAP_LINEAR":  CONST_GL_NEAREST_MIPMAP_LINEAR,
-	"gl.LINEAR_MIPMAP_LINEAR":   CONST_GL_LINEAR_MIPMAP_LINEAR,
-	"gl.TEXTURE_MAG_FILTER":     CONST_GL_TEXTURE_MAG_FILTER,
-	"gl.TEXTURE_MIN_FILTER":     CONST_GL_TEXTURE_MIN_FILTER,
-	"gl.TEXTURE_WRAP_S":         CONST_GL_TEXTURE_WRAP_S,
-	"gl.TEXTURE_WRAP_T":         CONST_GL_TEXTURE_WRAP_T,
-	"gl.REPEAT":                 CONST_GL_REPEAT,
+	AddConstCode( CONST_GL_DEPTH_BUFFER_BIT      , "gl.DEPTH_BUFFER_BIT"      , TYPE_I32, FromI32(0x00000100))
+	AddConstCode( CONST_GL_STENCIL_BUFFER_BIT    , "gl.STENCIL_BUFFER_BIT"    , TYPE_I32, FromI32(0x00000400))
+	AddConstCode( CONST_GL_COLOR_BUFFER_BIT      , "gl.COLOR_BUFFER_BIT"      , TYPE_I32, FromI32(0x00004000))
+	AddConstCode( CONST_GL_FALSE                 , "gl.FALSE"                 , TYPE_I32, FromI32(0))
+	AddConstCode( CONST_GL_TRUE                  , "gl.TRUE"                  , TYPE_I32, FromI32(1))
+	AddConstCode( CONST_GL_POINTS                , "gl.POINTS"                , TYPE_I32, FromI32(0x0000))
+	AddConstCode( CONST_GL_LINES                 , "gl.LINES"                 , TYPE_I32, FromI32(0x0001))
+	AddConstCode( CONST_GL_LINE_LOOP             , "gl.LINE_LOOP"             , TYPE_I32, FromI32(0x0002))
+	AddConstCode( CONST_GL_LINE_STRIP            , "gl.LINE_STRIP"            , TYPE_I32, FromI32(0x0003))
+	AddConstCode( CONST_GL_TRIANGLES             , "gl.TRIANGLES"             , TYPE_I32, FromI32(0x0004))
+	AddConstCode( CONST_GL_TRIANGLE_STRIP        , "gl.TRIANGLE_STRIP"        , TYPE_I32, FromI32(0x0005))
+	AddConstCode( CONST_GL_TRIANGLE_FAN          , "gl.TRIANGLE_FAN"          , TYPE_I32, FromI32(0x0006))
+	AddConstCode( CONST_GL_QUADS                 , "gl.QUADS"                 , TYPE_I32, FromI32(0x0007))
+	AddConstCode( CONST_GL_NEVER                 , "gl.NEVER"                 , TYPE_I32, FromI32(0x0200))
+	AddConstCode( CONST_GL_LESS                  , "gl.LESS"                  , TYPE_I32, FromI32(0x0201))
+	AddConstCode( CONST_GL_EQUAL                 , "gl.EQUAL"                 , TYPE_I32, FromI32(0x0202))
+	AddConstCode( CONST_GL_LEQUAL                , "gl.LEQUAL"                , TYPE_I32, FromI32(0x0203))
+	AddConstCode( CONST_GL_GREATER               , "gl.GREATER"               , TYPE_I32, FromI32(0x0204))
+	AddConstCode( CONST_GL_NOTEQUAL              , "gl.NOTEQUAL"              , TYPE_I32, FromI32(0x0205))
+	AddConstCode( CONST_GL_GEQUAL                , "gl.GEQUAL"                , TYPE_I32, FromI32(0x0206))
+	AddConstCode( CONST_GL_ALWAYS                , "gl.ALWAYS"                , TYPE_I32, FromI32(0x0207))
+	AddConstCode( CONST_GL_SRC_ALPHA             , "gl.SRC_ALPHA"             , TYPE_I32, FromI32(0x302))
+	AddConstCode( CONST_GL_ONE_MINUS_SRC_ALPHA   , "gl.ONE_MINUS_SRC_ALPHA"   , TYPE_I32, FromI32(0x303))
+	AddConstCode( CONST_GL_FRONT                 , "gl.FRONT"                 , TYPE_I32, FromI32(0x404))
+	AddConstCode( CONST_GL_BACK                  , "gl.BACK"                  , TYPE_I32, FromI32(0x405))
+	AddConstCode( CONST_GL_FRONT_AND_BACK        , "gl.FRONT_AND_BACK"        , TYPE_I32, FromI32(0x408))
+	AddConstCode( CONST_GL_NO_ERROR              , "gl.NO_ERROR"              , TYPE_I32, FromI32(0))
+	AddConstCode( CONST_GL_INVALID_ENUM          , "gl.INVALID_ENUM"          , TYPE_I32, FromI32(0x500))
+	AddConstCode( CONST_GL_INVALID_VALUE         , "gl.INVALID_VALUE"         , TYPE_I32, FromI32(0x501))
+	AddConstCode( CONST_GL_INVALID_OPERATION     , "gl.INVALID_OPERATION"     , TYPE_I32, FromI32(0x502))
+	AddConstCode( CONST_GL_STACK_OVERFLOW        , "gl.STACK_OVERFLOW"        , TYPE_I32, FromI32(0x503))
+	AddConstCode( CONST_GL_STACK_UNDERFLOW       , "gl.STACK_UNDERFLOW"       , TYPE_I32, FromI32(0x504))
+	AddConstCode( CONST_GL_OUT_OF_MEMORY         , "gl.OUT_OF_MEMORY"         , TYPE_I32, FromI32(0x505))
+	AddConstCode( CONST_GL_LINE_SMOOTH           , "gl.LINE_SMOOTH"           , TYPE_I32, FromI32(0x0B20))
+	AddConstCode( CONST_GL_POLYGON_SMOOTH        , "gl.POLYGON_SMOOTH"        , TYPE_I32, FromI32(0x0B41))
+	AddConstCode( CONST_GL_CULL_FACE             , "gl.CULL_FACE"             , TYPE_I32, FromI32(0x0B44))
+	AddConstCode( CONST_GL_DEPTH_TEST            , "gl.DEPTH_TEST"            , TYPE_I32, FromI32(0x0B71))
+	AddConstCode( CONST_GL_DITHER                , "gl.DITHER"                , TYPE_I32, FromI32(0x0BD0))
+	AddConstCode( CONST_GL_BLEND                 , "gl.BLEND"                 , TYPE_I32, FromI32(0x0BE2))
+	AddConstCode( CONST_GL_SCISSOR_TEST          , "gl.SCISSOR_TEST"          , TYPE_I32, FromI32(0x0C11))
+	AddConstCode( CONST_GL_POLYGON_SMOOTH_HINT   , "gl.POLYGON_SMOOTH_HINT"   , TYPE_I32, FromI32(0x0C53))
+	AddConstCode( CONST_GL_TEXTURE_2D            , "gl.TEXTURE_2D"            , TYPE_I32, FromI32(0x0DE1))
+	AddConstCode( CONST_GL_TEXTURE_WIDTH         , "gl.TEXTURE_WIDTH"         , TYPE_I32, FromI32(0x1000))
+	AddConstCode( CONST_GL_TEXTURE_HEIGHT        , "gl.TEXTURE_HEIGHT"        , TYPE_I32, FromI32(0x1001))
+	AddConstCode( CONST_GL_DONT_CARE             , "gl.DONT_CARE"             , TYPE_I32, FromI32(0x1100))
+	AddConstCode( CONST_GL_UNSIGNED_BYTE         , "gl.UNSIGNED_BYTE"         , TYPE_I32, FromI32(0x1401))
+	AddConstCode( CONST_GL_FLOAT                 , "gl.FLOAT"                 , TYPE_I32, FromI32(0x1406))
+	AddConstCode( CONST_GL_TEXTURE               , "gl.TEXTURE"               , TYPE_I32, FromI32(0x1702))
+	AddConstCode( CONST_GL_COLOR                 , "gl.COLOR"                 , TYPE_I32, FromI32(0x1800))
+	AddConstCode( CONST_GL_DEPTH_COMPONENT       , "gl.DEPTH_COMPONENT"       , TYPE_I32, FromI32(0x1902))
+	AddConstCode( CONST_GL_RGBA                  , "gl.RGBA"                  , TYPE_I32, FromI32(0x1908))
+	AddConstCode( CONST_GL_REPLACE               , "gl.REPLACE"               , TYPE_I32, FromI32(0x1E01))
+	AddConstCode( CONST_GL_NEAREST               , "gl.NEAREST"               , TYPE_I32, FromI32(0x2600))
+	AddConstCode( CONST_GL_LINEAR                , "gl.LINEAR"                , TYPE_I32, FromI32(0x2601))
+	AddConstCode( CONST_GL_NEAREST_MIPMAP_NEAREST, "gl.NEAREST_MIPMAP_NEAREST", TYPE_I32, FromI32(0x2700))
+	AddConstCode( CONST_GL_LINEAR_MIPMAP_NEAREST , "gl.LINEAR_MIPMAP_NEAREST" , TYPE_I32, FromI32(0x2701))
+	AddConstCode( CONST_GL_NEAREST_MIPMAP_LINEAR , "gl.NEAREST_MIPMAP_LINEAR" , TYPE_I32, FromI32(0x2702))
+	AddConstCode( CONST_GL_LINEAR_MIPMAP_LINEAR  , "gl.LINEAR_MIPMAP_LINEAR"  , TYPE_I32, FromI32(0x2703))
+	AddConstCode( CONST_GL_TEXTURE_MAG_FILTER    , "gl.TEXTURE_MAG_FILTER"    , TYPE_I32, FromI32(0x2800))
+	AddConstCode( CONST_GL_TEXTURE_MIN_FILTER    , "gl.TEXTURE_MIN_FILTER"    , TYPE_I32, FromI32(0x2801))
+	AddConstCode( CONST_GL_TEXTURE_WRAP_S        , "gl.TEXTURE_WRAP_S"        , TYPE_I32, FromI32(0x2802))
+	AddConstCode( CONST_GL_TEXTURE_WRAP_T        , "gl.TEXTURE_WRAP_T"        , TYPE_I32, FromI32(0x2803))
+	AddConstCode( CONST_GL_REPEAT                , "gl.REPEAT"                , TYPE_I32, FromI32(0x2901))
 
-	/* gl_1_1 */
-	"gl.RGBA8":                  CONST_GL_RGBA8,
-	"gl.VERTEX_ARRAY":           CONST_GL_VERTEX_ARRAY,
+	// gl_1_1
+	AddConstCode( CONST_GL_RGBA8                 , "gl.RGBA8"                 , TYPE_I32, FromI32(0x8058))
+	AddConstCode( CONST_GL_VERTEX_ARRAY          , "gl.VERTEX_ARRAY"          , TYPE_I32, FromI32(0x8074))
 
-	/* gl_1_2 */
-	"gl.TEXTURE_WRAP_R":         CONST_GL_TEXTURE_WRAP_R,
-	"gl.CLAMP_TO_EDGE":          CONST_GL_CLAMP_TO_EDGE,
+	// gl_1_2
+	AddConstCode( CONST_GL_TEXTURE_WRAP_R        , "gl.TEXTURE_WRAP_R"        , TYPE_I32, FromI32(0x8072))
+	AddConstCode( CONST_GL_CLAMP_TO_EDGE         , "gl.CLAMP_TO_EDGE"         , TYPE_I32, FromI32(0x812F))
 
-	/* gl_1_3 */
-	"gl.TEXTURE0":               CONST_GL_TEXTURE0,
-	"gl.MULTISAMPLE_ARB":        CONST_GL_MULTISAMPLE_ARB, // remove _ARB
-	"gl.CLAMP_TO_BORDER":        CONST_GL_CLAMP_TO_BORDER,
+	// gl_1_3
+	AddConstCode( CONST_GL_TEXTURE0              , "gl.TEXTURE0"              , TYPE_I32, FromI32(0x84C0))
+	AddConstCode( CONST_GL_MULTISAMPLE_ARB       , "gl.MULTISAMPLE_ARB"       , TYPE_I32, FromI32(0x809D)) // remove _ARB
+	AddConstCode( CONST_GL_CLAMP_TO_BORDER       , "gl.CLAMP_TO_BORDER"       , TYPE_I32, FromI32(0x812D))
 
-	/* gl_1_4 */
-	"gl.MIRRORED_REPEAT":        CONST_GL_MIRRORED_REPEAT,
+	// gl_1_4
+	AddConstCode( CONST_GL_MIRRORED_REPEAT       , "gl.MIRRORED_REPEAT"       , TYPE_I32, FromI32(0x8370))
 
-	/* gl_1_5 */
-	"gl.ARRAY_BUFFER":        CONST_GL_ARRAY_BUFFER,
-	"gl.STREAM_DRAW":         CONST_GL_STREAM_DRAW,
-	"gl.STREAM_READ":         CONST_GL_STREAM_READ,
-	"gl.STREAM_COPY":         CONST_GL_STREAM_COPY,
-	"gl.STATIC_DRAW":         CONST_GL_STATIC_DRAW,
-	"gl.STATIC_READ":         CONST_GL_STATIC_READ,
-	"gl.STATIC_COPY":         CONST_GL_STATIC_COPY,
-	"gl.DYNAMIC_DRAW":        CONST_GL_DYNAMIC_DRAW,
-	"gl.DYNAMIC_READ":        CONST_GL_DYNAMIC_READ,
-	"gl.DYNAMIC_COPY":        CONST_GL_DYNAMIC_COPY,
+	// gl_1_5
+	AddConstCode( CONST_GL_ARRAY_BUFFER          , "gl.ARRAY_BUFFER"          , TYPE_I32, FromI32(0x8892))
+	AddConstCode( CONST_GL_STREAM_DRAW           , "gl.STREAM_DRAW"           , TYPE_I32, FromI32(0x88E0))
+	AddConstCode( CONST_GL_STREAM_READ           , "gl.STREAM_READ"           , TYPE_I32, FromI32(0x88E1))
+	AddConstCode( CONST_GL_STREAM_COPY           , "gl.STREAM_COPY"           , TYPE_I32, FromI32(0x88E2))
+	AddConstCode( CONST_GL_STATIC_DRAW           , "gl.STATIC_DRAW"           , TYPE_I32, FromI32(0x88E4))
+	AddConstCode( CONST_GL_STATIC_READ           , "gl.STATIC_READ"           , TYPE_I32, FromI32(0x88E5))
+	AddConstCode( CONST_GL_STATIC_COPY           , "gl.STATIC_COPY"           , TYPE_I32, FromI32(0x88E6))
+	AddConstCode( CONST_GL_DYNAMIC_DRAW          , "gl.DYNAMIC_DRAW"          , TYPE_I32, FromI32(0x88E8))
+	AddConstCode( CONST_GL_DYNAMIC_READ          , "gl.DYNAMIC_READ"          , TYPE_I32, FromI32(0x88E9))
+	AddConstCode( CONST_GL_DYNAMIC_COPY          , "gl.DYNAMIC_COPY"          , TYPE_I32, FromI32(0x88EA))
 
-	/* gl_2_0 */
-	"gl.FRAGMENT_SHADER":     CONST_GL_FRAGMENT_SHADER,
-	"gl.VERTEX_SHADER":       CONST_GL_VERTEX_SHADER,
+	// gl_2_0
+	AddConstCode( CONST_GL_FRAGMENT_SHADER       , "gl.FRAGMENT_SHADER"       , TYPE_I32, FromI32(0x8B30))
+	AddConstCode( CONST_GL_VERTEX_SHADER         , "gl.VERTEX_SHADER"         , TYPE_I32, FromI32(0x8B31))
 
-	/* gl_3_0 */
-	"gl.FRAMEBUFFER_UNDEFINED":                     CONST_GL_FRAMEBUFFER_UNDEFINED,
-	"gl.FRAMEBUFFER_COMPLETE":                      CONST_GL_FRAMEBUFFER_COMPLETE,
-	"gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT":         CONST_GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT,
-	"gl.FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT": CONST_GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT,
-	"gl.FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER":        CONST_GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER,
-	"gl.FRAMEBUFFER_INCOMPLETE_READ_BUFFER":        CONST_GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER,
-	"gl.FRAMEBUFFER_UNSUPPORTED":                   CONST_GL_FRAMEBUFFER_UNSUPPORTED,
-	"gl.COLOR_ATTACHMENT0":                         CONST_GL_COLOR_ATTACHMENT0,
-	"gl.DEPTH_ATTACHMENT":                          CONST_GL_DEPTH_ATTACHMENT,
-	"gl.STENCIL_ATTACHMENT":                        CONST_GL_STENCIL_ATTACHMENT,
-	"gl.FRAMEBUFFER":                               CONST_GL_FRAMEBUFFER,
-	"gl.RENDERBUFFER":                              CONST_GL_RENDERBUFFER,
-	"gl.FRAMEBUFFER_INCOMPLETE_MULTISAMPLE":        CONST_GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE,
+	// gl_3_0
+	AddConstCode( CONST_GL_FRAMEBUFFER_UNDEFINED                     , "gl.FRAMEBUFFER_UNDEFINED"                    , TYPE_I32, FromI32(0x8219))
+	AddConstCode( CONST_GL_FRAMEBUFFER_COMPLETE                      , "gl.FRAMEBUFFER_COMPLETE"                     , TYPE_I32, FromI32(0x8CD5))
+	AddConstCode( CONST_GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT         , "gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT"        , TYPE_I32, FromI32(0x8CD6))
+	AddConstCode( CONST_GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT , "gl.FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT", TYPE_I32, FromI32(0x8CD7))
+	AddConstCode( CONST_GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER        , "gl.FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER"       , TYPE_I32, FromI32(0x8CDB))
+	AddConstCode( CONST_GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER        , "gl.FRAMEBUFFER_INCOMPLETE_READ_BUFFER"       , TYPE_I32, FromI32(0x8CDC))
+	AddConstCode( CONST_GL_FRAMEBUFFER_UNSUPPORTED                   , "gl.FRAMEBUFFER_UNSUPPORTED"                  , TYPE_I32, FromI32(0x8CDD))
+	AddConstCode( CONST_GL_COLOR_ATTACHMENT0                         , "gl.COLOR_ATTACHMENT0"                        , TYPE_I32, FromI32(0x8CE0))
+	AddConstCode( CONST_GL_DEPTH_ATTACHMENT                          , "gl.DEPTH_ATTACHMENT"                         , TYPE_I32, FromI32(0x8D00))
+	AddConstCode( CONST_GL_STENCIL_ATTACHMENT                        , "gl.STENCIL_ATTACHMENT"                       , TYPE_I32, FromI32(0x8D20))
+	AddConstCode( CONST_GL_FRAMEBUFFER                               , "gl.FRAMEBUFFER"                              , TYPE_I32, FromI32(0x8D40))
+	AddConstCode( CONST_GL_RENDERBUFFER                              , "gl.RENDERBUFFER"                             , TYPE_I32, FromI32(0x8D41))
+	AddConstCode( CONST_GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE        , "gl.FRAMEBUFFER_INCOMPLETE_MULTISAMPLE"       , TYPE_I32, FromI32(0x8D56))
 
-	/* gl_3_2 */
-	"gl.FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS":      CONST_GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS,
+	// gl_3_2
+	AddConstCode( CONST_GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS      , "gl.FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS"     , TYPE_I32, FromI32(0x8DA8))
 
-	/* gl_4_4 */
-	"gl.MIRROR_CLAMP_TO_EDGE": CONST_GL_MIRROR_CLAMP_TO_EDGE,
+	// gl_4_4
+	AddConstCode( CONST_GL_MIRROR_CLAMP_TO_EDGE   , "gl.MIRROR_CLAMP_TO_EDGE", TYPE_I32, FromI32(0x8743))
 
-	/* Deprecated ? */
-	"gl.POLYGON":             CONST_GL_POLYGON,
-	"gl.MODELVIEW":           CONST_GL_MODELVIEW,
-	"gl.PROJECTION":          CONST_GL_PROJECTION,
-	"gl.MODELVIEW_MATRIX":    CONST_GL_MODELVIEW_MATRIX,
-	"gl.LIGHTING":            CONST_GL_LIGHTING,
-	"gl.LIGHT0":              CONST_GL_LIGHT0,
-	"gl.AMBIENT":             CONST_GL_AMBIENT,
-	"gl.DIFFUSE":             CONST_GL_DIFFUSE,
-	"gl.POSITION":            CONST_GL_POSITION,
-	"gl.TEXTURE_ENV":         CONST_GL_TEXTURE_ENV,
-	"gl.TEXTURE_ENV_MODE":    CONST_GL_TEXTURE_ENV_MODE,
-	"gl.MODULATE":            CONST_GL_MODULATE,
-	"gl.DECAL":               CONST_GL_DECAL,
-	"gl.POINT_SMOOTH":        CONST_GL_POINT_SMOOTH,
+	// Fixed pipeline. Deprecated ?
+	AddConstCode( CONST_GL_POLYGON                , "gl.POLYGON"          , TYPE_I32, FromI32(9))
+	AddConstCode( CONST_GL_MODELVIEW              , "gl.MODELVIEW"        , TYPE_I32, FromI32(5888))
+	AddConstCode( CONST_GL_PROJECTION             , "gl.PROJECTION"       , TYPE_I32, FromI32(5889))
+	AddConstCode( CONST_GL_MODELVIEW_MATRIX       , "gl.MODELVIEW_MATRIX" , TYPE_I32, FromI32(2982))
+	AddConstCode( CONST_GL_LIGHTING               , "gl.LIGHTING"         , TYPE_I32, FromI32(2896))
+	AddConstCode( CONST_GL_LIGHT0                 , "gl.LIGHT0"           , TYPE_I32, FromI32(16384))
+	AddConstCode( CONST_GL_AMBIENT                , "gl.AMBIENT"          , TYPE_I32, FromI32(4608))
+	AddConstCode( CONST_GL_DIFFUSE                , "gl.DIFFUSE"          , TYPE_I32, FromI32(4609))
+	AddConstCode( CONST_GL_POSITION               , "gl.POSITION"         , TYPE_I32, FromI32(4611))
+	AddConstCode( CONST_GL_TEXTURE_ENV            , "gl.TEXTURE_ENV"      , TYPE_I32, FromI32(8960))
+	AddConstCode( CONST_GL_TEXTURE_ENV_MODE       , "gl.TEXTURE_ENV_MODE" , TYPE_I32, FromI32(8704))
+	AddConstCode( CONST_GL_MODULATE               , "gl.MODULATE"         , TYPE_I32, FromI32(8448))
+	AddConstCode( CONST_GL_DECAL                  , "gl.DECAL"            , TYPE_I32, FromI32(8449))
+	AddConstCode( CONST_GL_POINT_SMOOTH           , "gl.POINT_SMOOTH"     , TYPE_I32, FromI32(2832))
 
 	// glfw
-	"glfw.False":                    CONST_GLFW_FALSE,
-	"glfw.True":                     CONST_GLFW_TRUE,
-	"glfw.Press":                    CONST_GLFW_PRESS,
-	"glfw.Release":                  CONST_GLFW_RELEASE,
-	"glfw.Repeat":                   CONST_GLFW_REPEAT,
-	"glfw.KeyUnknown":               CONST_GLFW_KEY_UNKNOWN,
-	"glfw.Cursor":                   CONST_GLFW_CURSOR,
-	"glfw.StickyKeys":               CONST_GLFW_STICKY_KEYS,
-	"glfw.StickyMouseButtons":       CONST_GLFW_STICKY_MOUSE_BUTTONS,
-	"glfw.CursorNormal":             CONST_GLFW_CURSOR_NORMAL,
-	"glfw.CursorHidden":             CONST_GLFW_CURSOR_HIDDEN,
-	"glfw.CursorDisabled":           CONST_GLFW_CURSOR_DISABLED,
-	"glfw.Resizable":                CONST_GLFW_RESIZABLE,
-	"glfw.ContextVersionMajor":      CONST_GLFW_CONTEXT_VERSION_MAJOR,
-	"glfw.ContextVersionMinor":      CONST_GLFW_CONTEXT_VERSION_MINOR,
-	"glfw.Opengl.Profile":           CONST_GLFW_OPENGL_PROFILE,
-	"glfw.Opengl.Coreprofile":       CONST_GLFW_OPENGL_COREPROFILE,
-	"glfw.Opengl.ForwardCompatible": CONST_GLFW_OPENGL_FORWARD_COMPATIBLE,
-	"glfw.MouseButtonLast":          CONST_GLFW_MOUSE_BUTTON_LAST,
-	"glfw.MouseButtonLeft":          CONST_GLFW_MOUSE_BUTTON_LEFT,
-	"glfw.MouseButtonRight":         CONST_GLFW_MOUSE_BUTTON_RIGHT,
-	"glfw.MouseButtonMiddle":        CONST_GLFW_MOUSE_BUTTON_MIDDLE,
+	AddConstCode( CONST_GLFW_FALSE                     , "glfw.False"                    , TYPE_I32, FromI32(0))
+	AddConstCode( CONST_GLFW_TRUE                      , "glfw.True"                     , TYPE_I32, FromI32(1))
+	AddConstCode( CONST_GLFW_PRESS                     , "glfw.Press"                    , TYPE_I32, FromI32(1))
+	AddConstCode( CONST_GLFW_RELEASE                   , "glfw.Release"                  , TYPE_I32, FromI32(0))
+	AddConstCode( CONST_GLFW_REPEAT                    , "glfw.Repeat"                   , TYPE_I32, FromI32(2))
+	AddConstCode( CONST_GLFW_KEY_UNKNOWN               , "glfw.KeyUnknown"               , TYPE_I32, FromI32(-1))
+	AddConstCode( CONST_GLFW_CURSOR                    , "glfw.Cursor"                   , TYPE_I32, FromI32(208897))
+	AddConstCode( CONST_GLFW_STICKY_KEYS               , "glfw.StickyKeys"               , TYPE_I32, FromI32(208898))
+	AddConstCode( CONST_GLFW_STICKY_MOUSE_BUTTONS      , "glfw.StickyMouseButtons"       , TYPE_I32, FromI32(208899))
+	AddConstCode( CONST_GLFW_CURSOR_NORMAL             , "glfw.CursorNormal"             , TYPE_I32, FromI32(212993))
+	AddConstCode( CONST_GLFW_CURSOR_HIDDEN             , "glfw.CursorHidden"             , TYPE_I32, FromI32(212994))
+	AddConstCode( CONST_GLFW_CURSOR_DISABLED           , "glfw.CursorDisabled"           , TYPE_I32, FromI32(212995))
+	AddConstCode( CONST_GLFW_RESIZABLE                 , "glfw.Resizable"                , TYPE_I32, FromI32(131075))
+	AddConstCode( CONST_GLFW_CONTEXT_VERSION_MAJOR     , "glfw.ContextVersionMajor"      , TYPE_I32, FromI32(139266))
+	AddConstCode( CONST_GLFW_CONTEXT_VERSION_MINOR     , "glfw.ContextVersionMinor"      , TYPE_I32, FromI32(139267))
+	AddConstCode( CONST_GLFW_OPENGL_PROFILE            , "glfw.Opengl.Profile"           , TYPE_I32, FromI32(139272))
+	AddConstCode( CONST_GLFW_OPENGL_COREPROFILE        , "glfw.Opengl.Coreprofile"       , TYPE_I32, FromI32(204801))
+	AddConstCode( CONST_GLFW_OPENGL_FORWARD_COMPATIBLE , "glfw.Opengl.ForwardCompatible" , TYPE_I32, FromI32(139270))
+	AddConstCode( CONST_GLFW_MOUSE_BUTTON_LAST         , "glfw.MouseButtonLast"          , TYPE_I32, FromI32(7))
+	AddConstCode( CONST_GLFW_MOUSE_BUTTON_LEFT         , "glfw.MouseButtonLeft"          , TYPE_I32, FromI32(0))
+	AddConstCode( CONST_GLFW_MOUSE_BUTTON_RIGHT        , "glfw.MouseButtonRight"         , TYPE_I32, FromI32(1))
+	AddConstCode( CONST_GLFW_MOUSE_BUTTON_MIDDLE       , "glfw.MouseButtonMiddle"        , TYPE_I32, FromI32(2))
 
 	// gltext
-	"gltext.LeftToRight":           CONST_GLTEXT_LEFT_TO_RIGHT,
-	"gltext.RightToLeft":           CONST_GLTEXT_RIGHT_TO_LEFT,
-	"gltext.TopToBottom":           CONST_GLTEXT_TOP_TO_BOTTOM,
-}
-
-var Constants map[int]CXConstant = map[int]CXConstant{
-	/* gl_1_0 */
-	CONST_GL_DEPTH_BUFFER_BIT:       CXConstant{Type: TYPE_I32, Value: FromI32(0x00000100)},
-	CONST_GL_STENCIL_BUFFER_BIT:     CXConstant{Type: TYPE_I32, Value: FromI32(0x00000400)},
-	CONST_GL_COLOR_BUFFER_BIT:       CXConstant{Type: TYPE_I32, Value: FromI32(0x00004000)},
-	CONST_GL_FALSE:                  CXConstant{Type: TYPE_I32, Value: FromI32(0)},
-	CONST_GL_TRUE:                   CXConstant{Type: TYPE_I32, Value: FromI32(1)},
-	CONST_GL_POINTS:                 CXConstant{Type: TYPE_I32, Value: FromI32(0x0000)},
-	CONST_GL_LINES:                  CXConstant{Type: TYPE_I32, Value: FromI32(0x0001)},
-	CONST_GL_LINE_LOOP:              CXConstant{Type: TYPE_I32, Value: FromI32(0x0002)},
-	CONST_GL_LINE_STRIP:             CXConstant{Type: TYPE_I32, Value: FromI32(0x0003)},
-	CONST_GL_TRIANGLES:              CXConstant{Type: TYPE_I32, Value: FromI32(0x0004)},
-	CONST_GL_TRIANGLE_STRIP:         CXConstant{Type: TYPE_I32, Value: FromI32(0x0005)},
-	CONST_GL_TRIANGLE_FAN:           CXConstant{Type: TYPE_I32, Value: FromI32(0x0006)},
-	CONST_GL_QUADS:                  CXConstant{Type: TYPE_I32, Value: FromI32(0x0007)},
-	CONST_GL_NEVER:                  CXConstant{Type: TYPE_I32, Value: FromI32(0x0200)},
-	CONST_GL_LESS:                   CXConstant{Type: TYPE_I32, Value: FromI32(0x0201)},
-	CONST_GL_EQUAL:                  CXConstant{Type: TYPE_I32, Value: FromI32(0x0202)},
-	CONST_GL_LEQUAL:                 CXConstant{Type: TYPE_I32, Value: FromI32(0x0203)},
-	CONST_GL_GREATER:                CXConstant{Type: TYPE_I32, Value: FromI32(0x0204)},
-	CONST_GL_NOTEQUAL:               CXConstant{Type: TYPE_I32, Value: FromI32(0x0205)},
-	CONST_GL_GEQUAL:                 CXConstant{Type: TYPE_I32, Value: FromI32(0x0206)},
-	CONST_GL_ALWAYS:                 CXConstant{Type: TYPE_I32, Value: FromI32(0x0207)},
-	CONST_GL_SRC_ALPHA:              CXConstant{Type: TYPE_I32, Value: FromI32(0x302)},
-	CONST_GL_ONE_MINUS_SRC_ALPHA:    CXConstant{Type: TYPE_I32, Value: FromI32(0x303)},
-	CONST_GL_FRONT:                  CXConstant{Type: TYPE_I32, Value: FromI32(0x404)},
-	CONST_GL_BACK:                   CXConstant{Type: TYPE_I32, Value: FromI32(0x405)},
-	CONST_GL_FRONT_AND_BACK:         CXConstant{Type: TYPE_I32, Value: FromI32(0x408)},
-	CONST_GL_NO_ERROR:               CXConstant{Type: TYPE_I32, Value: FromI32(0)},
-	CONST_GL_INVALID_ENUM:           CXConstant{Type: TYPE_I32, Value: FromI32(0x500)},
-	CONST_GL_INVALID_VALUE:          CXConstant{Type: TYPE_I32, Value: FromI32(0x501)},
-	CONST_GL_INVALID_OPERATION:      CXConstant{Type: TYPE_I32, Value: FromI32(0x502)},
-	CONST_GL_STACK_OVERFLOW:         CXConstant{Type: TYPE_I32, Value: FromI32(0x503)},
-	CONST_GL_STACK_UNDERFLOW:        CXConstant{Type: TYPE_I32, Value: FromI32(0x504)},
-	CONST_GL_OUT_OF_MEMORY:          CXConstant{Type: TYPE_I32, Value: FromI32(0x505)},
-	CONST_GL_LINE_SMOOTH:            CXConstant{Type: TYPE_I32, Value: FromI32(0x0B20)},
-	CONST_GL_POLYGON_SMOOTH:         CXConstant{Type: TYPE_I32, Value: FromI32(0x0B41)},
-	CONST_GL_CULL_FACE:              CXConstant{Type: TYPE_I32, Value: FromI32(0x0B44)},
-	CONST_GL_DEPTH_TEST:             CXConstant{Type: TYPE_I32, Value: FromI32(0x0B71)},
-	CONST_GL_DITHER:                 CXConstant{Type: TYPE_I32, Value: FromI32(0x0BD0)},
-	CONST_GL_BLEND:                  CXConstant{Type: TYPE_I32, Value: FromI32(0x0BE2)},
-	CONST_GL_SCISSOR_TEST:           CXConstant{Type: TYPE_I32, Value: FromI32(0x0C11)},
-	CONST_GL_POLYGON_SMOOTH_HINT:    CXConstant{Type: TYPE_I32, Value: FromI32(0x0C53)},
-	CONST_GL_TEXTURE_2D:             CXConstant{Type: TYPE_I32, Value: FromI32(0x0DE1)},
-	CONST_GL_TEXTURE_WIDTH:          CXConstant{Type: TYPE_I32, Value: FromI32(0x1000)},
-	CONST_GL_TEXTURE_HEIGHT:         CXConstant{Type: TYPE_I32, Value: FromI32(0x1001)},
-	CONST_GL_DONT_CARE:              CXConstant{Type: TYPE_I32, Value: FromI32(0x1100)},
-	CONST_GL_UNSIGNED_BYTE:          CXConstant{Type: TYPE_I32, Value: FromI32(0x1401)},
-	CONST_GL_FLOAT:                  CXConstant{Type: TYPE_I32, Value: FromI32(0x1406)},
-	CONST_GL_TEXTURE:                CXConstant{Type: TYPE_I32, Value: FromI32(0x1702)},
-	CONST_GL_COLOR:                  CXConstant{Type: TYPE_I32, Value: FromI32(0x1800)},
-	CONST_GL_DEPTH_COMPONENT:        CXConstant{Type: TYPE_I32, Value: FromI32(0x1902)},
-	CONST_GL_RGBA:                   CXConstant{Type: TYPE_I32, Value: FromI32(0x1908)},
-	CONST_GL_REPLACE:                CXConstant{Type: TYPE_I32, Value: FromI32(0x1E01)},
-	CONST_GL_NEAREST:                CXConstant{Type: TYPE_I32, Value: FromI32(0x2600)},
-	CONST_GL_LINEAR:                 CXConstant{Type: TYPE_I32, Value: FromI32(0x2601)},
-	CONST_GL_NEAREST_MIPMAP_NEAREST: CXConstant{Type: TYPE_I32, Value: FromI32(0x2700)},
-	CONST_GL_LINEAR_MIPMAP_NEAREST:  CXConstant{Type: TYPE_I32, Value: FromI32(0x2701)},
-	CONST_GL_NEAREST_MIPMAP_LINEAR:  CXConstant{Type: TYPE_I32, Value: FromI32(0x2702)},
-	CONST_GL_LINEAR_MIPMAP_LINEAR:   CXConstant{Type: TYPE_I32, Value: FromI32(0x2703)},
-	CONST_GL_TEXTURE_MAG_FILTER:     CXConstant{Type: TYPE_I32, Value: FromI32(0x2800)},
-	CONST_GL_TEXTURE_MIN_FILTER:     CXConstant{Type: TYPE_I32, Value: FromI32(0x2801)},
-	CONST_GL_TEXTURE_WRAP_S:         CXConstant{Type: TYPE_I32, Value: FromI32(0x2802)},
-	CONST_GL_TEXTURE_WRAP_T:         CXConstant{Type: TYPE_I32, Value: FromI32(0x2803)},
-	CONST_GL_REPEAT:                 CXConstant{Type: TYPE_I32, Value: FromI32(0x2901)},
-
-	/* gl_1_1 */
-	CONST_GL_RGBA8:                  CXConstant{Type: TYPE_I32, Value: FromI32(0x8058)},
-	CONST_GL_VERTEX_ARRAY:           CXConstant{Type: TYPE_I32, Value: FromI32(0x8074)},
-
-	/* gl_1_2 */
-	CONST_GL_TEXTURE_WRAP_R:         CXConstant{Type: TYPE_I32, Value: FromI32(0x8072)},
-	CONST_GL_CLAMP_TO_EDGE:          CXConstant{Type: TYPE_I32, Value: FromI32(0x812F)},
-
-	/* gl_1_3 */
-	CONST_GL_TEXTURE0:            CXConstant{Type: TYPE_I32, Value: FromI32(0x84C0)},
-	CONST_GL_MULTISAMPLE_ARB:     CXConstant{Type: TYPE_I32, Value: FromI32(0x809D)}, // remove _ARB
-	CONST_GL_CLAMP_TO_BORDER:     CXConstant{Type: TYPE_I32, Value: FromI32(0x812D)},
-
-	/* gl_1_4 */
-	CONST_GL_MIRRORED_REPEAT:     CXConstant{Type: TYPE_I32, Value: FromI32(0x8370)},
-
-	/* gl_1_5 */
-	CONST_GL_ARRAY_BUFFER:        CXConstant{Type: TYPE_I32, Value: FromI32(0x8892)},
-	CONST_GL_STREAM_DRAW:         CXConstant{Type: TYPE_I32, Value: FromI32(0x88E0)},
-	CONST_GL_STREAM_READ:         CXConstant{Type: TYPE_I32, Value: FromI32(0x88E1)},
-	CONST_GL_STREAM_COPY:         CXConstant{Type: TYPE_I32, Value: FromI32(0x88E2)},
-	CONST_GL_STATIC_DRAW:         CXConstant{Type: TYPE_I32, Value: FromI32(0x88E4)},
-	CONST_GL_STATIC_READ:         CXConstant{Type: TYPE_I32, Value: FromI32(0x88E5)},
-	CONST_GL_STATIC_COPY:         CXConstant{Type: TYPE_I32, Value: FromI32(0x88E6)},
-	CONST_GL_DYNAMIC_DRAW:        CXConstant{Type: TYPE_I32, Value: FromI32(0x88E8)},
-	CONST_GL_DYNAMIC_READ:        CXConstant{Type: TYPE_I32, Value: FromI32(0x88E9)},
-	CONST_GL_DYNAMIC_COPY:        CXConstant{Type: TYPE_I32, Value: FromI32(0x88EA)},
-
-	/* gl_2_0 */
-	CONST_GL_FRAGMENT_SHADER:     CXConstant{Type: TYPE_I32, Value: FromI32(0x8B30)},
-	CONST_GL_VERTEX_SHADER:       CXConstant{Type: TYPE_I32, Value: FromI32(0x8B31)},
-
-	/* gl_3_0 */
-	CONST_GL_FRAMEBUFFER_UNDEFINED:                     CXConstant{Type: TYPE_I32, Value: FromI32(0x8219)},
-	CONST_GL_FRAMEBUFFER_COMPLETE:                      CXConstant{Type: TYPE_I32, Value: FromI32(0x8CD5)},
-	CONST_GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT:         CXConstant{Type: TYPE_I32, Value: FromI32(0x8CD6)},
-	CONST_GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT: CXConstant{Type: TYPE_I32, Value: FromI32(0x8CD7)},
-	CONST_GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER:        CXConstant{Type: TYPE_I32, Value: FromI32(0x8CDB)},
-	CONST_GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER:        CXConstant{Type: TYPE_I32, Value: FromI32(0x8CDC)},
-	CONST_GL_FRAMEBUFFER_UNSUPPORTED:                   CXConstant{Type: TYPE_I32, Value: FromI32(0x8CDD)},
-	CONST_GL_COLOR_ATTACHMENT0:                         CXConstant{Type: TYPE_I32, Value: FromI32(0x8CE0)},
-	CONST_GL_DEPTH_ATTACHMENT:                          CXConstant{Type: TYPE_I32, Value: FromI32(0x8D00)},
-	CONST_GL_STENCIL_ATTACHMENT:                        CXConstant{Type: TYPE_I32, Value: FromI32(0x8D20)},
-	CONST_GL_FRAMEBUFFER:                               CXConstant{Type: TYPE_I32, Value: FromI32(0x8D40)},
-	CONST_GL_RENDERBUFFER:                              CXConstant{Type: TYPE_I32, Value: FromI32(0x8D41)},
-	CONST_GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE:        CXConstant{Type: TYPE_I32, Value: FromI32(0x8D56)},
-
-	/* gl_3_2 */
-	CONST_GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS:      CXConstant{Type: TYPE_I32, Value: FromI32(0x8DA8)},
-
-	/* gl_4_4 */
-	CONST_GL_MIRROR_CLAMP_TO_EDGE: CXConstant{Type: TYPE_I32, Value: FromI32(0x8743)},
-
-	/* Fixed pipeline. Deprecated ? */
-	CONST_GL_POLYGON:             CXConstant{Type: TYPE_I32, Value: FromI32(9)},
-	CONST_GL_MODELVIEW:           CXConstant{Type: TYPE_I32, Value: FromI32(5888)},
-	CONST_GL_PROJECTION:          CXConstant{Type: TYPE_I32, Value: FromI32(5889)},
-	CONST_GL_MODELVIEW_MATRIX:    CXConstant{Type: TYPE_I32, Value: FromI32(2982)},
-	CONST_GL_LIGHTING:            CXConstant{Type: TYPE_I32, Value: FromI32(2896)},
-	CONST_GL_LIGHT0:              CXConstant{Type: TYPE_I32, Value: FromI32(16384)},
-	CONST_GL_AMBIENT:             CXConstant{Type: TYPE_I32, Value: FromI32(4608)},
-	CONST_GL_DIFFUSE:             CXConstant{Type: TYPE_I32, Value: FromI32(4609)},
-	CONST_GL_POSITION:            CXConstant{Type: TYPE_I32, Value: FromI32(4611)},
-	CONST_GL_TEXTURE_ENV:         CXConstant{Type: TYPE_I32, Value: FromI32(8960)},
-	CONST_GL_TEXTURE_ENV_MODE:    CXConstant{Type: TYPE_I32, Value: FromI32(8704)},
-	CONST_GL_MODULATE:            CXConstant{Type: TYPE_I32, Value: FromI32(8448)},
-	CONST_GL_DECAL:               CXConstant{Type: TYPE_I32, Value: FromI32(8449)},
-	CONST_GL_POINT_SMOOTH:        CXConstant{Type: TYPE_I32, Value: FromI32(2832)},
-
-	// glfw
-	CONST_GLFW_FALSE:                     CXConstant{Type: TYPE_I32, Value: FromI32(0)},
-	CONST_GLFW_TRUE:                      CXConstant{Type: TYPE_I32, Value: FromI32(1)},
-	CONST_GLFW_PRESS:                     CXConstant{Type: TYPE_I32, Value: FromI32(1)},
-	CONST_GLFW_RELEASE:                   CXConstant{Type: TYPE_I32, Value: FromI32(0)},
-	CONST_GLFW_REPEAT:                    CXConstant{Type: TYPE_I32, Value: FromI32(2)},
-	CONST_GLFW_KEY_UNKNOWN:               CXConstant{Type: TYPE_I32, Value: FromI32(-1)},
-	CONST_GLFW_CURSOR:                    CXConstant{Type: TYPE_I32, Value: FromI32(208897)},
-	CONST_GLFW_STICKY_KEYS:               CXConstant{Type: TYPE_I32, Value: FromI32(208898)},
-	CONST_GLFW_STICKY_MOUSE_BUTTONS:      CXConstant{Type: TYPE_I32, Value: FromI32(208899)},
-	CONST_GLFW_CURSOR_NORMAL:             CXConstant{Type: TYPE_I32, Value: FromI32(212993)},
-	CONST_GLFW_CURSOR_HIDDEN:             CXConstant{Type: TYPE_I32, Value: FromI32(212994)},
-	CONST_GLFW_CURSOR_DISABLED:           CXConstant{Type: TYPE_I32, Value: FromI32(212995)},
-	CONST_GLFW_RESIZABLE:                 CXConstant{Type: TYPE_I32, Value: FromI32(131075)},
-	CONST_GLFW_CONTEXT_VERSION_MAJOR:     CXConstant{Type: TYPE_I32, Value: FromI32(139266)},
-	CONST_GLFW_CONTEXT_VERSION_MINOR:     CXConstant{Type: TYPE_I32, Value: FromI32(139267)},
-	CONST_GLFW_OPENGL_PROFILE:            CXConstant{Type: TYPE_I32, Value: FromI32(139272)},
-	CONST_GLFW_OPENGL_COREPROFILE:        CXConstant{Type: TYPE_I32, Value: FromI32(204801)},
-	CONST_GLFW_OPENGL_FORWARD_COMPATIBLE: CXConstant{Type: TYPE_I32, Value: FromI32(139270)},
-	CONST_GLFW_MOUSE_BUTTON_LAST:         CXConstant{Type: TYPE_I32, Value: FromI32(7)},
-	CONST_GLFW_MOUSE_BUTTON_LEFT:         CXConstant{Type: TYPE_I32, Value: FromI32(0)},
-	CONST_GLFW_MOUSE_BUTTON_RIGHT:        CXConstant{Type: TYPE_I32, Value: FromI32(1)},
-	CONST_GLFW_MOUSE_BUTTON_MIDDLE:       CXConstant{Type: TYPE_I32, Value: FromI32(2)},
-
-	// gltext
-	CONST_GLTEXT_LEFT_TO_RIGHT:           CXConstant{Type: TYPE_I32, Value: FromI32(0)},
-	CONST_GLTEXT_RIGHT_TO_LEFT:           CXConstant{Type: TYPE_I32, Value: FromI32(1)},
-	CONST_GLTEXT_TOP_TO_BOTTOM:           CXConstant{Type: TYPE_I32, Value: FromI32(2)},
+	AddConstCode( CONST_GLTEXT_LEFT_TO_RIGHT           , "gltext.LeftToRight"            , TYPE_I32, FromI32(0))
+	AddConstCode( CONST_GLTEXT_RIGHT_TO_LEFT           , "gltext.RightToLeft"            , TYPE_I32, FromI32(1))
+	AddConstCode( CONST_GLTEXT_TOP_TO_BOTTOM           , "gltext.TopToBottom"            , TYPE_I32, FromI32(2))
 }

--- a/cx/opcodes_bare.go
+++ b/cx/opcodes_bare.go
@@ -51,7 +51,7 @@ const (
 	OP_BYTE_I64
 	OP_BYTE_F32
 	OP_BYTE_F64
-	
+
 	OP_BYTE_PRINT
 
 	OP_I32_BYTE
@@ -60,7 +60,7 @@ const (
 	OP_I32_I64
 	OP_I32_F32
 	OP_I32_F64
-	
+
 	OP_I32_PRINT
 	OP_I32_ADD
 	OP_I32_SUB
@@ -131,7 +131,7 @@ const (
 	OP_F32_I64
 	OP_F32_F32
 	OP_F32_F64
-	
+
 	OP_F32_PRINT
 	OP_F32_ADD
 	OP_F32_SUB
@@ -194,7 +194,7 @@ const (
 	OP_STR_I64
 	OP_STR_F32
 	OP_STR_F64
-	
+
 	OP_MAKE
 	OP_READ
 	OP_WRITE
@@ -234,593 +234,210 @@ const (
 )
 
 // For the parser. These shouldn't be used in the runtime for performance reasons
-var OpNames map[int]string
-var OpCodes map[string]int
-var Natives map[int]*CXFunction
+var OpNames map[int]string = map[int]string{}
+var OpCodes map[string]int = map[string]int{}
+var Natives map[int]*CXFunction = map[int]*CXFunction{}
 var execNative func(*CXProgram)
 
+func AddOpCode (code int, name string, inputs []int, outputs []int) {
+	OpNames[code] = name
+	OpCodes[name] = code
+	Natives[code] = MakeNative(code, inputs, outputs)
+}
+
 func init () {
-	OpNames = map[int]string{
-		OP_IDENTITY:   "identity",
-		OP_JMP:        "jmp",
-		OP_DEBUG:      "debug",
+	AddOpCode(OP_IDENTITY, "identity", []int{TYPE_UNDEFINED}, []int{TYPE_UNDEFINED})
+	AddOpCode(OP_JMP, "jmp", []int{TYPE_BOOL}, []int{})
+	AddOpCode(OP_DEBUG, "debug", []int{}, []int{})
 
-		OP_UND_EQUAL:    "eq",
-		OP_UND_UNEQUAL:  "uneq",
-		OP_UND_BITAND:   "bitand",
-		OP_UND_BITXOR:   "bitxor",
-		OP_UND_BITOR:    "bitor",
-		OP_UND_BITCLEAR: "bitclear",
-		OP_UND_MUL:      "mul",
-		OP_UND_DIV:      "div",
-		OP_UND_MOD:      "mod",
-		OP_UND_ADD:      "add",
-		OP_UND_SUB:      "sub",
-		OP_UND_BITSHL:   "bitshl",
-		OP_UND_LT:       "lt",
-		OP_UND_GT:       "gt",
-		OP_UND_LTEQ:     "lteq",
-		OP_UND_GTEQ:     "gteq",
-		OP_UND_LEN:      "len",
-		OP_UND_PRINTF:   "printf",
-		OP_UND_SPRINTF:  "sprintf",
-		OP_UND_READ:     "read",
+	AddOpCode(OP_UND_EQUAL, "eq", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_BOOL})
+	AddOpCode(OP_UND_UNEQUAL, "uneq", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_BOOL})
+	AddOpCode(OP_UND_BITAND, "bitand", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED})
+	AddOpCode(OP_UND_BITXOR, "bitxor", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED})
+	AddOpCode(OP_UND_BITOR, "bitor", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED})
+	AddOpCode(OP_UND_BITCLEAR, "bitclear", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED})
+	AddOpCode(OP_UND_MUL, "mul", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED})
+	AddOpCode(OP_UND_DIV, "div", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED})
+	AddOpCode(OP_UND_MOD, "mod", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED})
+	AddOpCode(OP_UND_ADD, "add", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED})
+	AddOpCode(OP_UND_SUB, "sub", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED})
+	AddOpCode(OP_UND_BITSHL, "bitshl", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED})
+	AddOpCode(OP_UND_BITSHR, "bitshr", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED})
+	AddOpCode(OP_UND_LT, "lt", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_BOOL})
+	AddOpCode(OP_UND_GT, "gt", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_BOOL})
+	AddOpCode(OP_UND_LTEQ, "lteq", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_BOOL})
+	AddOpCode(OP_UND_GTEQ, "gteq", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_BOOL})
+	AddOpCode(OP_UND_LEN, "len", []int{TYPE_UNDEFINED}, []int{TYPE_I32})
+	AddOpCode(OP_UND_PRINTF, "printf", []int{TYPE_UNDEFINED}, []int{})
+	AddOpCode(OP_UND_SPRINTF, "sprintf", []int{TYPE_UNDEFINED}, []int{TYPE_STR})
+	AddOpCode(OP_UND_READ, "read", []int{}, []int{TYPE_STR})
 
-		OP_BYTE_BYTE: "byte.byte",
-		OP_BYTE_STR: "byte.str",
-		OP_BYTE_I32: "byte.i32",
-		OP_BYTE_I64: "byte.i64",
-		OP_BYTE_F32: "byte.f32",
-		OP_BYTE_F64: "byte.f64",
-		
-		OP_BYTE_PRINT: "byte.print",
+	AddOpCode(OP_BYTE_BYTE, "byte.byte", []int{TYPE_BYTE}, []int{TYPE_BYTE})
+	AddOpCode(OP_BYTE_STR, "byte.str", []int{TYPE_BYTE}, []int{TYPE_STR})
+	AddOpCode(OP_BYTE_I32, "byte.i32", []int{TYPE_BYTE}, []int{TYPE_I32})
+	AddOpCode(OP_BYTE_I64, "byte.i64", []int{TYPE_BYTE}, []int{TYPE_I64})
+	AddOpCode(OP_BYTE_F32, "byte.f32", []int{TYPE_BYTE}, []int{TYPE_F32})
+	AddOpCode(OP_BYTE_F64, "byte.f64", []int{TYPE_BYTE}, []int{TYPE_F64})
 
-		OP_BOOL_PRINT:   "bool.print",
-		OP_BOOL_EQUAL:   "bool.eq",
-		OP_BOOL_UNEQUAL: "bool.uneq",
-		OP_BOOL_NOT:     "bool.not",
-		OP_BOOL_OR:      "bool.or",
-		OP_BOOL_AND:     "bool.and",
-		
-		OP_I32_BYTE:     "i32.byte",
-		OP_I32_STR:      "i32.str",
-		OP_I32_I32:      "i32.i32",
-		OP_I32_I64:      "i32.i64",
-		OP_I32_F32:      "i32.f32",
-		OP_I32_F64:      "i32.f64",
+	AddOpCode(OP_BYTE_PRINT, "byte.print", []int{TYPE_BYTE}, []int{})
 
-		OP_I32_PRINT:    "i32.print",
-		OP_I32_ADD:      "i32.add",
-		OP_I32_SUB:      "i32.sub",
-		OP_I32_MUL:      "i32.mul",
-		OP_I32_DIV:      "i32.div",
-		OP_I32_ABS:      "i32.abs",
-		OP_I32_POW:      "i32.pow",
-		OP_I32_GT:       "i32.gt",
-		OP_I32_GTEQ:     "i32.gteq",
-		OP_I32_LT:       "i32.lt",
-		OP_I32_LTEQ:     "i32.lteq",
-		OP_I32_EQ:       "i32.eq",
-		OP_I32_UNEQ:     "i32.uneq",
-		OP_I32_MOD:      "i32.mod",
-		OP_I32_RAND:     "i32.rand",
-		OP_I32_BITAND:   "i32.bitand",
-		OP_I32_BITOR:    "i32.bitor",
-		OP_I32_BITXOR:   "i32.bitxor",
-		OP_I32_BITCLEAR: "i32.bitclear",
-		OP_I32_BITSHL:   "i32.bitshl",
-		OP_I32_BITSHR:   "i32.bitshr",
-		OP_I32_SQRT:     "i32.sqrt",
-		OP_I32_LOG:      "i32.log",
-		OP_I32_LOG2:     "i32.log2",
-		OP_I32_LOG10:    "i32.log10",
-		OP_I32_MAX:      "i32.max",
-		OP_I32_MIN:      "i32.min",
+	AddOpCode(OP_BOOL_PRINT, "bool.print", []int{TYPE_BOOL}, []int{})
+	AddOpCode(OP_BOOL_EQUAL, "bool.eq", []int{TYPE_BOOL, TYPE_BOOL}, []int{TYPE_BOOL})
+	AddOpCode(OP_BOOL_UNEQUAL, "bool.uneq", []int{TYPE_BOOL, TYPE_BOOL}, []int{TYPE_BOOL})
+	AddOpCode(OP_BOOL_NOT, "bool.not", []int{TYPE_BOOL}, []int{TYPE_BOOL})
+	AddOpCode(OP_BOOL_OR, "bool.or", []int{TYPE_BOOL, TYPE_BOOL}, []int{TYPE_BOOL})
+	AddOpCode(OP_BOOL_AND, "bool.and", []int{TYPE_BOOL, TYPE_BOOL}, []int{TYPE_BOOL})
 
-		OP_I64_BYTE:     "i64.byte",
-		OP_I64_STR:      "i64.str",
-		OP_I64_I32:      "i64.i32",
-		OP_I64_I64:      "i64.i64",
-		OP_I64_F32:      "i64.f32",
-		OP_I64_F64:      "i64.f64",
-		
-		OP_I64_PRINT:    "i64.print",
-		OP_I64_ADD:      "i64.add",
-		OP_I64_SUB:      "i64.sub",
-		OP_I64_MUL:      "i64.mul",
-		OP_I64_DIV:      "i64.div",
-		OP_I64_ABS:      "i64.abs",
-		OP_I64_POW:      "i64.pow",
-		OP_I64_GT:       "i64.gt",
-		OP_I64_GTEQ:     "i64.gteq",
-		OP_I64_LT:       "i64.lt",
-		OP_I64_LTEQ:     "i64.lteq",
-		OP_I64_EQ:       "i64.eq",
-		OP_I64_UNEQ:     "i64.uneq",
-		OP_I64_MOD:      "i64.mod",
-		OP_I64_RAND:     "i64.rand",
-		OP_I64_BITAND:   "i64.bitand",
-		OP_I64_BITOR:    "i64.bitor",
-		OP_I64_BITXOR:   "i64.bitxor",
-		OP_I64_BITCLEAR: "i64.bitclear",
-		OP_I64_BITSHL:   "i64.bitshl",
-		OP_I64_BITSHR:   "i64.bitshr",
-		OP_I64_SQRT:     "i64.sqrt",
-		OP_I64_LOG:      "i64.log",
-		OP_I64_LOG2:     "i64.log2",
-		OP_I64_LOG10:    "i64.log10",
-		OP_I64_MAX:      "i64.max",
-		OP_I64_MIN:      "i64.min",
-		
-		OP_F32_BYTE:     "f32.byte",
-		OP_F32_STR:      "f32.str",
-		OP_F32_I32:      "f32.i32",
-		OP_F32_I64:      "f32.i64",
-		OP_F32_F32:      "f32.f32",
-		OP_F32_F64:      "f32.f64",
-		
-		OP_F32_PRINT:    "f32.print",
-		OP_F32_ADD:      "f32.add",
-		OP_F32_SUB:      "f32.sub",
-		OP_F32_MUL:      "f32.mul",
-		OP_F32_DIV:      "f32.div",
-		OP_F32_ABS:      "f32.abs",
-		OP_F32_POW:      "f32.pow",
-		OP_F32_GT:       "f32.gt",
-		OP_F32_GTEQ:     "f32.gteq",
-		OP_F32_LT:       "f32.lt",
-		OP_F32_LTEQ:     "f32.lteq",
-		OP_F32_EQ:       "f32.eq",
-		OP_F32_UNEQ:     "f32.uneq",
-		OP_F32_COS:      "f32.cos",
-		OP_F32_SIN:      "f32.sin",
-		OP_F32_SQRT:     "f32.sqrt",
-		OP_F32_LOG:      "f32.log",
-		OP_F32_LOG2:     "f32.log2",
-		OP_F32_LOG10:    "f32.log10",
-		OP_F32_MAX:      "f32.max",
-		OP_F32_MIN:      "f32.min",
+	AddOpCode(OP_I32_BYTE, "i32.byte", []int{TYPE_I32}, []int{TYPE_BYTE})
+	AddOpCode(OP_I32_STR, "i32.str", []int{TYPE_I32}, []int{TYPE_STR})
+	AddOpCode(OP_I32_I32, "i32.i32", []int{TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_I64, "i32.i64", []int{TYPE_I32}, []int{TYPE_I64})
+	AddOpCode(OP_I32_F32, "i32.f32", []int{TYPE_I32}, []int{TYPE_F32})
+	AddOpCode(OP_I32_F64, "i32.f64", []int{TYPE_I32}, []int{TYPE_F64})
 
-		OP_F64_BYTE:    "f64.byte",
-		OP_F64_STR:    "f64.str",
-		OP_F64_I32:    "f64.i32",
-		OP_F64_I64:    "f64.i64",
-		OP_F64_F32:    "f64.f32",
-		OP_F64_F64:    "f64.f64",
-		
-		OP_F64_PRINT:    "f64.print",
-		OP_F64_ADD:      "f64.add",
-		OP_F64_SUB:      "f64.sub",
-		OP_F64_MUL:      "f64.mul",
-		OP_F64_DIV:      "f64.div",
-		OP_F64_ABS:      "f64.abs",
-		OP_F64_POW:      "f64.pow",
-		OP_F64_GT:       "f64.gt",
-		OP_F64_GTEQ:     "f64.gteq",
-		OP_F64_LT:       "f64.lt",
-		OP_F64_LTEQ:     "f64.lteq",
-		OP_F64_EQ:       "f64.eq",
-		OP_F64_UNEQ:     "f64.uneq",
-		OP_F64_COS:      "f64.cos",
-		OP_F64_SIN:      "f64.sin",
-		OP_F64_SQRT:     "f64.sqrt",
-		OP_F64_LOG:      "f64.log",
-		OP_F64_LOG2:     "f64.log2",
-		OP_F64_LOG10:    "f64.log10",
-		OP_F64_MAX:      "f64.max",
-		OP_F64_MIN:      "f64.min",
+	AddOpCode(OP_I32_PRINT, "i32.print", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_I32_ADD, "i32.add", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_SUB, "i32.sub", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_MUL, "i32.mul", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_DIV, "i32.div", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_ABS, "i32.abs", []int{TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_POW, "i32.pow", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_GT, "i32.gt", []int{TYPE_I32, TYPE_I32}, []int{TYPE_BOOL})
+	AddOpCode(OP_I32_GTEQ, "i32.gteq", []int{TYPE_I32, TYPE_I32}, []int{TYPE_BOOL})
+	AddOpCode(OP_I32_LT, "i32.lt", []int{TYPE_I32, TYPE_I32}, []int{TYPE_BOOL})
+	AddOpCode(OP_I32_LTEQ, "i32.lteq", []int{TYPE_I32, TYPE_I32}, []int{TYPE_BOOL})
+	AddOpCode(OP_I32_EQ, "i32.eq", []int{TYPE_I32, TYPE_I32}, []int{TYPE_BOOL})
+	AddOpCode(OP_I32_UNEQ, "i32.uneq", []int{TYPE_I32, TYPE_I32}, []int{TYPE_BOOL})
+	AddOpCode(OP_I32_MOD, "i32.mod", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_RAND, "i32.rand", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_BITAND, "i32.bitand", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_BITOR, "i32.bitor", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_BITXOR, "i32.bitxor", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_BITCLEAR, "i32.bitclear", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_BITSHL, "i32.bitshl", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_BITSHR, "i32.bitshr", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_SQRT, "i32.sqrt", []int{TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_LOG, "i32.log", []int{TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_LOG2, "i32.log2", []int{TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_LOG10, "i32.log10", []int{TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_MAX, "i32.max", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_I32_MIN, "i32.min", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
 
-		OP_STR_PRINT: "str.print",
-		OP_STR_CONCAT: "str.concat",
-		OP_STR_EQ: "str.eq",
+	AddOpCode(OP_I64_BYTE, "i64.byte", []int{TYPE_I64}, []int{TYPE_BYTE})
+	AddOpCode(OP_I64_STR, "i64.str", []int{TYPE_I64}, []int{TYPE_STR})
+	AddOpCode(OP_I64_I32, "i64.i32", []int{TYPE_I64}, []int{TYPE_I32})
+	AddOpCode(OP_I64_I64, "i64.i64", []int{TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_F32, "i64.f32", []int{TYPE_I64}, []int{TYPE_F32})
+	AddOpCode(OP_I64_F64, "i64.f64", []int{TYPE_I64}, []int{TYPE_F64})
 
-		OP_STR_BYTE: "str.byte",
-		OP_STR_STR: "str.str",
-		OP_STR_I32: "str.i32",
-		OP_STR_I64: "str.i64",
-		OP_STR_F32: "str.f32",
-		OP_STR_F64: "str.f64",
+	AddOpCode(OP_I64_PRINT, "i64.print", []int{TYPE_I64}, []int{})
+	AddOpCode(OP_I64_ADD, "i64.add", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_SUB, "i64.sub", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_MUL, "i64.mul", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_DIV, "i64.div", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_ABS, "i64.abs", []int{TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_POW, "i64.pow", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_GT, "i64.gt", []int{TYPE_I64, TYPE_I64}, []int{TYPE_BOOL})
+	AddOpCode(OP_I64_GTEQ, "i64.gteq", []int{TYPE_I64, TYPE_I64}, []int{TYPE_BOOL})
+	AddOpCode(OP_I64_LT, "i64.lt", []int{TYPE_I64, TYPE_I64}, []int{TYPE_BOOL})
+	AddOpCode(OP_I64_LTEQ, "i64.lteq", []int{TYPE_I64, TYPE_I64}, []int{TYPE_BOOL})
+	AddOpCode(OP_I64_EQ, "i64.eq", []int{TYPE_I64, TYPE_I64}, []int{TYPE_BOOL})
+	AddOpCode(OP_I64_UNEQ, "i64.uneq", []int{TYPE_I64, TYPE_I64}, []int{TYPE_BOOL})
+	AddOpCode(OP_I64_MOD, "i64.mod", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_RAND, "i64.rand", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_BITAND, "i64.bitand", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_BITOR, "i64.bitor", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_BITXOR, "i64.bitxor", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_BITCLEAR, "i64.bitclear", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_BITSHL, "i64.bitshl", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_BITSHR, "i64.bitshr", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_SQRT, "i64.sqrt", []int{TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_LOG, "i64.log", []int{TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_LOG2, "i64.log2", []int{TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_LOG10, "i64.log10", []int{TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_MAX, "i64.max", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
+	AddOpCode(OP_I64_MIN, "i64.min", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
 
-		OP_APPEND: "append",
-		OP_ASSERT: "assert",
+	AddOpCode(OP_F32_BYTE, "f32.byte", []int{TYPE_F32}, []int{TYPE_BYTE})
+	AddOpCode(OP_F32_STR, "f32.str", []int{TYPE_F32}, []int{TYPE_STR})
+	AddOpCode(OP_F32_I32, "f32.i32", []int{TYPE_F32}, []int{TYPE_I32})
+	AddOpCode(OP_F32_I64, "f32.i64", []int{TYPE_F32}, []int{TYPE_I64})
+	AddOpCode(OP_F32_F32, "f32.f32", []int{TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_F64, "f32.f64", []int{TYPE_F32}, []int{TYPE_F64})
+	AddOpCode(OP_F32_PRINT, "f32.print", []int{TYPE_F32}, []int{})
+	AddOpCode(OP_F32_ADD, "f32.add", []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_SUB, "f32.sub", []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_MUL, "f32.mul", []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_DIV, "f32.div", []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_ABS, "f32.abs", []int{TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_POW, "f32.pow", []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_GT, "f32.gt", []int{TYPE_F32, TYPE_F32}, []int{TYPE_BOOL})
+	AddOpCode(OP_F32_GTEQ, "f32.gteq", []int{TYPE_F32, TYPE_F32}, []int{TYPE_BOOL})
+	AddOpCode(OP_F32_LT, "f32.lt", []int{TYPE_F32, TYPE_F32}, []int{TYPE_BOOL})
+	AddOpCode(OP_F32_LTEQ, "f32.lteq", []int{TYPE_F32, TYPE_F32}, []int{TYPE_BOOL})
+	AddOpCode(OP_F32_EQ, "f32.eq", []int{TYPE_F32, TYPE_F32}, []int{TYPE_BOOL})
+	AddOpCode(OP_F32_UNEQ, "f32.uneq", []int{TYPE_F32, TYPE_F32}, []int{TYPE_BOOL})
+	AddOpCode(OP_F32_COS, "f32.cos", []int{TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_SIN, "f32.sin", []int{TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_SQRT, "f32.sqrt", []int{TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_LOG, "f32.log", []int{TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_LOG2, "f32.log2", []int{TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_LOG10, "f32.log10", []int{TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_MAX, "f32.max", []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32})
+	AddOpCode(OP_F32_MIN, "f32.min", []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32})
 
-		// affordances
-		OP_AFF_PRINT: "aff.print",
-		OP_AFF_QUERY: "aff.query",
-		OP_AFF_ON: "aff.on",
-		OP_AFF_OF: "aff.of",
-		OP_AFF_INFORM: "aff.inform",
-		OP_AFF_REQUEST: "aff.request",
-	}
+	AddOpCode(OP_F64_BYTE, "f64.byte", []int{TYPE_F64}, []int{TYPE_BYTE})
+	AddOpCode(OP_F64_STR, "f64.str", []int{TYPE_F64}, []int{TYPE_STR})
+	AddOpCode(OP_F64_I32, "f64.i32", []int{TYPE_F64}, []int{TYPE_I32})
+	AddOpCode(OP_F64_I64, "f64.i64", []int{TYPE_F64}, []int{TYPE_I64})
+	AddOpCode(OP_F64_F32, "f64.f32", []int{TYPE_F64}, []int{TYPE_F32})
+	AddOpCode(OP_F64_F64, "f64.f64", []int{TYPE_F64}, []int{TYPE_F64})
 
-	OpCodes = map[string]int{
-		"identity": OP_IDENTITY,
-		"jmp":      OP_JMP,
-		"debug":    OP_DEBUG,
+	AddOpCode(OP_F64_PRINT, "f64.print", []int{TYPE_F64}, []int{})
+	AddOpCode(OP_F64_ADD, "f64.add", []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64})
+	AddOpCode(OP_F64_SUB, "f64.sub", []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64})
+	AddOpCode(OP_F64_MUL, "f64.mul", []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64})
+	AddOpCode(OP_F64_DIV, "f64.div", []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64})
+	AddOpCode(OP_F64_ABS, "f64.abs", []int{TYPE_F64}, []int{TYPE_F64})
+	AddOpCode(OP_F64_POW, "f64.pow", []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64})
+	AddOpCode(OP_F64_GT, "f64.gt", []int{TYPE_F64, TYPE_F64}, []int{TYPE_BOOL})
+	AddOpCode(OP_F64_GTEQ, "f64.gteq", []int{TYPE_F64, TYPE_F64}, []int{TYPE_BOOL})
+	AddOpCode(OP_F64_LT, "f64.lt", []int{TYPE_F64, TYPE_F64}, []int{TYPE_BOOL})
+	AddOpCode(OP_F64_LTEQ, "f64.lteq", []int{TYPE_F64, TYPE_F64}, []int{TYPE_BOOL})
+	AddOpCode(OP_F64_EQ, "f64.eq", []int{TYPE_F64, TYPE_F64}, []int{TYPE_BOOL})
+	AddOpCode(OP_F64_UNEQ, "f64.uneq", []int{TYPE_F64, TYPE_F64}, []int{TYPE_BOOL})
+	AddOpCode(OP_F64_COS, "f64.cos", []int{TYPE_F64}, []int{TYPE_F64})
+	AddOpCode(OP_F64_SIN, "f64.sin", []int{TYPE_F64}, []int{TYPE_F64})
+	AddOpCode(OP_F64_SQRT, "f64.sqrt", []int{TYPE_F64}, []int{TYPE_F64})
+	AddOpCode(OP_F64_LOG, "f64.log", []int{TYPE_F64}, []int{TYPE_F64})
+	AddOpCode(OP_F64_LOG2, "f64.log2", []int{TYPE_F64}, []int{TYPE_F64})
+	AddOpCode(OP_F64_LOG10, "f64.log10", []int{TYPE_F64}, []int{TYPE_F64})
+	AddOpCode(OP_F64_MAX, "f64.max", []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64})
+	AddOpCode(OP_F64_MIN, "f64.min", []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64})
 
-		"eq":       OP_UND_EQUAL,
-		"uneq":     OP_UND_UNEQUAL,
-		"bitand":   OP_UND_BITAND,
-		"bitxor":   OP_UND_BITXOR,
-		"bitor":    OP_UND_BITOR,
-		"bitclear": OP_UND_BITCLEAR,
-		"mul":      OP_UND_MUL,
-		"div":      OP_UND_DIV,
-		"mod":      OP_UND_MOD,
-		"add":      OP_UND_ADD,
-		"sub":      OP_UND_SUB,
-		"bitshl":   OP_UND_BITSHL,
-		"bitshr":   OP_UND_BITSHR,
-		"lt":       OP_UND_LT,
-		"gt":       OP_UND_GT,
-		"lteq":     OP_UND_LTEQ,
-		"gteq":     OP_UND_GTEQ,
-		"len":      OP_UND_LEN,
-		"printf":   OP_UND_PRINTF,
-		"sprintf":  OP_UND_SPRINTF,
-		"read":     OP_UND_READ,
+	AddOpCode(OP_STR_PRINT, "str.print", []int{TYPE_STR}, []int{})
+	AddOpCode(OP_STR_CONCAT, "str.concat", []int{TYPE_STR, TYPE_STR}, []int{TYPE_STR})
+	AddOpCode(OP_STR_EQ, "str.eq", []int{TYPE_STR, TYPE_STR}, []int{TYPE_BOOL})
 
-		"byte.byte":  OP_BYTE_BYTE,
-		"byte.str":   OP_BYTE_STR,
-		"byte.i32":   OP_BYTE_I32,
-		"byte.i64":   OP_BYTE_I64,
-		"byte.f32":   OP_BYTE_F32,
-		"byte.f64":   OP_BYTE_F64,
-		
-		"byte.print": OP_BYTE_PRINT,
+	AddOpCode(OP_STR_BYTE, "str.byte", []int{TYPE_STR}, []int{TYPE_BYTE})
+	AddOpCode(OP_STR_STR, "str.str", []int{TYPE_STR}, []int{TYPE_STR})
+	AddOpCode(OP_STR_I32, "str.i32", []int{TYPE_STR}, []int{TYPE_I32})
+	AddOpCode(OP_STR_I64, "str.i64", []int{TYPE_STR}, []int{TYPE_I64})
+	AddOpCode(OP_STR_F32, "str.f32", []int{TYPE_STR}, []int{TYPE_F32})
+	AddOpCode(OP_STR_F64, "str.f64", []int{TYPE_STR}, []int{TYPE_F64})
 
-		"bool.print": OP_BOOL_PRINT,
-		"bool.eq":    OP_BOOL_EQUAL,
-		"bool.uneq":  OP_BOOL_UNEQUAL,
-		"bool.not":   OP_BOOL_NOT,
-		"bool.or":    OP_BOOL_OR,
-		"bool.and":   OP_BOOL_AND,
+	AddOpCode(OP_APPEND, "append", []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED})
+	AddOpCode(OP_ASSERT, "assert", []int{TYPE_UNDEFINED, TYPE_UNDEFINED, TYPE_STR}, []int{TYPE_BOOL})
 
-		"i32.byte":     OP_I32_BYTE,
-		"i32.str":      OP_I32_STR,
-		"i32.i32":      OP_I32_I32,
-		"i32.i64":      OP_I32_I64,
-		"i32.f32":      OP_I32_F32,
-		"i32.f64":      OP_I32_F64,
-		
-		"i32.print":    OP_I32_PRINT,
-		"i32.add":      OP_I32_ADD,
-		"i32.sub":      OP_I32_SUB,
-		"i32.mul":      OP_I32_MUL,
-		"i32.div":      OP_I32_DIV,
-		"i32.abs":      OP_I32_ABS,
-		"i32.pow":      OP_I32_POW,
-		"i32.gt":       OP_I32_GT,
-		"i32.gteq":     OP_I32_GTEQ,
-		"i32.lt":       OP_I32_LT,
-		"i32.lteq":     OP_I32_LTEQ,
-		"i32.eq":       OP_I32_EQ,
-		"i32.uneq":     OP_I32_UNEQ,
-		"i32.mod":      OP_I32_MOD,
-		"i32.rand":     OP_I32_RAND,
-		"i32.bitand":   OP_I32_BITAND,
-		"i32.bitor":    OP_I32_BITOR,
-		"i32.bitxor":   OP_I32_BITXOR,
-		"i32.bitclear": OP_I32_BITCLEAR,
-		"i32.bitshl":   OP_I32_BITSHL,
-		"i32.bitshr":   OP_I32_BITSHR,
-		"i32.sqrt":     OP_I32_SQRT,
-		"i32.log":      OP_I32_LOG,
-		"i32.log2":     OP_I32_LOG2,
-		"i32.log10":    OP_I32_LOG10,
-		"i32.max":      OP_I32_MAX,
-		"i32.min":      OP_I32_MIN,
+	// affordances
+	AddOpCode(OP_AFF_PRINT, "aff.print", []int{TYPE_AFF}, []int{})
+	AddOpCode(OP_AFF_QUERY, "aff.query", []int{TYPE_AFF}, []int{TYPE_AFF})
+	AddOpCode(OP_AFF_ON, "aff.on", []int{TYPE_AFF, TYPE_AFF}, []int{})
+	AddOpCode(OP_AFF_OF, "aff.of", []int{TYPE_AFF, TYPE_AFF}, []int{})
+	AddOpCode(OP_AFF_INFORM, "aff.inform", []int{TYPE_AFF, TYPE_I32, TYPE_AFF}, []int{})
+	AddOpCode(OP_AFF_REQUEST, "aff.request", []int{TYPE_AFF, TYPE_I32, TYPE_AFF}, []int{})
 
-		"i64.byte":     OP_I64_BYTE,
-		"i64.str":      OP_I64_STR,
-		"i64.i32":      OP_I64_I32,
-		"i64.i64":      OP_I64_I64,
-		"i64.f32":      OP_I64_F32,
-		"i64.f64":      OP_I64_F64,
-		
-		"i64.print":    OP_I64_PRINT,
-		"i64.add":      OP_I64_ADD,
-		"i64.sub":      OP_I64_SUB,
-		"i64.mul":      OP_I64_MUL,
-		"i64.div":      OP_I64_DIV,
-		"i64.abs":      OP_I64_ABS,
-		"i64.pow":      OP_I64_POW,
-		"i64.gt":       OP_I64_GT,
-		"i64.gteq":     OP_I64_GTEQ,
-		"i64.lt":       OP_I64_LT,
-		"i64.lteq":     OP_I64_LTEQ,
-		"i64.eq":       OP_I64_EQ,
-		"i64.uneq":     OP_I64_UNEQ,
-		"i64.mod":      OP_I64_MOD,
-		"i64.rand":     OP_I64_RAND,
-		"i64.bitand":   OP_I64_BITAND,
-		"i64.bitor":    OP_I64_BITOR,
-		"i64.bitxor":   OP_I64_BITXOR,
-		"i64.bitclear": OP_I64_BITCLEAR,
-		"i64.bitshl":   OP_I64_BITSHL,
-		"i64.bitshr":   OP_I64_BITSHR,
-		"i64.sqrt":     OP_I64_SQRT,
-		"i64.log":      OP_I64_LOG,
-		"i64.log2":     OP_I64_LOG2,
-		"i64.log10":    OP_I64_LOG10,
-		"i64.max":      OP_I64_MAX,
-		"i64.min":      OP_I64_MIN,
-		
-		"f32.byte":     OP_F32_BYTE,
-		"f32.str":      OP_F32_STR,
-		"f32.i32":      OP_F32_I32,
-		"f32.i64":      OP_F32_I64,
-		"f32.f32":      OP_F32_F32,
-		"f32.f64":      OP_F32_F64,
-		
-		"f32.print":    OP_F32_PRINT,
-		"f32.add":      OP_F32_ADD,
-		"f32.sub":      OP_F32_SUB,
-		"f32.mul":      OP_F32_MUL,
-		"f32.div":      OP_F32_DIV,
-		"f32.abs":      OP_F32_ABS,
-		"f32.pow":      OP_F32_POW,
-		"f32.gt":       OP_F32_GT,
-		"f32.gteq":     OP_F32_GTEQ,
-		"f32.lt":       OP_F32_LT,
-		"f32.lteq":     OP_F32_LTEQ,
-		"f32.eq":       OP_F32_EQ,
-		"f32.uneq":     OP_F32_UNEQ,
-		"f32.cos":      OP_F32_COS,
-		"f32.sin":      OP_F32_SIN,
-		"f32.sqrt":     OP_F32_SQRT,
-		"f32.log":      OP_F32_LOG,
-		"f32.log2":     OP_F32_LOG2,
-		"f32.log10":    OP_F32_LOG10,
-		"f32.max":      OP_F32_MAX,
-		"f32.min":      OP_F32_MIN,
-
-		"f64.byte":     OP_F64_BYTE,
-		"f64.str":      OP_F64_STR,
-		"f64.i32":      OP_F64_I32,
-		"f64.i64":      OP_F64_I64,
-		"f64.f32":      OP_F64_F32,
-		"f64.f64":      OP_F64_F64,
-
-		"f64.print":    OP_F64_PRINT,
-		"f64.add":      OP_F64_ADD,
-		"f64.sub":      OP_F64_SUB,
-		"f64.mul":      OP_F64_MUL,
-		"f64.div":      OP_F64_DIV,
-		"f64.abs":      OP_F64_ABS,
-		"f64.pow":      OP_F64_POW,
-		"f64.gt":       OP_F64_GT,
-		"f64.gteq":     OP_F64_GTEQ,
-		"f64.lt":       OP_F64_LT,
-		"f64.lteq":     OP_F64_LTEQ,
-		"f64.eq":       OP_F64_EQ,
-		"f64.uneq":     OP_F64_UNEQ,
-		"f64.cos":      OP_F64_COS,
-		"f64.sin":      OP_F64_SIN,
-		"f64.sqrt":     OP_F64_SQRT,
-		"f64.log":      OP_F64_LOG,
-		"f64.log2":     OP_F64_LOG2,
-		"f64.log10":    OP_F64_LOG10,
-		"f64.max":      OP_F64_MAX,
-		"f64.min":      OP_F64_MIN,
-
-		"str.print": OP_STR_PRINT,
-		"str.concat": OP_STR_CONCAT,
-		"str.eq": OP_STR_EQ,
-
-		"str.byte": OP_STR_BYTE,
-		"str.str": OP_STR_STR,
-		"str.i32": OP_STR_I32,
-		"str.i64": OP_STR_I64,
-		"str.f32": OP_STR_F32,
-		"str.f64": OP_STR_F64,
-
-		"append":       OP_APPEND,
-		"assert":       OP_ASSERT,
-
-		// affordances
-		"aff.print": OP_AFF_PRINT,
-		"aff.query": OP_AFF_QUERY,
-		"aff.on": OP_AFF_ON,
-		"aff.of": OP_AFF_OF,
-		"aff.inform": OP_AFF_INFORM,
-		"aff.request": OP_AFF_REQUEST,
-	}
-
-	Natives = map[int]*CXFunction{
-		OP_IDENTITY:     MakeNative(OP_IDENTITY, []int{TYPE_UNDEFINED}, []int{TYPE_UNDEFINED}),
-		OP_JMP:          MakeNative(OP_JMP, []int{TYPE_BOOL}, []int{}),
-		OP_DEBUG:        MakeNative(OP_DEBUG, []int{}, []int{}),
-
-		OP_UND_EQUAL:    MakeNative(OP_UND_EQUAL, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_BOOL}),
-		OP_UND_UNEQUAL:  MakeNative(OP_UND_UNEQUAL, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_BOOL}),
-		OP_UND_BITAND:   MakeNative(OP_UND_BITAND, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED}),
-		OP_UND_BITXOR:   MakeNative(OP_UND_BITXOR, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED}),
-		OP_UND_BITOR:    MakeNative(OP_UND_BITOR, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED}),
-		OP_UND_BITCLEAR: MakeNative(OP_UND_BITCLEAR, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED}),
-		OP_UND_MUL:      MakeNative(OP_UND_MUL, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED}),
-		OP_UND_DIV:      MakeNative(OP_UND_DIV, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED}),
-		OP_UND_MOD:      MakeNative(OP_UND_MOD, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED}),
-		OP_UND_ADD:      MakeNative(OP_UND_ADD, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED}),
-		OP_UND_SUB:      MakeNative(OP_UND_SUB, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED}),
-		OP_UND_BITSHL:   MakeNative(OP_UND_BITSHL, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED}),
-		OP_UND_BITSHR:   MakeNative(OP_UND_BITSHR, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED}),
-		OP_UND_LT:       MakeNative(OP_UND_LT, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_BOOL}),
-		OP_UND_GT:       MakeNative(OP_UND_GT, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_BOOL}),
-		OP_UND_LTEQ:     MakeNative(OP_UND_LTEQ, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_BOOL}),
-		OP_UND_GTEQ:     MakeNative(OP_UND_GTEQ, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_BOOL}),
-		OP_UND_LEN:      MakeNative(OP_UND_LEN, []int{TYPE_UNDEFINED}, []int{TYPE_I32}),
-		OP_UND_PRINTF:   MakeNative(OP_UND_PRINTF, []int{TYPE_UNDEFINED}, []int{}),
-		OP_UND_SPRINTF:  MakeNative(OP_UND_SPRINTF, []int{TYPE_UNDEFINED}, []int{TYPE_STR}),
-		OP_UND_READ:     MakeNative(OP_UND_READ, []int{}, []int{TYPE_STR}),
-
-		OP_BYTE_BYTE:   MakeNative(OP_BYTE_BYTE, []int{TYPE_BYTE}, []int{TYPE_BYTE}),
-		OP_BYTE_STR:    MakeNative(OP_BYTE_STR, []int{TYPE_BYTE}, []int{TYPE_STR}),
-		OP_BYTE_I32:    MakeNative(OP_BYTE_I32, []int{TYPE_BYTE}, []int{TYPE_I32}),
-		OP_BYTE_I64:    MakeNative(OP_BYTE_I64, []int{TYPE_BYTE}, []int{TYPE_I64}),
-		OP_BYTE_F32:    MakeNative(OP_BYTE_F32, []int{TYPE_BYTE}, []int{TYPE_F32}),
-		OP_BYTE_F64:    MakeNative(OP_BYTE_F64, []int{TYPE_BYTE}, []int{TYPE_F64}),
-
-		OP_BYTE_PRINT:   MakeNative(OP_BYTE_PRINT, []int{TYPE_BYTE}, []int{}),
-
-		OP_BOOL_PRINT:   MakeNative(OP_BOOL_PRINT, []int{TYPE_BOOL}, []int{}),
-		OP_BOOL_EQUAL:   MakeNative(OP_BOOL_EQUAL, []int{TYPE_BOOL, TYPE_BOOL}, []int{TYPE_BOOL}),
-		OP_BOOL_UNEQUAL: MakeNative(OP_BOOL_UNEQUAL, []int{TYPE_BOOL, TYPE_BOOL}, []int{TYPE_BOOL}),
-		OP_BOOL_NOT:     MakeNative(OP_BOOL_NOT, []int{TYPE_BOOL}, []int{TYPE_BOOL}),
-		OP_BOOL_OR:      MakeNative(OP_BOOL_OR, []int{TYPE_BOOL, TYPE_BOOL}, []int{TYPE_BOOL}),
-		OP_BOOL_AND:     MakeNative(OP_BOOL_AND, []int{TYPE_BOOL, TYPE_BOOL}, []int{TYPE_BOOL}),
-
-		OP_I32_BYTE:     MakeNative(OP_I32_BYTE, []int{TYPE_I32}, []int{TYPE_BYTE}),
-		OP_I32_STR:      MakeNative(OP_I32_STR, []int{TYPE_I32}, []int{TYPE_STR}),
-		OP_I32_I32:      MakeNative(OP_I32_I32, []int{TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_I64:      MakeNative(OP_I32_I64, []int{TYPE_I32}, []int{TYPE_I64}),
-		OP_I32_F32:      MakeNative(OP_I32_F32, []int{TYPE_I32}, []int{TYPE_F32}),
-		OP_I32_F64:      MakeNative(OP_I32_F64, []int{TYPE_I32}, []int{TYPE_F64}),
-
-		OP_I32_PRINT:    MakeNative(OP_I32_PRINT, []int{TYPE_I32}, []int{}),
-		OP_I32_ADD:      MakeNative(OP_I32_ADD, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_SUB:      MakeNative(OP_I32_SUB, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_MUL:      MakeNative(OP_I32_MUL, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_DIV:      MakeNative(OP_I32_DIV, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_ABS:      MakeNative(OP_I32_ABS, []int{TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_POW:      MakeNative(OP_I32_POW, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_GT:       MakeNative(OP_I32_GT, []int{TYPE_I32, TYPE_I32}, []int{TYPE_BOOL}),
-		OP_I32_GTEQ:     MakeNative(OP_I32_GTEQ, []int{TYPE_I32, TYPE_I32}, []int{TYPE_BOOL}),
-		OP_I32_LT:       MakeNative(OP_I32_LT, []int{TYPE_I32, TYPE_I32}, []int{TYPE_BOOL}),
-		OP_I32_LTEQ:     MakeNative(OP_I32_LTEQ, []int{TYPE_I32, TYPE_I32}, []int{TYPE_BOOL}),
-		OP_I32_EQ:       MakeNative(OP_I32_EQ, []int{TYPE_I32, TYPE_I32}, []int{TYPE_BOOL}),
-		OP_I32_UNEQ:     MakeNative(OP_I32_UNEQ, []int{TYPE_I32, TYPE_I32}, []int{TYPE_BOOL}),
-		OP_I32_MOD:      MakeNative(OP_I32_MOD, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_RAND:     MakeNative(OP_I32_RAND, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_BITAND:   MakeNative(OP_I32_BITAND, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_BITOR:    MakeNative(OP_I32_BITOR, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_BITXOR:   MakeNative(OP_I32_BITXOR, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_BITCLEAR: MakeNative(OP_I32_BITCLEAR, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_BITSHL:   MakeNative(OP_I32_BITSHL, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_BITSHR:   MakeNative(OP_I32_BITSHR, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_SQRT:     MakeNative(OP_I32_SQRT, []int{TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_LOG:      MakeNative(OP_I32_LOG, []int{TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_LOG2:     MakeNative(OP_I32_LOG2, []int{TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_LOG10:    MakeNative(OP_I32_LOG10, []int{TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_MAX:      MakeNative(OP_I32_MAX, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-		OP_I32_MIN:      MakeNative(OP_I32_MIN, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32}),
-
-		OP_I64_BYTE:     MakeNative(OP_I64_BYTE, []int{TYPE_I64}, []int{TYPE_BYTE}),
-		OP_I64_STR:      MakeNative(OP_I64_STR, []int{TYPE_I64}, []int{TYPE_STR}),
-		OP_I64_I32:      MakeNative(OP_I64_I32, []int{TYPE_I64}, []int{TYPE_I32}),
-		OP_I64_I64:      MakeNative(OP_I64_I64, []int{TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_F32:      MakeNative(OP_I64_F32, []int{TYPE_I64}, []int{TYPE_F32}),
-		OP_I64_F64:      MakeNative(OP_I64_F64, []int{TYPE_I64}, []int{TYPE_F64}),
-		
-		OP_I64_PRINT:    MakeNative(OP_I64_PRINT, []int{TYPE_I64}, []int{}),
-		OP_I64_ADD:      MakeNative(OP_I64_ADD, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_SUB:      MakeNative(OP_I64_SUB, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_MUL:      MakeNative(OP_I64_MUL, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_DIV:      MakeNative(OP_I64_DIV, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_ABS:      MakeNative(OP_I64_ABS, []int{TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_POW:      MakeNative(OP_I64_POW, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_GT:       MakeNative(OP_I64_GT, []int{TYPE_I64, TYPE_I64}, []int{TYPE_BOOL}),
-		OP_I64_GTEQ:     MakeNative(OP_I64_GTEQ, []int{TYPE_I64, TYPE_I64}, []int{TYPE_BOOL}),
-		OP_I64_LT:       MakeNative(OP_I64_LT, []int{TYPE_I64, TYPE_I64}, []int{TYPE_BOOL}),
-		OP_I64_LTEQ:     MakeNative(OP_I64_LTEQ, []int{TYPE_I64, TYPE_I64}, []int{TYPE_BOOL}),
-		OP_I64_EQ:       MakeNative(OP_I64_EQ, []int{TYPE_I64, TYPE_I64}, []int{TYPE_BOOL}),
-		OP_I64_UNEQ:     MakeNative(OP_I64_UNEQ, []int{TYPE_I64, TYPE_I64}, []int{TYPE_BOOL}),
-		OP_I64_MOD:      MakeNative(OP_I64_MOD, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_RAND:     MakeNative(OP_I64_RAND, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_BITAND:   MakeNative(OP_I64_BITAND, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_BITOR:    MakeNative(OP_I64_BITOR, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_BITXOR:   MakeNative(OP_I64_BITXOR, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_BITCLEAR: MakeNative(OP_I64_BITCLEAR, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_BITSHL:   MakeNative(OP_I64_BITSHL, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_BITSHR:   MakeNative(OP_I64_BITSHR, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_SQRT:     MakeNative(OP_I64_SQRT, []int{TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_LOG:      MakeNative(OP_I64_LOG, []int{TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_LOG2:     MakeNative(OP_I64_LOG2, []int{TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_LOG10:    MakeNative(OP_I64_LOG10, []int{TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_MAX:      MakeNative(OP_I64_MAX, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-		OP_I64_MIN:      MakeNative(OP_I64_MIN, []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64}),
-
-		OP_F32_BYTE:     MakeNative(OP_F32_BYTE, []int{TYPE_F32}, []int{TYPE_BYTE}),
-		OP_F32_STR:      MakeNative(OP_F32_STR,  []int{TYPE_F32}, []int{TYPE_STR}),
-		OP_F32_I32:      MakeNative(OP_F32_I32,  []int{TYPE_F32}, []int{TYPE_I32}),
-		OP_F32_I64:      MakeNative(OP_F32_I64,  []int{TYPE_F32}, []int{TYPE_I64}),
-		OP_F32_F32:      MakeNative(OP_F32_F32,  []int{TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_F64:      MakeNative(OP_F32_F64,  []int{TYPE_F32}, []int{TYPE_F64}),
-		
-		OP_F32_PRINT:    MakeNative(OP_F32_PRINT, []int{TYPE_F32}, []int{}),
-		OP_F32_ADD:      MakeNative(OP_F32_ADD, []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_SUB:      MakeNative(OP_F32_SUB, []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_MUL:      MakeNative(OP_F32_MUL, []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_DIV:      MakeNative(OP_F32_DIV, []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_ABS:      MakeNative(OP_F32_ABS, []int{TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_POW:      MakeNative(OP_F32_POW, []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_GT:       MakeNative(OP_F32_GT, []int{TYPE_F32, TYPE_F32}, []int{TYPE_BOOL}),
-		OP_F32_GTEQ:     MakeNative(OP_F32_GTEQ, []int{TYPE_F32, TYPE_F32}, []int{TYPE_BOOL}),
-		OP_F32_LT:       MakeNative(OP_F32_LT, []int{TYPE_F32, TYPE_F32}, []int{TYPE_BOOL}),
-		OP_F32_LTEQ:     MakeNative(OP_F32_LTEQ, []int{TYPE_F32, TYPE_F32}, []int{TYPE_BOOL}),
-		OP_F32_EQ:       MakeNative(OP_F32_EQ, []int{TYPE_F32, TYPE_F32}, []int{TYPE_BOOL}),
-		OP_F32_UNEQ:     MakeNative(OP_F32_UNEQ, []int{TYPE_F32, TYPE_F32}, []int{TYPE_BOOL}),
-		OP_F32_COS:      MakeNative(OP_F32_COS, []int{TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_SIN:      MakeNative(OP_F32_SIN, []int{TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_SQRT:     MakeNative(OP_F32_SQRT, []int{TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_LOG:      MakeNative(OP_F32_LOG, []int{TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_LOG2:     MakeNative(OP_F32_LOG2, []int{TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_LOG10:    MakeNative(OP_F32_LOG10, []int{TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_MAX:      MakeNative(OP_F32_MAX, []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32}),
-		OP_F32_MIN:      MakeNative(OP_F32_MIN, []int{TYPE_F32, TYPE_F32}, []int{TYPE_F32}),
-
-		OP_F64_BYTE:   MakeNative(OP_F64_BYTE, []int{TYPE_F64}, []int{TYPE_BYTE}),
-		OP_F64_STR:    MakeNative(OP_F64_STR, []int{TYPE_F64}, []int{TYPE_STR}),
-		OP_F64_I32:    MakeNative(OP_F64_I32, []int{TYPE_F64}, []int{TYPE_I32}),
-		OP_F64_I64:    MakeNative(OP_F64_I64, []int{TYPE_F64}, []int{TYPE_I64}),
-		OP_F64_F32:    MakeNative(OP_F64_F32, []int{TYPE_F64}, []int{TYPE_F32}),
-		OP_F64_F64:    MakeNative(OP_F64_F64, []int{TYPE_F64}, []int{TYPE_F64}),
-
-		OP_F64_PRINT:    MakeNative(OP_F64_PRINT, []int{TYPE_F64}, []int{}),
-		OP_F64_ADD:      MakeNative(OP_F64_ADD, []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64}),
-		OP_F64_SUB:      MakeNative(OP_F64_SUB, []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64}),
-		OP_F64_MUL:      MakeNative(OP_F64_MUL, []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64}),
-		OP_F64_DIV:      MakeNative(OP_F64_DIV, []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64}),
-		OP_F64_ABS:      MakeNative(OP_F64_ABS, []int{TYPE_F64}, []int{TYPE_F64}),
-		OP_F64_POW:      MakeNative(OP_F64_POW, []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64}),
-		OP_F64_GT:       MakeNative(OP_F64_GT, []int{TYPE_F64, TYPE_F64}, []int{TYPE_BOOL}),
-		OP_F64_GTEQ:     MakeNative(OP_F64_GTEQ, []int{TYPE_F64, TYPE_F64}, []int{TYPE_BOOL}),
-		OP_F64_LT:       MakeNative(OP_F64_LT, []int{TYPE_F64, TYPE_F64}, []int{TYPE_BOOL}),
-		OP_F64_LTEQ:     MakeNative(OP_F64_LTEQ, []int{TYPE_F64, TYPE_F64}, []int{TYPE_BOOL}),
-		OP_F64_EQ:       MakeNative(OP_F64_EQ, []int{TYPE_F64, TYPE_F64}, []int{TYPE_BOOL}),
-		OP_F64_UNEQ:     MakeNative(OP_F64_UNEQ, []int{TYPE_F64, TYPE_F64}, []int{TYPE_BOOL}),
-		OP_F64_COS:      MakeNative(OP_F64_COS, []int{TYPE_F64}, []int{TYPE_F64}),
-		OP_F64_SIN:      MakeNative(OP_F64_SIN, []int{TYPE_F64}, []int{TYPE_F64}),
-		OP_F64_SQRT:     MakeNative(OP_F64_SQRT, []int{TYPE_F64}, []int{TYPE_F64}),
-		OP_F64_LOG:      MakeNative(OP_F64_LOG, []int{TYPE_F64}, []int{TYPE_F64}),
-		OP_F64_LOG2:     MakeNative(OP_F64_LOG2, []int{TYPE_F64}, []int{TYPE_F64}),
-		OP_F64_LOG10:    MakeNative(OP_F64_LOG10, []int{TYPE_F64}, []int{TYPE_F64}),
-		OP_F64_MIN:      MakeNative(OP_F64_MIN, []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64}),
-		OP_F64_MAX:      MakeNative(OP_F64_MAX, []int{TYPE_F64, TYPE_F64}, []int{TYPE_F64}),
-		
-		OP_STR_PRINT:    MakeNative(OP_STR_PRINT, []int{TYPE_STR}, []int{}),
-		OP_STR_CONCAT:   MakeNative(OP_STR_CONCAT, []int{TYPE_STR, TYPE_STR}, []int{TYPE_STR}),
-		OP_STR_EQ:       MakeNative(OP_STR_EQ, []int{TYPE_STR, TYPE_STR}, []int{TYPE_BOOL}),
-
-		OP_STR_BYTE:      MakeNative(OP_STR_BYTE,[]int{TYPE_STR}, []int{TYPE_BYTE}),
-		OP_STR_STR:       MakeNative(OP_STR_STR, []int{TYPE_STR}, []int{TYPE_STR}),
-		OP_STR_I32:       MakeNative(OP_STR_I32, []int{TYPE_STR}, []int{TYPE_I32}),
-		OP_STR_I64:       MakeNative(OP_STR_I64, []int{TYPE_STR}, []int{TYPE_I64}),
-		OP_STR_F32:       MakeNative(OP_STR_F32, []int{TYPE_STR}, []int{TYPE_F32}),
-		OP_STR_F64:       MakeNative(OP_STR_F64, []int{TYPE_STR}, []int{TYPE_F64}),
-
-		OP_APPEND:     MakeNative(OP_APPEND, []int{TYPE_UNDEFINED, TYPE_UNDEFINED}, []int{TYPE_UNDEFINED}),
-		OP_ASSERT:     MakeNative(OP_ASSERT, []int{TYPE_UNDEFINED, TYPE_UNDEFINED, TYPE_STR}, []int{TYPE_BOOL}),
-
-		// affordances
-		OP_AFF_PRINT:  MakeNative(OP_AFF_PRINT, []int{TYPE_AFF}, []int{}),
-		OP_AFF_QUERY:  MakeNative(OP_AFF_QUERY, []int{TYPE_AFF}, []int{TYPE_AFF}),
-		OP_AFF_ON: MakeNative(OP_AFF_ON, []int{TYPE_AFF, TYPE_AFF}, []int{}),
-		OP_AFF_OF: MakeNative(OP_AFF_OF, []int{TYPE_AFF, TYPE_AFF}, []int{}),
-		OP_AFF_INFORM: MakeNative(OP_AFF_INFORM, []int{TYPE_AFF, TYPE_I32, TYPE_AFF}, []int{}),
-		OP_AFF_REQUEST: MakeNative(OP_AFF_REQUEST, []int{TYPE_AFF, TYPE_I32, TYPE_AFF}, []int{}),
-	}
-
+	// exec
 	execNative = func(prgrm *CXProgram) {
 		call := &prgrm.CallStack[prgrm.CallCounter]
 		expr := call.Operator.Expressions[call.Line]
@@ -919,7 +536,7 @@ func init () {
 			op_i32_i32(expr, fp)
 		case OP_I32_F64:
 			op_i32_i32(expr, fp)
-			
+
 		case OP_I32_PRINT:
 			op_i32_print(expr, fp)
 		case OP_I32_ADD:
@@ -1056,7 +673,7 @@ func init () {
 			op_f32_f32(expr, fp)
 		case OP_F32_F64:
 			op_f32_f32(expr, fp)
-			
+
 		case OP_F32_PRINT:
 			op_f32_print(expr, fp)
 		case OP_F32_ADD:
@@ -1161,7 +778,7 @@ func init () {
 			op_str_concat(expr, fp)
 		case OP_STR_EQ:
 			op_str_eq(expr, fp)
-			
+
 		case OP_STR_BYTE:
 			op_str_str(expr, fp)
 		case OP_STR_STR:

--- a/cx/opcodes_base.go
+++ b/cx/opcodes_base.go
@@ -21,7 +21,7 @@ const (
 	OP_OS_GET_WORKING_DIRECTORY
 	OP_OS_OPEN
 	OP_OS_CLOSE
-	
+
 	// http
 	OP_HTTP_GET
 
@@ -33,52 +33,19 @@ const (
 
 func init () {
 	// time
-	OpNames[OP_TIME_SLEEP] = "time.Sleep"
-	OpNames[OP_TIME_UNIX_MILLI] = "time.UnixMilli"
-	OpNames[OP_TIME_UNIX_NANO] = "time.UnixNano"
-	
+	AddOpCode(OP_TIME_SLEEP, "time.Sleep", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_TIME_UNIX_MILLI, "time.UnixMilli", []int{}, []int{TYPE_I64})
+	AddOpCode(OP_TIME_UNIX_NANO, "time.UnixNano", []int{}, []int{TYPE_I64})
+
 	// http
-	OpNames[OP_HTTP_GET] = "http.Get"
-	
+	AddOpCode(OP_HTTP_GET, "http.Get", []int{TYPE_STR}, []int{TYPE_STR})
+
 	// os
-	OpNames[OP_OS_GET_WORKING_DIRECTORY] = "os.GetWorkingDirectory"
-	OpNames[OP_OS_OPEN] = "os.Open"
-	OpNames[OP_OS_CLOSE] = "os.Close"
+	AddOpCode(OP_OS_GET_WORKING_DIRECTORY, "os.GetWorkingDirectory", []int{}, []int{TYPE_STR})
+	AddOpCode(OP_OS_OPEN, "os.Open", []int{TYPE_STR}, []int{})
+	AddOpCode(OP_OS_CLOSE, "os.Close", []int{TYPE_STR}, []int{})
 
-	/*
-            OpCodes
-        */
-
-	// time
-	OpCodes["time.Sleep"] = OP_TIME_SLEEP
-	OpCodes["time.UnixMilli"] = OP_TIME_UNIX_MILLI
-	OpCodes["time.UnixNano"] = OP_TIME_UNIX_NANO
-	
-	// http
-	OpCodes["http.Get"] = OP_HTTP_GET
-	
-	// os
-	OpCodes["os.GetWorkingDirectory"] = OP_OS_GET_WORKING_DIRECTORY
-	OpCodes["os.Open"] = OP_OS_OPEN
-	OpCodes["os.Close"] = OP_OS_CLOSE
-
-	/*
-            Natives
-        */
-
-	// time
-	Natives[OP_TIME_SLEEP] = MakeNative(OP_TIME_SLEEP, []int{TYPE_I32}, []int{})
-	Natives[OP_TIME_UNIX_MILLI] = MakeNative(OP_TIME_UNIX_MILLI, []int{}, []int{TYPE_I64})
-	Natives[OP_TIME_UNIX_NANO] = MakeNative(OP_TIME_UNIX_NANO, []int{}, []int{TYPE_I64})
-	
-	// http
-	Natives[OP_HTTP_GET] = MakeNative(OP_HTTP_GET, []int{TYPE_STR}, []int{TYPE_STR})
-	
-	// os
-	Natives[OP_OS_GET_WORKING_DIRECTORY] = MakeNative(OP_OS_GET_WORKING_DIRECTORY, []int{}, []int{TYPE_STR})
-	Natives[OP_OS_OPEN] = MakeNative(OP_OS_OPEN, []int{TYPE_STR}, []int{})
-	Natives[OP_OS_CLOSE] = MakeNative(OP_OS_CLOSE, []int{TYPE_STR}, []int{})
-
+	// exec
 	execNative = func(prgrm *CXProgram) {
 		call := &prgrm.CallStack[prgrm.CallCounter]
 		expr := call.Operator.Expressions[call.Line]

--- a/cx/opcodes_extra.go
+++ b/cx/opcodes_extra.go
@@ -131,383 +131,128 @@ const (
 )
 
 func init () {
-	/*
-            OpNames
-        */
-	
-	// opengl
-	OpNames[OP_GL_INIT] = "gl.Init"
-	OpNames[OP_GL_GET_ERROR] = "gl.GetError"
-	OpNames[OP_GL_CULL_FACE] = "gl.CullFace"
-	OpNames[OP_GL_CREATE_PROGRAM] = "gl.CreateProgram"
-	OpNames[OP_GL_DELETE_PROGRAM] = "gl.DeleteProgram"
-	OpNames[OP_GL_LINK_PROGRAM] = "gl.LinkProgram"
-	OpNames[OP_GL_CLEAR] = "gl.Clear"
-	OpNames[OP_GL_USE_PROGRAM] = "gl.UseProgram"
-	OpNames[OP_GL_BIND_BUFFER] = "gl.BindBuffer"
-	OpNames[OP_GL_BIND_VERTEX_ARRAY] = "gl.BindVertexArray"
-	OpNames[OP_GL_ENABLE_VERTEX_ATTRIB_ARRAY] = "gl.EnableVertexAttribArray"
-	OpNames[OP_GL_VERTEX_ATTRIB_POINTER] = "gl.VertexAttribPointer"
-	OpNames[OP_GL_VERTEX_ATTRIB_POINTER_I32] = "gl.VertexAttribPointerI32"
-	OpNames[OP_GL_DRAW_ARRAYS] = "gl.DrawArrays"
-	OpNames[OP_GL_GEN_BUFFERS] = "gl.GenBuffers"
-	OpNames[OP_GL_DELETE_BUFFERS] = "gl.DeleteBuffers"
-	OpNames[OP_GL_BUFFER_DATA] = "gl.BufferData"
-	OpNames[OP_GL_BUFFER_SUB_DATA] = "gl.BufferSubData"
-	OpNames[OP_GL_GEN_VERTEX_ARRAYS] = "gl.GenVertexArrays"
-	OpNames[OP_GL_DELETE_VERTEX_ARRAYS] = "gl.DeleteVertexArrays"
-	OpNames[OP_GL_CREATE_SHADER] = "gl.CreateShader"
-	OpNames[OP_GL_DETACH_SHADER] = "gl.DetachShader"
-	OpNames[OP_GL_DELETE_SHADER] = "gl.DeleteShader"
-	OpNames[OP_GL_STRS] = "gl.Strs"
-	OpNames[OP_GL_FREE] = "gl.Free"
-	OpNames[OP_GL_SHADER_SOURCE] = "gl.ShaderSource"
-	OpNames[OP_GL_COMPILE_SHADER] = "gl.CompileShader"
-	OpNames[OP_GL_GET_SHADERIV] = "gl.GetShaderiv"
-	OpNames[OP_GL_ATTACH_SHADER] = "gl.AttachShader"
-	OpNames[OP_GL_MATRIX_MODE] = "gl.MatrixMode"
-	OpNames[OP_GL_ROTATEF] = "gl.Rotatef"
-	OpNames[OP_GL_TRANSLATEF] = "gl.Translatef"
-	OpNames[OP_GL_LOAD_IDENTITY] = "gl.LoadIdentity"
-	OpNames[OP_GL_PUSH_MATRIX] = "gl.PushMatrix"
-	OpNames[OP_GL_POP_MATRIX] = "gl.PopMatrix"
-	OpNames[OP_GL_ENABLE_CLIENT_STATE] = "gl.EnableClientState"
-	OpNames[OP_GL_ACTIVE_TEXTURE] = "gl.ActiveTexture"
-	OpNames[OP_GL_COLOR3F] = "gl.Color3f"
-	OpNames[OP_GL_COLOR4F] = "gl.Color4f"
-	OpNames[OP_GL_BEGIN] = "gl.Begin"
-	OpNames[OP_GL_END] = "gl.End"
-	OpNames[OP_GL_NORMAL3F] = "gl.Normal3f"
-	OpNames[OP_GL_VERTEX_2F] = "gl.Vertex2f"
-	OpNames[OP_GL_VERTEX_3F] = "gl.Vertex3f"
-	OpNames[OP_GL_ENABLE] = "gl.Enable"
-	OpNames[OP_GL_CLEAR_COLOR] = "gl.ClearColor"
-	OpNames[OP_GL_CLEAR_DEPTH] = "gl.ClearDepth"
-	OpNames[OP_GL_DEPTH_FUNC] = "gl.DepthFunc"
-	OpNames[OP_GL_LIGHTFV] = "gl.Lightfv"
-	OpNames[OP_GL_FRUSTUM] = "gl.Frustum"
-	OpNames[OP_GL_DISABLE] = "gl.Disable"
-	OpNames[OP_GL_HINT] = "gl.Hint"
-	OpNames[OP_GL_NEW_TEXTURE] = "gl.NewTexture"
-	OpNames[OP_GL_DEPTH_MASK] = "gl.DepthMask"
-	OpNames[OP_GL_TEX_ENVI] = "gl.TexEnvi"
-	OpNames[OP_GL_BLEND_FUNC] = "gl.BlendFunc"
-	OpNames[OP_GL_ORTHO] = "gl.Ortho"
-	OpNames[OP_GL_VIEWPORT] = "gl.Viewport"
-	OpNames[OP_GL_SCALEF] = "gl.Scalef"
-	OpNames[OP_GL_TEX_COORD_2D] = "gl.TexCoord2d"
-	OpNames[OP_GL_TEX_COORD_2F] = "gl.TexCoord2f"
-	
-	/* gl_1_0 */
-	OpNames[OP_GL_SCISSOR] = "gl.Scissor"
-	OpNames[OP_GL_TEX_IMAGE_2D] = "gl.TexImage2D"
-	OpNames[OP_GL_TEX_PARAMETERI] = "gl.TexParameteri"
-	OpNames[OP_GL_GET_TEX_LEVEL_PARAMETERIV] = "gl.GetTexLevelParameteriv"
-	
-	/* gl_1_1 */
-	OpNames[OP_GL_BIND_TEXTURE] = "gl.BindTexture"
-	OpNames[OP_GL_GEN_TEXTURES] = "gl.GenTextures"
-	OpNames[OP_GL_DELETE_TEXTURES] = "gl.DeleteTextures"
-	
-	/* gl_2_0 */
-	OpNames[OP_GL_BIND_ATTRIB_LOCATION] = "gl.BindAttribLocation"
-	OpNames[OP_GL_GET_ATTRIB_LOCATION] = "gl.GetAttribLocation"
-	OpNames[OP_GL_GET_UNIFORM_LOCATION] = "gl.GetUniformLocation"
-	OpNames[OP_GL_UNIFORM_1F] = "gl.Uniform1f"
-	OpNames[OP_GL_UNIFORM_1I] = "gl.Uniform1i"
-	
-	/* gl_3_0 */
-	OpNames[OP_GL_BIND_RENDERBUFFER] = "gl.BindRenderbuffer"
-	OpNames[OP_GL_DELETE_RENDERBUFFERS] = "gl.DeleteRenderbuffers"
-	OpNames[OP_GL_GEN_RENDERBUFFERS] = "gl.GenRenderbuffers"
-	OpNames[OP_GL_RENDERBUFFER_STORAGE] = "gl.RenderbufferStorage"
-	OpNames[OP_GL_BIND_FRAMEBUFFER] = "gl.BindFramebuffer"
-	OpNames[OP_GL_DELETE_FRAMEBUFFERS] = "gl.DeleteFramebuffers"
-	OpNames[OP_GL_GEN_FRAMEBUFFERS] = "gl.GenFramebuffers"
-	OpNames[OP_GL_CHECK_FRAMEBUFFER_STATUS] = "gl.CheckFramebufferStatus"
-	OpNames[OP_GL_FRAMEBUFFER_TEXTURE_2D] = "gl.FramebufferTexture2D"
-	OpNames[OP_GL_FRAMEBUFFER_RENDERBUFFER] = "gl.FramebufferRenderbuffer"
-	
+	// gl_0.0
+	AddOpCode(OP_GL_INIT, "gl.Init", []int{}, []int{})
+	AddOpCode(OP_GL_GET_ERROR, "gl.GetError", []int{}, []int{TYPE_I32})
+	AddOpCode(OP_GL_CULL_FACE, "gl.CullFace", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_CREATE_PROGRAM, "gl.CreateProgram", []int{}, []int{TYPE_I32})
+	AddOpCode(OP_GL_DELETE_PROGRAM, "gl.DeleteProgram", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_LINK_PROGRAM, "gl.LinkProgram", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_CLEAR, "gl.Clear", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_USE_PROGRAM, "gl.UseProgram", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_BIND_BUFFER, "gl.BindBuffer", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_BIND_VERTEX_ARRAY, "gl.BindVertexArray", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_ENABLE_VERTEX_ATTRIB_ARRAY, "gl.EnableVertexAttribArray", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_VERTEX_ATTRIB_POINTER, "gl.VertexAttribPointer", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_BOOL, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_VERTEX_ATTRIB_POINTER_I32, "gl.VertexAttribPointerI32", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_BOOL, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_DRAW_ARRAYS, "gl.DrawArrays", []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_GEN_BUFFERS, "gl.GenBuffers", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_GL_DELETE_BUFFERS, "gl.DeleteBuffers", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_BUFFER_DATA, "gl.BufferData", []int{TYPE_I32, TYPE_I32, TYPE_F32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_BUFFER_SUB_DATA, "gl.BufferSubData", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_F32}, []int{})
+	AddOpCode(OP_GL_GEN_VERTEX_ARRAYS, "gl.GenVertexArrays", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_GL_DELETE_VERTEX_ARRAYS, "gl.DeleteVertexArrays", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_CREATE_SHADER, "gl.CreateShader", []int{TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_GL_DETACH_SHADER, "gl.DetachShader", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_DELETE_SHADER, "gl.DeleteShader", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_STRS, "gl.Strs", []int{TYPE_STR, TYPE_STR}, []int{})
+	AddOpCode(OP_GL_FREE, "gl.Free", []int{TYPE_STR}, []int{})
+	AddOpCode(OP_GL_SHADER_SOURCE, "gl.ShaderSource", []int{TYPE_I32, TYPE_I32, TYPE_STR}, []int{})
+	AddOpCode(OP_GL_COMPILE_SHADER, "gl.CompileShader", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_GET_SHADERIV, "gl.GetShaderiv", []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_ATTACH_SHADER, "gl.AttachShader", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_MATRIX_MODE, "gl.MatrixMode", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_ROTATEF, "gl.Rotatef", []int{TYPE_F32, TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
+	AddOpCode(OP_GL_TRANSLATEF, "gl.Translatef", []int{TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
+	AddOpCode(OP_GL_LOAD_IDENTITY, "gl.LoadIdentity", []int{}, []int{})
+	AddOpCode(OP_GL_PUSH_MATRIX, "gl.PushMatrix", []int{}, []int{})
+	AddOpCode(OP_GL_POP_MATRIX, "gl.PopMatrix", []int{}, []int{})
+	AddOpCode(OP_GL_ENABLE_CLIENT_STATE, "gl.EnableClientState", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_ACTIVE_TEXTURE, "gl.ActiveTexture", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_COLOR3F, "gl.Color3f", []int{TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
+	AddOpCode(OP_GL_COLOR4F, "gl.Color4f", []int{TYPE_F32, TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
+	AddOpCode(OP_GL_BEGIN, "gl.Begin", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_END, "gl.End", []int{}, []int{})
+	AddOpCode(OP_GL_NORMAL3F, "gl.Normal3f", []int{TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
+	AddOpCode(OP_GL_VERTEX_2F, "gl.Vertex2f", []int{TYPE_F32, TYPE_F32}, []int{})
+	AddOpCode(OP_GL_VERTEX_3F, "gl.Vertex3f", []int{TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
+	AddOpCode(OP_GL_ENABLE, "gl.Enable", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_CLEAR_COLOR, "gl.ClearColor", []int{TYPE_F32, TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
+	AddOpCode(OP_GL_CLEAR_DEPTH, "gl.ClearDepth", []int{TYPE_F64}, []int{})
+	AddOpCode(OP_GL_DEPTH_FUNC, "gl.DepthFunc", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_LIGHTFV, "gl.Lightfv", []int{TYPE_I32, TYPE_I32, TYPE_F32}, []int{})
+	AddOpCode(OP_GL_FRUSTUM, "gl.Frustum", []int{TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64}, []int{})
+	AddOpCode(OP_GL_DISABLE, "gl.Disable", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_HINT, "gl.Hint", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_NEW_TEXTURE, "gl.NewTexture", []int{TYPE_STR}, []int{TYPE_I32})
+	AddOpCode(OP_GL_DEPTH_MASK, "gl.DepthMask", []int{TYPE_BOOL}, []int{})
+	AddOpCode(OP_GL_TEX_ENVI, "gl.TexEnvi", []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_BLEND_FUNC, "gl.BlendFunc", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_ORTHO, "gl.Ortho", []int{TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64}, []int{})
+	AddOpCode(OP_GL_VIEWPORT, "gl.Viewport", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_SCALEF, "gl.Scalef", []int{TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
+	AddOpCode(OP_GL_TEX_COORD_2D, "gl.TexCoord2d", []int{TYPE_F64, TYPE_F64}, []int{})
+	AddOpCode(OP_GL_TEX_COORD_2F, "gl.TexCoord2f", []int{TYPE_F32, TYPE_F32}, []int{})
+
+	// gl_1_0
+	AddOpCode(OP_GL_SCISSOR, "gl.Scissor", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_TEX_IMAGE_2D, "gl.TexImage2D", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_TEX_PARAMETERI, "gl.TexParameteri", []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_GET_TEX_LEVEL_PARAMETERIV, "gl.GetTexLevelParameteriv", []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+
+	// gl_1_1
+	AddOpCode(OP_GL_BIND_TEXTURE, "gl.BindTexture", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_GEN_TEXTURES, "gl.GenTextures", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_GL_DELETE_TEXTURES, "gl.DeleteTextures", []int{TYPE_I32, TYPE_I32}, []int{})
+
+	//gl_2_0
+	AddOpCode(OP_GL_BIND_ATTRIB_LOCATION, "gl.BindAttribLocation", []int{TYPE_I32, TYPE_I32, TYPE_STR}, []int{})
+	AddOpCode(OP_GL_GET_ATTRIB_LOCATION, "gl.GetAttribLocation", []int{TYPE_I32, TYPE_STR}, []int{TYPE_I32})
+	AddOpCode(OP_GL_GET_UNIFORM_LOCATION, "gl.GetUniformLocation", []int{TYPE_I32, TYPE_STR}, []int{TYPE_I32})
+	AddOpCode(OP_GL_UNIFORM_1F, "gl.Uniform1f", []int{TYPE_I32, TYPE_F32}, []int{})
+	AddOpCode(OP_GL_UNIFORM_1I, "gl.Uniform1i", []int{TYPE_I32, TYPE_I32}, []int{})
+
+	// gl_3_0
+	AddOpCode(OP_GL_BIND_RENDERBUFFER, "gl.BindRenderbuffer", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_DELETE_RENDERBUFFERS, "gl.DeleteRenderbuffers", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_GEN_RENDERBUFFERS, "gl.GenRenderbuffers", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_GL_RENDERBUFFER_STORAGE, "gl.RenderbufferStorage", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_BIND_FRAMEBUFFER, "gl.BindFramebuffer", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_DELETE_FRAMEBUFFERS, "gl.DeleteFramebuffers", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_GEN_FRAMEBUFFERS, "gl.GenFramebuffers", []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_GL_CHECK_FRAMEBUFFER_STATUS, "gl.CheckFramebufferStatus", []int{TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_GL_FRAMEBUFFER_TEXTURE_2D, "gl.FramebufferTexture2D", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_FRAMEBUFFER_RENDERBUFFER, "gl.FramebufferRenderbuffer", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+
 	// glfw
-	OpNames[OP_GLFW_INIT] = "glfw.Init"
-	OpNames[OP_GLFW_WINDOW_HINT] = "glfw.WindowHint"
-	OpNames[OP_GLFW_CREATE_WINDOW] = "glfw.CreateWindow"
-	OpNames[OP_GLFW_MAKE_CONTEXT_CURRENT] = "glfw.MakeContextCurrent"
-	OpNames[OP_GLFW_SHOULD_CLOSE] = "glfw.ShouldClose"
-	OpNames[OP_GLFW_SET_SHOULD_CLOSE] = "glfw.SetShouldClose"
-	OpNames[OP_GLFW_POLL_EVENTS] = "glfw.PollEvents"
-	OpNames[OP_GLFW_SWAP_BUFFERS] = "glfw.SwapBuffers"
-	OpNames[OP_GLFW_GET_FRAMEBUFFER_SIZE] = "glfw.GetFramebufferSize"
-	OpNames[OP_GLFW_SWAP_INTERVAL] = "glfw.SwapInterval"
-	OpNames[OP_GLFW_SET_KEY_CALLBACK] = "glfw.SetKeyCallback"
-	OpNames[OP_GLFW_GET_TIME] = "glfw.GetTime"
-	OpNames[OP_GLFW_SET_MOUSE_BUTTON_CALLBACK] = "glfw.SetMouseButtonCallback"
-	OpNames[OP_GLFW_SET_CURSOR_POS_CALLBACK] = "glfw.SetCursorPosCallback"
-	OpNames[OP_GLFW_GET_CURSOR_POS] = "glfw.GetCursorPos"
-	OpNames[OP_GLFW_SET_INPUT_MODE] = "glfw.SetInputMode"
-	OpNames[OP_GLFW_SET_WINDOW_POS] = "glfw.SetWindowPos"
-	OpNames[OP_GLFW_GET_KEY] = "glfw.GetKey"
-	
+	AddOpCode(OP_GLFW_INIT, "glfw.Init", []int{}, []int{})
+	AddOpCode(OP_GLFW_WINDOW_HINT, "glfw.WindowHint", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GLFW_CREATE_WINDOW, "glfw.CreateWindow", []int{TYPE_STR, TYPE_I32, TYPE_I32, TYPE_STR}, []int{})
+	AddOpCode(OP_GLFW_MAKE_CONTEXT_CURRENT, "glfw.MakeContextCurrent", []int{TYPE_STR}, []int{})
+	AddOpCode(OP_GLFW_SHOULD_CLOSE, "glfw.ShouldClose", []int{TYPE_STR}, []int{TYPE_BOOL})
+	AddOpCode(OP_GLFW_SET_SHOULD_CLOSE, "glfw.SetShouldClose", []int{TYPE_STR, TYPE_BOOL}, []int{})
+	AddOpCode(OP_GLFW_POLL_EVENTS, "glfw.PollEvents", []int{}, []int{})
+	AddOpCode(OP_GLFW_SWAP_BUFFERS, "glfw.SwapBuffers", []int{TYPE_STR}, []int{})
+	AddOpCode(OP_GLFW_GET_FRAMEBUFFER_SIZE, "glfw.GetFramebufferSize", []int{TYPE_STR}, []int{TYPE_I32, TYPE_I32})
+	AddOpCode(OP_GLFW_SWAP_INTERVAL, "glfw.SwapInterval", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GLFW_SET_KEY_CALLBACK, "glfw.SetKeyCallback", []int{TYPE_STR, TYPE_STR}, []int{})
+	AddOpCode(OP_GLFW_GET_TIME, "glfw.GetTime", []int{}, []int{TYPE_F64})
+	AddOpCode(OP_GLFW_SET_MOUSE_BUTTON_CALLBACK, "glfw.SetMouseButtonCallback", []int{TYPE_STR, TYPE_STR}, []int{})
+	AddOpCode(OP_GLFW_SET_CURSOR_POS_CALLBACK, "glfw.SetCursorPosCallback", []int{TYPE_STR, TYPE_STR}, []int{})
+	AddOpCode(OP_GLFW_GET_CURSOR_POS, "glfw.GetCursorPos", []int{TYPE_STR}, []int{TYPE_F64, TYPE_F64})
+	AddOpCode(OP_GLFW_SET_INPUT_MODE, "glfw.SetInputMode", []int{TYPE_STR, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GLFW_SET_WINDOW_POS, "glfw.SetWindowPos", []int{TYPE_STR, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GLFW_GET_KEY, "glfw.GetKey", []int{TYPE_STR, TYPE_I32}, []int{TYPE_I32})
+
 	// gltext
-	OpNames[OP_GLTEXT_LOAD_TRUE_TYPE] = "gltext.LoadTrueType"
-	OpNames[OP_GLTEXT_PRINTF] = "gltext.Printf"
-	OpNames[OP_GLTEXT_METRICS] = "gltext.Metrics"
-	OpNames[OP_GLTEXT_TEXTURE] = "gltext.Texture"
-	OpNames[OP_GLTEXT_NEXT_RUNE] = "gltext.NextRune"
-	OpNames[OP_GLTEXT_GLYPH_BOUNDS] = "gltext.GlyphBounds"
+	AddOpCode(OP_GLTEXT_LOAD_TRUE_TYPE, "gltext.LoadTrueType", []int{TYPE_STR, TYPE_STR, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GLTEXT_PRINTF, "gltext.Printf", []int{TYPE_STR, TYPE_F32, TYPE_F32, TYPE_STR}, []int{})
+	AddOpCode(OP_GLTEXT_METRICS, "gltext.Metrics", []int{TYPE_STR, TYPE_STR}, []int{TYPE_I32, TYPE_I32})
+	AddOpCode(OP_GLTEXT_TEXTURE, "gltext.Texture", []int{TYPE_STR}, []int{TYPE_I32})
+	AddOpCode(OP_GLTEXT_NEXT_RUNE, "gltext.NextRune", []int{TYPE_STR, TYPE_STR, TYPE_I32}, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32})
+	AddOpCode(OP_GLTEXT_GLYPH_BOUNDS, "gltext.GlyphBounds", []int{}, []int{TYPE_I32, TYPE_I32})
 
-	/*
-            OpCodes
-        */
-	
-	// opengl
-	OpCodes["gl.Init"] = OP_GL_INIT
-	OpCodes["gl.GetError"] = OP_GL_GET_ERROR
-	OpCodes["gl.CullFace"] = OP_GL_CULL_FACE
-	OpCodes["gl.CreateProgram"] = OP_GL_CREATE_PROGRAM
-	OpCodes["gl.DeleteProgram"] = OP_GL_DELETE_PROGRAM
-	OpCodes["gl.LinkProgram"] = OP_GL_LINK_PROGRAM
-	OpCodes["gl.Clear"] = OP_GL_CLEAR
-	OpCodes["gl.UseProgram"] = OP_GL_USE_PROGRAM
-	OpCodes["gl.BindBuffer"] = OP_GL_BIND_BUFFER
-	OpCodes["gl.BindVertexArray"] = OP_GL_BIND_VERTEX_ARRAY
-	OpCodes["gl.EnableVertexAttribArray"] = OP_GL_ENABLE_VERTEX_ATTRIB_ARRAY
-	OpCodes["gl.VertexAttribPointer"] = OP_GL_VERTEX_ATTRIB_POINTER
-	OpCodes["gl.VertexAttribPointerI32"] = OP_GL_VERTEX_ATTRIB_POINTER_I32
-	OpCodes["gl.DrawArrays"] = OP_GL_DRAW_ARRAYS
-	OpCodes["gl.GenBuffers"] = OP_GL_GEN_BUFFERS
-	OpCodes["gl.DeleteBuffers"] = OP_GL_DELETE_BUFFERS
-	OpCodes["gl.BufferData"] = OP_GL_BUFFER_DATA
-	OpCodes["gl.BufferSubData"] = OP_GL_BUFFER_SUB_DATA
-	OpCodes["gl.GenVertexArrays"] = OP_GL_GEN_VERTEX_ARRAYS
-	OpCodes["gl.DeleteVertexArrays"] = OP_GL_DELETE_VERTEX_ARRAYS
-	OpCodes["gl.CreateShader"] = OP_GL_CREATE_SHADER
-	OpCodes["gl.DetachShader"] = OP_GL_DETACH_SHADER
-	OpCodes["gl.DeleteShader"] = OP_GL_DELETE_SHADER
-	OpCodes["gl.Strs"] = OP_GL_STRS
-	OpCodes["gl.Free"] = OP_GL_FREE
-	OpCodes["gl.ShaderSource"] = OP_GL_SHADER_SOURCE
-	OpCodes["gl.CompileShader"] = OP_GL_COMPILE_SHADER
-	OpCodes["gl.GetShaderiv"] = OP_GL_GET_SHADERIV
-	OpCodes["gl.AttachShader"] = OP_GL_ATTACH_SHADER
-	OpCodes["gl.MatrixMode"] = OP_GL_MATRIX_MODE
-	OpCodes["gl.Rotatef"] = OP_GL_ROTATEF
-	OpCodes["gl.Translatef"] = OP_GL_TRANSLATEF
-	OpCodes["gl.LoadIdentity"] = OP_GL_LOAD_IDENTITY
-	OpCodes["gl.PushMatrix"] = OP_GL_PUSH_MATRIX
-	OpCodes["gl.PopMatrix"] = OP_GL_POP_MATRIX
-	OpCodes["gl.EnableClientState"] = OP_GL_ENABLE_CLIENT_STATE
-	OpCodes["gl.ActiveTexture"] = OP_GL_ACTIVE_TEXTURE
-	OpCodes["gl.Color3f"] = OP_GL_COLOR3F
-	OpCodes["gl.Color4f"] = OP_GL_COLOR4F
-	OpCodes["gl.Begin"] = OP_GL_BEGIN
-	OpCodes["gl.End"] = OP_GL_END
-	OpCodes["gl.Normal3f"] = OP_GL_NORMAL3F
-	OpCodes["gl.Vertex2f"] = OP_GL_VERTEX_2F
-	OpCodes["gl.Vertex3f"] = OP_GL_VERTEX_3F
-	OpCodes["gl.Enable"] = OP_GL_ENABLE
-	OpCodes["gl.ClearColor"] = OP_GL_CLEAR_COLOR
-	OpCodes["gl.ClearDepth"] = OP_GL_CLEAR_DEPTH
-	OpCodes["gl.DepthFunc"] = OP_GL_DEPTH_FUNC
-	OpCodes["gl.Lightfv"] = OP_GL_LIGHTFV
-	OpCodes["gl.Frustum"] = OP_GL_FRUSTUM
-	OpCodes["gl.Disable"] = OP_GL_DISABLE
-	OpCodes["gl.Hint"] = OP_GL_HINT
-	OpCodes["gl.NewTexture"] = OP_GL_NEW_TEXTURE
-	OpCodes["gl.DepthMask"] = OP_GL_DEPTH_MASK
-	OpCodes["gl.TexEnvi"] = OP_GL_TEX_ENVI
-	OpCodes["gl.BlendFunc"] = OP_GL_BLEND_FUNC
-	OpCodes["gl.Ortho"] = OP_GL_ORTHO
-	OpCodes["gl.Viewport"] = OP_GL_VIEWPORT
-	OpCodes["gl.Scalef"] = OP_GL_SCALEF
-	OpCodes["gl.TexCoord2d"] = OP_GL_TEX_COORD_2D
-	OpCodes["gl.TexCoord2f"] = OP_GL_TEX_COORD_2F
-	
-	/* gl_1_0 */
-	OpCodes["gl.Scissor"] = OP_GL_SCISSOR
-	OpCodes["gl.TexImage2D"] = OP_GL_TEX_IMAGE_2D
-	OpCodes["gl.TexParameteri"] = OP_GL_TEX_PARAMETERI
-	OpCodes["gl.GetTexLevelParameteriv"] = OP_GL_GET_TEX_LEVEL_PARAMETERIV
-	
-	/* gl_1_1 */
-	OpCodes["gl.BindTexture"] = OP_GL_BIND_TEXTURE
-	OpCodes["gl.GenTextures"] = OP_GL_GEN_TEXTURES
-	OpCodes["gl.DeleteTextures"] = OP_GL_DELETE_TEXTURES
-	
-	/* gl_2_0 */
-	OpCodes["gl.BindAttribLocation"] = OP_GL_BIND_ATTRIB_LOCATION
-	OpCodes["gl.GetAttribLocation"] = OP_GL_GET_ATTRIB_LOCATION
-	OpCodes["gl.GetUniformLocation"] = OP_GL_GET_UNIFORM_LOCATION
-	OpCodes["gl.Uniform1f"] = OP_GL_UNIFORM_1F
-	OpCodes["gl.Uniform1i"] = OP_GL_UNIFORM_1I
-	
-	/* gl_3_0 */
-	OpCodes["gl.BindRenderbuffer"] = OP_GL_BIND_RENDERBUFFER
-	OpCodes["gl.DeleteRenderbuffers"] = OP_GL_DELETE_RENDERBUFFERS
-	OpCodes["gl.GenRenderbuffers"] = OP_GL_GEN_RENDERBUFFERS
-	OpCodes["gl.RenderbufferStorage"] = OP_GL_RENDERBUFFER_STORAGE
-	OpCodes["gl.BindFramebuffer"] = OP_GL_BIND_FRAMEBUFFER
-	OpCodes["gl.DeleteFramebuffers"] = OP_GL_DELETE_FRAMEBUFFERS
-	OpCodes["gl.GenFramebuffers"] = OP_GL_GEN_FRAMEBUFFERS
-	OpCodes["gl.CheckFramebufferStatus"] = OP_GL_CHECK_FRAMEBUFFER_STATUS
-	OpCodes["gl.FramebufferTexture2D"] = OP_GL_FRAMEBUFFER_TEXTURE_2D
-	OpCodes["gl.FramebufferRenderbuffer"] = OP_GL_FRAMEBUFFER_RENDERBUFFER
-	
-	// glfw
-	OpCodes["glfw.Init"] = OP_GLFW_INIT
-	OpCodes["glfw.WindowHint"] = OP_GLFW_WINDOW_HINT
-	OpCodes["glfw.CreateWindow"] = OP_GLFW_CREATE_WINDOW
-	OpCodes["glfw.MakeContextCurrent"] = OP_GLFW_MAKE_CONTEXT_CURRENT
-	OpCodes["glfw.ShouldClose"] = OP_GLFW_SHOULD_CLOSE
-	OpCodes["glfw.SetShouldClose"] = OP_GLFW_SET_SHOULD_CLOSE
-	OpCodes["glfw.PollEvents"] = OP_GLFW_POLL_EVENTS
-	OpCodes["glfw.SwapBuffers"] = OP_GLFW_SWAP_BUFFERS
-	OpCodes["glfw.GetFramebufferSize"] = OP_GLFW_GET_FRAMEBUFFER_SIZE
-	OpCodes["glfw.SwapInterval"] = OP_GLFW_SWAP_INTERVAL
-	OpCodes["glfw.SetKeyCallback"] = OP_GLFW_SET_KEY_CALLBACK
-	OpCodes["glfw.GetTime"] = OP_GLFW_GET_TIME
-	OpCodes["glfw.SetMouseButtonCallback"] = OP_GLFW_SET_MOUSE_BUTTON_CALLBACK
-	OpCodes["glfw.SetCursorPosCallback"] = OP_GLFW_SET_CURSOR_POS_CALLBACK
-	OpCodes["glfw.GetCursorPos"] = OP_GLFW_GET_CURSOR_POS
-	OpCodes["glfw.SetInputMode"] = OP_GLFW_SET_INPUT_MODE
-	OpCodes["glfw.SetWindowPos"] = OP_GLFW_SET_WINDOW_POS
-	OpCodes["glfw.GetKey"] = OP_GLFW_GET_KEY
-	
-	// gltext
-	OpCodes["gltext.LoadTrueType"] = OP_GLTEXT_LOAD_TRUE_TYPE
-	OpCodes["gltext.Printf"] = OP_GLTEXT_PRINTF
-	OpCodes["gltext.Metrics"] = OP_GLTEXT_METRICS
-	OpCodes["gltext.Texture"] = OP_GLTEXT_TEXTURE
-	OpCodes["gltext.NextRune"] = OP_GLTEXT_NEXT_RUNE
-	OpCodes["gltext.GlyphBounds"] = OP_GLTEXT_GLYPH_BOUNDS
-
-	/*
-            Natives
-        */
-
-	// opengl
-	Natives[OP_GL_INIT] = MakeNative(OP_GL_INIT, []int{}, []int{})
-	Natives[OP_GL_GET_ERROR] = MakeNative(OP_GL_GET_ERROR, []int{}, []int{TYPE_I32})
-	Natives[OP_GL_CULL_FACE] = MakeNative(OP_GL_CULL_FACE, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_CREATE_PROGRAM] = MakeNative(OP_GL_CREATE_PROGRAM, []int{}, []int{TYPE_I32})
-	Natives[OP_GL_DELETE_PROGRAM] = MakeNative(OP_GL_DELETE_PROGRAM, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_LINK_PROGRAM] = MakeNative(OP_GL_LINK_PROGRAM, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_CLEAR] = MakeNative(OP_GL_CLEAR, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_USE_PROGRAM] = MakeNative(OP_GL_USE_PROGRAM, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_BIND_BUFFER] = MakeNative(OP_GL_BIND_BUFFER, []int{TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_BIND_VERTEX_ARRAY] = MakeNative(OP_GL_BIND_VERTEX_ARRAY, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_ENABLE_VERTEX_ATTRIB_ARRAY] = MakeNative(OP_GL_ENABLE_VERTEX_ATTRIB_ARRAY, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_VERTEX_ATTRIB_POINTER] = MakeNative(OP_GL_VERTEX_ATTRIB_POINTER, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_BOOL, TYPE_I32}, []int{})
-	Natives[OP_GL_VERTEX_ATTRIB_POINTER_I32] = MakeNative(OP_GL_VERTEX_ATTRIB_POINTER_I32,[]int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_BOOL, TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_DRAW_ARRAYS] = MakeNative(OP_GL_DRAW_ARRAYS, []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_GEN_BUFFERS] = MakeNative(OP_GL_GEN_BUFFERS, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
-	Natives[OP_GL_DELETE_BUFFERS] = MakeNative(OP_GL_DELETE_BUFFERS, []int{TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_BUFFER_DATA] = MakeNative(OP_GL_BUFFER_DATA, []int{TYPE_I32, TYPE_I32, TYPE_F32, TYPE_I32}, []int{})
-	Natives[OP_GL_BUFFER_SUB_DATA] = MakeNative(OP_GL_BUFFER_SUB_DATA, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_F32}, []int{})
-	Natives[OP_GL_GEN_VERTEX_ARRAYS] = MakeNative(OP_GL_GEN_VERTEX_ARRAYS, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
-	Natives[OP_GL_DELETE_VERTEX_ARRAYS] = MakeNative(OP_GL_DELETE_VERTEX_ARRAYS, []int{TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_CREATE_SHADER] = MakeNative(OP_GL_CREATE_SHADER, []int{TYPE_I32}, []int{TYPE_I32})
-	Natives[OP_GL_DETACH_SHADER] = MakeNative(OP_GL_DETACH_SHADER, []int{TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_DELETE_SHADER] = MakeNative(OP_GL_DELETE_SHADER, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_STRS] = MakeNative(OP_GL_STRS, []int{TYPE_STR, TYPE_STR}, []int{})
-	Natives[OP_GL_FREE] = MakeNative(OP_GL_FREE, []int{TYPE_STR}, []int{})
-	Natives[OP_GL_SHADER_SOURCE] = MakeNative(OP_GL_SHADER_SOURCE, []int{TYPE_I32, TYPE_I32, TYPE_STR}, []int{})
-	Natives[OP_GL_COMPILE_SHADER] = MakeNative(OP_GL_COMPILE_SHADER, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_GET_SHADERIV] = MakeNative(OP_GL_GET_SHADERIV, []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_ATTACH_SHADER] = MakeNative(OP_GL_ATTACH_SHADER, []int{TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_MATRIX_MODE] = MakeNative(OP_GL_MATRIX_MODE, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_ROTATEF] = MakeNative(OP_GL_ROTATEF, []int{TYPE_F32, TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
-	Natives[OP_GL_TRANSLATEF] = MakeNative(OP_GL_TRANSLATEF, []int{TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
-	Natives[OP_GL_LOAD_IDENTITY] = MakeNative(OP_GL_LOAD_IDENTITY, []int{}, []int{})
-	Natives[OP_GL_PUSH_MATRIX] = MakeNative(OP_GL_PUSH_MATRIX, []int{}, []int{})
-	Natives[OP_GL_POP_MATRIX] = MakeNative(OP_GL_POP_MATRIX, []int{}, []int{})
-	Natives[OP_GL_ENABLE_CLIENT_STATE] = MakeNative(OP_GL_ENABLE_CLIENT_STATE, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_ACTIVE_TEXTURE] = MakeNative(OP_GL_ACTIVE_TEXTURE, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_COLOR3F] = MakeNative(OP_GL_COLOR3F, []int{TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
-	Natives[OP_GL_COLOR4F] = MakeNative(OP_GL_COLOR4F, []int{TYPE_F32, TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
-	Natives[OP_GL_BEGIN] = MakeNative(OP_GL_BEGIN, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_END] = MakeNative(OP_GL_END, []int{}, []int{})
-	Natives[OP_GL_NORMAL3F] = MakeNative(OP_GL_NORMAL3F, []int{TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
-	
-	Natives[OP_GL_VERTEX_2F] = MakeNative(OP_GL_VERTEX_2F, []int{TYPE_F32, TYPE_F32}, []int{})
-	Natives[OP_GL_VERTEX_3F] = MakeNative(OP_GL_VERTEX_3F, []int{TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
-	
-	Natives[OP_GL_ENABLE] = MakeNative(OP_GL_ENABLE, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_CLEAR_COLOR] = MakeNative(OP_GL_CLEAR_COLOR, []int{TYPE_F32, TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
-	Natives[OP_GL_CLEAR_DEPTH] = MakeNative(OP_GL_CLEAR_DEPTH, []int{TYPE_F64}, []int{})
-	Natives[OP_GL_DEPTH_FUNC] = MakeNative(OP_GL_DEPTH_FUNC, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_LIGHTFV] = MakeNative(OP_GL_LIGHTFV, []int{TYPE_I32, TYPE_I32, TYPE_F32}, []int{})
-	Natives[OP_GL_FRUSTUM] = MakeNative(OP_GL_FRUSTUM, []int{TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64}, []int{})
-	Natives[OP_GL_DISABLE] = MakeNative(OP_GL_DISABLE, []int{TYPE_I32}, []int{})
-	Natives[OP_GL_HINT] = MakeNative(OP_GL_HINT, []int{TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_NEW_TEXTURE] = MakeNative(OP_GL_NEW_TEXTURE, []int{TYPE_STR}, []int{TYPE_I32})
-	Natives[OP_GL_DEPTH_MASK] = MakeNative(OP_GL_DEPTH_MASK, []int{TYPE_BOOL}, []int{})
-	Natives[OP_GL_TEX_ENVI] = MakeNative(OP_GL_TEX_ENVI, []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_BLEND_FUNC] = MakeNative(OP_GL_BLEND_FUNC, []int{TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_ORTHO] = MakeNative(OP_GL_ORTHO, []int{TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64}, []int{})
-	Natives[OP_GL_VIEWPORT] = MakeNative(OP_GL_VIEWPORT, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_SCALEF] = MakeNative(OP_GL_SCALEF, []int{TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
-	Natives[OP_GL_TEX_COORD_2D] = MakeNative(OP_GL_TEX_COORD_2D, []int{TYPE_F64, TYPE_F64}, []int{})
-	Natives[OP_GL_TEX_COORD_2F] = MakeNative(OP_GL_TEX_COORD_2F, []int{TYPE_F32, TYPE_F32}, []int{})
-	
-	/* gl_1_0 */
-	Natives[OP_GL_SCISSOR] = MakeNative(OP_GL_SCISSOR, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_TEX_IMAGE_2D] = MakeNative(OP_GL_TEX_IMAGE_2D, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_TEX_PARAMETERI] = MakeNative(OP_GL_TEX_PARAMETERI, []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_GET_TEX_LEVEL_PARAMETERIV] = MakeNative(OP_GL_GET_TEX_LEVEL_PARAMETERIV, []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{TYPE_I32})
-	
-	/* gl_1_1 */
-	Natives[OP_GL_BIND_TEXTURE] = MakeNative(OP_GL_BIND_TEXTURE, []int{TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_GEN_TEXTURES] = MakeNative(OP_GL_GEN_TEXTURES, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
-	Natives[OP_GL_DELETE_TEXTURES] = MakeNative(OP_GL_DELETE_TEXTURES, []int{TYPE_I32, TYPE_I32}, []int{})
-	
-	/* gl_2_0 */
-	Natives[OP_GL_BIND_ATTRIB_LOCATION] = MakeNative(OP_GL_BIND_ATTRIB_LOCATION, []int{TYPE_I32, TYPE_I32, TYPE_STR}, []int{})
-	Natives[OP_GL_GET_ATTRIB_LOCATION] = MakeNative(OP_GL_GET_ATTRIB_LOCATION, []int{TYPE_I32, TYPE_STR}, []int{TYPE_I32})
-	Natives[OP_GL_GET_UNIFORM_LOCATION] = MakeNative(OP_GL_GET_UNIFORM_LOCATION, []int{TYPE_I32, TYPE_STR}, []int{TYPE_I32})
-	Natives[OP_GL_UNIFORM_1F] = MakeNative(OP_GL_UNIFORM_1F, []int{TYPE_I32, TYPE_F32}, []int{})
-	Natives[OP_GL_UNIFORM_1I] = MakeNative(OP_GL_UNIFORM_1I, []int{TYPE_I32, TYPE_I32}, []int{})
-	
-	/* gl_3_0 */
-	Natives[OP_GL_BIND_RENDERBUFFER] = MakeNative(OP_GL_BIND_RENDERBUFFER, []int{TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_DELETE_RENDERBUFFERS] = MakeNative(OP_GL_DELETE_RENDERBUFFERS, []int{TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_GEN_RENDERBUFFERS] = MakeNative(OP_GL_GEN_RENDERBUFFERS, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
-	Natives[OP_GL_RENDERBUFFER_STORAGE] = MakeNative(OP_GL_RENDERBUFFER_STORAGE, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_BIND_FRAMEBUFFER] = MakeNative(OP_GL_BIND_FRAMEBUFFER, []int{TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_DELETE_FRAMEBUFFERS] = MakeNative(OP_GL_DELETE_FRAMEBUFFERS, []int{TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_GEN_FRAMEBUFFERS] = MakeNative(OP_GL_GEN_FRAMEBUFFERS, []int{TYPE_I32, TYPE_I32}, []int{TYPE_I32})
-	Natives[OP_GL_CHECK_FRAMEBUFFER_STATUS] = MakeNative(OP_GL_CHECK_FRAMEBUFFER_STATUS, []int{TYPE_I32}, []int{TYPE_I32})
-	Natives[OP_GL_FRAMEBUFFER_TEXTURE_2D] = MakeNative(OP_GL_FRAMEBUFFER_TEXTURE_2D, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GL_FRAMEBUFFER_RENDERBUFFER] = MakeNative(OP_GL_FRAMEBUFFER_RENDERBUFFER, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
-	
-	// glfw
-	Natives[OP_GLFW_INIT] = MakeNative(OP_GLFW_INIT, []int{}, []int{})
-	Natives[OP_GLFW_WINDOW_HINT] = MakeNative(OP_GLFW_WINDOW_HINT, []int{TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GLFW_CREATE_WINDOW] = MakeNative(OP_GLFW_CREATE_WINDOW, []int{TYPE_STR, TYPE_I32, TYPE_I32, TYPE_STR}, []int{})
-	Natives[OP_GLFW_MAKE_CONTEXT_CURRENT] = MakeNative(OP_GLFW_MAKE_CONTEXT_CURRENT, []int{TYPE_STR}, []int{})
-	Natives[OP_GLFW_SHOULD_CLOSE] = MakeNative(OP_GLFW_SHOULD_CLOSE, []int{TYPE_STR}, []int{TYPE_BOOL})
-	Natives[OP_GLFW_SET_SHOULD_CLOSE] = MakeNative(OP_GLFW_SET_SHOULD_CLOSE, []int{TYPE_STR, TYPE_BOOL}, []int{})
-	Natives[OP_GLFW_POLL_EVENTS] = MakeNative(OP_GLFW_POLL_EVENTS, []int{}, []int{})
-	Natives[OP_GLFW_SWAP_BUFFERS] = MakeNative(OP_GLFW_SWAP_BUFFERS, []int{TYPE_STR}, []int{})
-	Natives[OP_GLFW_GET_FRAMEBUFFER_SIZE] = MakeNative(OP_GLFW_GET_FRAMEBUFFER_SIZE, []int{TYPE_STR}, []int{TYPE_I32, TYPE_I32})
-	Natives[OP_GLFW_SWAP_INTERVAL] = MakeNative(OP_GLFW_SWAP_INTERVAL, []int{TYPE_I32}, []int{})
-	Natives[OP_GLFW_SET_KEY_CALLBACK] = MakeNative(OP_GLFW_SET_KEY_CALLBACK, []int{TYPE_STR, TYPE_STR}, []int{})
-	Natives[OP_GLFW_GET_TIME] = MakeNative(OP_GLFW_GET_TIME, []int{}, []int{TYPE_F64})
-	Natives[OP_GLFW_SET_MOUSE_BUTTON_CALLBACK] = MakeNative(OP_GLFW_SET_MOUSE_BUTTON_CALLBACK, []int{TYPE_STR, TYPE_STR}, []int{})
-	Natives[OP_GLFW_SET_CURSOR_POS_CALLBACK] = MakeNative(OP_GLFW_SET_CURSOR_POS_CALLBACK, []int{TYPE_STR, TYPE_STR}, []int{})
-	Natives[OP_GLFW_GET_CURSOR_POS] = MakeNative(OP_GLFW_GET_CURSOR_POS, []int{TYPE_STR}, []int{TYPE_F64, TYPE_F64})
-	Natives[OP_GLFW_SET_INPUT_MODE] = MakeNative(OP_GLFW_SET_INPUT_MODE, []int{TYPE_STR, TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GLFW_SET_WINDOW_POS] = MakeNative(OP_GLFW_SET_WINDOW_POS, []int{TYPE_STR, TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GLFW_GET_KEY] = MakeNative(OP_GLFW_GET_KEY, []int{TYPE_STR, TYPE_I32}, []int{TYPE_I32})
-	
-	// gltext
-	Natives[OP_GLTEXT_LOAD_TRUE_TYPE] = MakeNative(OP_GLTEXT_LOAD_TRUE_TYPE, []int{TYPE_STR, TYPE_STR, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
-	Natives[OP_GLTEXT_PRINTF] = MakeNative(OP_GLTEXT_PRINTF, []int{TYPE_STR, TYPE_F32, TYPE_F32, TYPE_STR}, []int{})
-	Natives[OP_GLTEXT_METRICS] = MakeNative(OP_GLTEXT_METRICS, []int{TYPE_STR, TYPE_STR}, []int{TYPE_I32, TYPE_I32})
-	Natives[OP_GLTEXT_TEXTURE] = MakeNative(OP_GLTEXT_TEXTURE, []int{TYPE_STR}, []int{TYPE_I32})
-	Natives[OP_GLTEXT_NEXT_RUNE] = MakeNative(OP_GLTEXT_NEXT_RUNE, []int{TYPE_STR, TYPE_STR, TYPE_I32}, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32})
-	Natives[OP_GLTEXT_GLYPH_BOUNDS] = MakeNative(OP_GLTEXT_GLYPH_BOUNDS, []int{}, []int{TYPE_I32, TYPE_I32})
-
+	// exec
 	execNative = func (prgrm *CXProgram) {
 		call := &prgrm.CallStack[prgrm.CallCounter]
 		expr := call.Operator.Expressions[call.Line]
@@ -606,7 +351,7 @@ func init () {
 			op_i32_i32(expr, fp)
 		case OP_I32_F64:
 			op_i32_i32(expr, fp)
-			
+
 		case OP_I32_PRINT:
 			op_i32_print(expr, fp)
 		case OP_I32_ADD:
@@ -743,7 +488,7 @@ func init () {
 			op_f32_f32(expr, fp)
 		case OP_F32_F64:
 			op_f32_f32(expr, fp)
-			
+
 		case OP_F32_PRINT:
 			op_f32_print(expr, fp)
 		case OP_F32_ADD:
@@ -848,7 +593,7 @@ func init () {
 			op_str_concat(expr, fp)
 		case OP_STR_EQ:
 			op_str_eq(expr, fp)
-			
+
 		case OP_STR_BYTE:
 			op_str_str(expr, fp)
 		case OP_STR_STR:
@@ -1137,7 +882,7 @@ func init () {
 			op_glfw_SetWindowPos(expr, fp)
 		case OP_GLFW_GET_KEY:
 			op_glfw_GetKey(expr, fp)
-			
+
 			// gltext
 		case OP_GLTEXT_LOAD_TRUE_TYPE:
 			op_gltext_LoadTrueType(expr, fp)


### PR DESCRIPTION
Refactor to reduce frictions and code duplication when adding new opcodes.

Next step is to remove code duplication in the execNative methods without adding runtime overhead.