### PR TITLE
Bindings

### DIFF
--- a/cx/constcodes.go
+++ b/cx/constcodes.go
@@ -25,6 +25,8 @@ const (
 	CONST_GL_NOTEQUAL
 	CONST_GL_GEQUAL
 	CONST_GL_ALWAYS
+	CONST_GL_ZERO
+	CONST_GL_ONE
 	CONST_GL_SRC_ALPHA
 	CONST_GL_ONE_MINUS_SRC_ALPHA
 	CONST_GL_FRONT
@@ -40,7 +42,20 @@ const (
 	CONST_GL_LINE_SMOOTH
 	CONST_GL_POLYGON_SMOOTH
 	CONST_GL_CULL_FACE
+	CONST_GL_DEPTH_RANGE
 	CONST_GL_DEPTH_TEST
+	CONST_GL_DEPTH_WRITEMASK
+	CONST_GL_DEPTH_CLEAR_VALUE
+	CONST_GL_DEPTH_FUNC
+	CONST_GL_STENCIL_TEST
+	CONST_GL_STENCIL_CLEAR_VALUE
+	CONST_GL_STENCIL_FUNC
+	CONST_GL_STENCIL_VALUE_MASK
+	CONST_GL_STENCIL_FAIL
+	CONST_GL_STENCIL_PASS_DEPTH_FAIL
+	CONST_GL_STENCIL_PASS_DEPTH_PASS
+	CONST_GL_STENCIL_REF
+	CONST_GL_STENCIL_WRITEMASK
 	CONST_GL_DITHER
 	CONST_GL_BLEND
 	CONST_GL_SCISSOR_TEST
@@ -51,11 +66,18 @@ const (
 	CONST_GL_DONT_CARE
 	CONST_GL_UNSIGNED_BYTE
 	CONST_GL_FLOAT
+	CONST_GL_INVERT
 	CONST_GL_TEXTURE
 	CONST_GL_COLOR
+	CONST_GL_DEPTH
+	CONST_GL_STENCIL
+	CONST_GL_STENCIL_INDEX
 	CONST_GL_DEPTH_COMPONENT
 	CONST_GL_RGBA
+	CONST_GL_KEEP
 	CONST_GL_REPLACE
+	CONST_GL_INCR
+	CONST_GL_DECR
 	CONST_GL_NEAREST
 	CONST_GL_LINEAR
 	CONST_GL_NEAREST_MIPMAP_NEAREST
@@ -82,7 +104,12 @@ const (
 	CONST_GL_CLAMP_TO_BORDER
 
 	// gl_1_4
+	CONST_GL_DEPTH_COMPONENT16
+	CONST_GL_DEPTH_COMPONENT24
+	CONST_GL_DEPTH_COMPONENT32
 	CONST_GL_MIRRORED_REPEAT
+	CONST_GL_INCR_WRAP
+	CONST_GL_DECR_WRAP
 
 	// gl_1_5
 	CONST_GL_ARRAY_BUFFER
@@ -97,11 +124,23 @@ const (
 	CONST_GL_DYNAMIC_COPY
 
 	// gl_2_0
+	CONST_GL_STENCIL_BACK_FUNC
+	CONST_GL_STENCIL_BACK_FAIL
+	CONST_GL_STENCIL_BACK_PASS_DEPTH_FAIL
+	CONST_GL_STENCIL_BACK_PASS_DEPTH_PASS
 	CONST_GL_FRAGMENT_SHADER
 	CONST_GL_VERTEX_SHADER
+	CONST_GL_STENCIL_BACK_REF
+	CONST_GL_STENCIL_BACK_VALUE_MASK
+	CONST_GL_STENCIL_BACK_WRITEMASK
 
 	// gl_3_0
+	CONST_GL_DEPTH_COMPONENT32F
+	CONST_GL_DEPTH32F_STENCIL8
 	CONST_GL_FRAMEBUFFER_UNDEFINED
+	CONST_GL_DEPTH_STENCIL_ATTACHMENT
+	CONST_GL_DEPTH_STENCIL
+	CONST_GL_DEPTH24_STENCIL8
 	CONST_GL_FRAMEBUFFER_COMPLETE
 	CONST_GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT
 	CONST_GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT
@@ -114,6 +153,10 @@ const (
 	CONST_GL_FRAMEBUFFER
 	CONST_GL_RENDERBUFFER
 	CONST_GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE
+	CONST_GL_STENCIL_INDEX1
+	CONST_GL_STENCIL_INDEX4
+	CONST_GL_STENCIL_INDEX8
+	CONST_GL_STENCIL_INDEX16
 
 	// gl_3_2
 	CONST_GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS
@@ -180,69 +223,91 @@ func AddConstCode(code int, name string, typ int, value []byte) {
 
 func init() {
 	/* gl_1_0 */
-	AddConstCode( CONST_GL_DEPTH_BUFFER_BIT      , "gl.DEPTH_BUFFER_BIT"      , TYPE_I32, FromI32(0x00000100))
-	AddConstCode( CONST_GL_STENCIL_BUFFER_BIT    , "gl.STENCIL_BUFFER_BIT"    , TYPE_I32, FromI32(0x00000400))
-	AddConstCode( CONST_GL_COLOR_BUFFER_BIT      , "gl.COLOR_BUFFER_BIT"      , TYPE_I32, FromI32(0x00004000))
-	AddConstCode( CONST_GL_FALSE                 , "gl.FALSE"                 , TYPE_I32, FromI32(0))
-	AddConstCode( CONST_GL_TRUE                  , "gl.TRUE"                  , TYPE_I32, FromI32(1))
-	AddConstCode( CONST_GL_POINTS                , "gl.POINTS"                , TYPE_I32, FromI32(0x0000))
-	AddConstCode( CONST_GL_LINES                 , "gl.LINES"                 , TYPE_I32, FromI32(0x0001))
-	AddConstCode( CONST_GL_LINE_LOOP             , "gl.LINE_LOOP"             , TYPE_I32, FromI32(0x0002))
-	AddConstCode( CONST_GL_LINE_STRIP            , "gl.LINE_STRIP"            , TYPE_I32, FromI32(0x0003))
-	AddConstCode( CONST_GL_TRIANGLES             , "gl.TRIANGLES"             , TYPE_I32, FromI32(0x0004))
-	AddConstCode( CONST_GL_TRIANGLE_STRIP        , "gl.TRIANGLE_STRIP"        , TYPE_I32, FromI32(0x0005))
-	AddConstCode( CONST_GL_TRIANGLE_FAN          , "gl.TRIANGLE_FAN"          , TYPE_I32, FromI32(0x0006))
-	AddConstCode( CONST_GL_QUADS                 , "gl.QUADS"                 , TYPE_I32, FromI32(0x0007))
-	AddConstCode( CONST_GL_NEVER                 , "gl.NEVER"                 , TYPE_I32, FromI32(0x0200))
-	AddConstCode( CONST_GL_LESS                  , "gl.LESS"                  , TYPE_I32, FromI32(0x0201))
-	AddConstCode( CONST_GL_EQUAL                 , "gl.EQUAL"                 , TYPE_I32, FromI32(0x0202))
-	AddConstCode( CONST_GL_LEQUAL                , "gl.LEQUAL"                , TYPE_I32, FromI32(0x0203))
-	AddConstCode( CONST_GL_GREATER               , "gl.GREATER"               , TYPE_I32, FromI32(0x0204))
-	AddConstCode( CONST_GL_NOTEQUAL              , "gl.NOTEQUAL"              , TYPE_I32, FromI32(0x0205))
-	AddConstCode( CONST_GL_GEQUAL                , "gl.GEQUAL"                , TYPE_I32, FromI32(0x0206))
-	AddConstCode( CONST_GL_ALWAYS                , "gl.ALWAYS"                , TYPE_I32, FromI32(0x0207))
-	AddConstCode( CONST_GL_SRC_ALPHA             , "gl.SRC_ALPHA"             , TYPE_I32, FromI32(0x302))
-	AddConstCode( CONST_GL_ONE_MINUS_SRC_ALPHA   , "gl.ONE_MINUS_SRC_ALPHA"   , TYPE_I32, FromI32(0x303))
-	AddConstCode( CONST_GL_FRONT                 , "gl.FRONT"                 , TYPE_I32, FromI32(0x404))
-	AddConstCode( CONST_GL_BACK                  , "gl.BACK"                  , TYPE_I32, FromI32(0x405))
-	AddConstCode( CONST_GL_FRONT_AND_BACK        , "gl.FRONT_AND_BACK"        , TYPE_I32, FromI32(0x408))
-	AddConstCode( CONST_GL_NO_ERROR              , "gl.NO_ERROR"              , TYPE_I32, FromI32(0))
-	AddConstCode( CONST_GL_INVALID_ENUM          , "gl.INVALID_ENUM"          , TYPE_I32, FromI32(0x500))
-	AddConstCode( CONST_GL_INVALID_VALUE         , "gl.INVALID_VALUE"         , TYPE_I32, FromI32(0x501))
-	AddConstCode( CONST_GL_INVALID_OPERATION     , "gl.INVALID_OPERATION"     , TYPE_I32, FromI32(0x502))
-	AddConstCode( CONST_GL_STACK_OVERFLOW        , "gl.STACK_OVERFLOW"        , TYPE_I32, FromI32(0x503))
-	AddConstCode( CONST_GL_STACK_UNDERFLOW       , "gl.STACK_UNDERFLOW"       , TYPE_I32, FromI32(0x504))
-	AddConstCode( CONST_GL_OUT_OF_MEMORY         , "gl.OUT_OF_MEMORY"         , TYPE_I32, FromI32(0x505))
-	AddConstCode( CONST_GL_LINE_SMOOTH           , "gl.LINE_SMOOTH"           , TYPE_I32, FromI32(0x0B20))
-	AddConstCode( CONST_GL_POLYGON_SMOOTH        , "gl.POLYGON_SMOOTH"        , TYPE_I32, FromI32(0x0B41))
-	AddConstCode( CONST_GL_CULL_FACE             , "gl.CULL_FACE"             , TYPE_I32, FromI32(0x0B44))
-	AddConstCode( CONST_GL_DEPTH_TEST            , "gl.DEPTH_TEST"            , TYPE_I32, FromI32(0x0B71))
-	AddConstCode( CONST_GL_DITHER                , "gl.DITHER"                , TYPE_I32, FromI32(0x0BD0))
-	AddConstCode( CONST_GL_BLEND                 , "gl.BLEND"                 , TYPE_I32, FromI32(0x0BE2))
-	AddConstCode( CONST_GL_SCISSOR_TEST          , "gl.SCISSOR_TEST"          , TYPE_I32, FromI32(0x0C11))
-	AddConstCode( CONST_GL_POLYGON_SMOOTH_HINT   , "gl.POLYGON_SMOOTH_HINT"   , TYPE_I32, FromI32(0x0C53))
-	AddConstCode( CONST_GL_TEXTURE_2D            , "gl.TEXTURE_2D"            , TYPE_I32, FromI32(0x0DE1))
-	AddConstCode( CONST_GL_TEXTURE_WIDTH         , "gl.TEXTURE_WIDTH"         , TYPE_I32, FromI32(0x1000))
-	AddConstCode( CONST_GL_TEXTURE_HEIGHT        , "gl.TEXTURE_HEIGHT"        , TYPE_I32, FromI32(0x1001))
-	AddConstCode( CONST_GL_DONT_CARE             , "gl.DONT_CARE"             , TYPE_I32, FromI32(0x1100))
-	AddConstCode( CONST_GL_UNSIGNED_BYTE         , "gl.UNSIGNED_BYTE"         , TYPE_I32, FromI32(0x1401))
-	AddConstCode( CONST_GL_FLOAT                 , "gl.FLOAT"                 , TYPE_I32, FromI32(0x1406))
-	AddConstCode( CONST_GL_TEXTURE               , "gl.TEXTURE"               , TYPE_I32, FromI32(0x1702))
-	AddConstCode( CONST_GL_COLOR                 , "gl.COLOR"                 , TYPE_I32, FromI32(0x1800))
-	AddConstCode( CONST_GL_DEPTH_COMPONENT       , "gl.DEPTH_COMPONENT"       , TYPE_I32, FromI32(0x1902))
-	AddConstCode( CONST_GL_RGBA                  , "gl.RGBA"                  , TYPE_I32, FromI32(0x1908))
-	AddConstCode( CONST_GL_REPLACE               , "gl.REPLACE"               , TYPE_I32, FromI32(0x1E01))
-	AddConstCode( CONST_GL_NEAREST               , "gl.NEAREST"               , TYPE_I32, FromI32(0x2600))
-	AddConstCode( CONST_GL_LINEAR                , "gl.LINEAR"                , TYPE_I32, FromI32(0x2601))
-	AddConstCode( CONST_GL_NEAREST_MIPMAP_NEAREST, "gl.NEAREST_MIPMAP_NEAREST", TYPE_I32, FromI32(0x2700))
-	AddConstCode( CONST_GL_LINEAR_MIPMAP_NEAREST , "gl.LINEAR_MIPMAP_NEAREST" , TYPE_I32, FromI32(0x2701))
-	AddConstCode( CONST_GL_NEAREST_MIPMAP_LINEAR , "gl.NEAREST_MIPMAP_LINEAR" , TYPE_I32, FromI32(0x2702))
-	AddConstCode( CONST_GL_LINEAR_MIPMAP_LINEAR  , "gl.LINEAR_MIPMAP_LINEAR"  , TYPE_I32, FromI32(0x2703))
-	AddConstCode( CONST_GL_TEXTURE_MAG_FILTER    , "gl.TEXTURE_MAG_FILTER"    , TYPE_I32, FromI32(0x2800))
-	AddConstCode( CONST_GL_TEXTURE_MIN_FILTER    , "gl.TEXTURE_MIN_FILTER"    , TYPE_I32, FromI32(0x2801))
-	AddConstCode( CONST_GL_TEXTURE_WRAP_S        , "gl.TEXTURE_WRAP_S"        , TYPE_I32, FromI32(0x2802))
-	AddConstCode( CONST_GL_TEXTURE_WRAP_T        , "gl.TEXTURE_WRAP_T"        , TYPE_I32, FromI32(0x2803))
-	AddConstCode( CONST_GL_REPEAT                , "gl.REPEAT"                , TYPE_I32, FromI32(0x2901))
+	AddConstCode( CONST_GL_DEPTH_BUFFER_BIT       , "gl.DEPTH_BUFFER_BIT"       , TYPE_I32, FromI32(0x00000100))
+	AddConstCode( CONST_GL_STENCIL_BUFFER_BIT     , "gl.STENCIL_BUFFER_BIT"     , TYPE_I32, FromI32(0x00000400))
+	AddConstCode( CONST_GL_COLOR_BUFFER_BIT       , "gl.COLOR_BUFFER_BIT"       , TYPE_I32, FromI32(0x00004000))
+	AddConstCode( CONST_GL_FALSE                  , "gl.FALSE"                  , TYPE_I32, FromI32(0))
+	AddConstCode( CONST_GL_TRUE                   , "gl.TRUE"                   , TYPE_I32, FromI32(1))
+	AddConstCode( CONST_GL_POINTS                 , "gl.POINTS"                 , TYPE_I32, FromI32(0x0000))
+	AddConstCode( CONST_GL_LINES                  , "gl.LINES"                  , TYPE_I32, FromI32(0x0001))
+	AddConstCode( CONST_GL_LINE_LOOP              , "gl.LINE_LOOP"              , TYPE_I32, FromI32(0x0002))
+	AddConstCode( CONST_GL_LINE_STRIP             , "gl.LINE_STRIP"             , TYPE_I32, FromI32(0x0003))
+	AddConstCode( CONST_GL_TRIANGLES              , "gl.TRIANGLES"              , TYPE_I32, FromI32(0x0004))
+	AddConstCode( CONST_GL_TRIANGLE_STRIP         , "gl.TRIANGLE_STRIP"         , TYPE_I32, FromI32(0x0005))
+	AddConstCode( CONST_GL_TRIANGLE_FAN           , "gl.TRIANGLE_FAN"           , TYPE_I32, FromI32(0x0006))
+	AddConstCode( CONST_GL_QUADS                  , "gl.QUADS"                  , TYPE_I32, FromI32(0x0007))
+	AddConstCode( CONST_GL_NEVER                  , "gl.NEVER"                  , TYPE_I32, FromI32(0x0200))
+	AddConstCode( CONST_GL_LESS                   , "gl.LESS"                   , TYPE_I32, FromI32(0x0201))
+	AddConstCode( CONST_GL_EQUAL                  , "gl.EQUAL"                  , TYPE_I32, FromI32(0x0202))
+	AddConstCode( CONST_GL_LEQUAL                 , "gl.LEQUAL"                 , TYPE_I32, FromI32(0x0203))
+	AddConstCode( CONST_GL_GREATER                , "gl.GREATER"                , TYPE_I32, FromI32(0x0204))
+	AddConstCode( CONST_GL_NOTEQUAL               , "gl.NOTEQUAL"               , TYPE_I32, FromI32(0x0205))
+	AddConstCode( CONST_GL_GEQUAL                 , "gl.GEQUAL"                 , TYPE_I32, FromI32(0x0206))
+	AddConstCode( CONST_GL_ALWAYS                 , "gl.ALWAYS"                 , TYPE_I32, FromI32(0x0207))
+	AddConstCode( CONST_GL_ZERO                   , "gl.ZERO"                   , TYPE_I32, FromI32(0))
+	AddConstCode( CONST_GL_ONE                    , "gl.ONE"                    , TYPE_I32, FromI32(1))
+	AddConstCode( CONST_GL_SRC_ALPHA              , "gl.SRC_ALPHA"              , TYPE_I32, FromI32(0x302))
+	AddConstCode( CONST_GL_ONE_MINUS_SRC_ALPHA    , "gl.ONE_MINUS_SRC_ALPHA"    , TYPE_I32, FromI32(0x303))
+	AddConstCode( CONST_GL_FRONT                  , "gl.FRONT"                  , TYPE_I32, FromI32(0x404))
+	AddConstCode( CONST_GL_BACK                   , "gl.BACK"                   , TYPE_I32, FromI32(0x405))
+	AddConstCode( CONST_GL_FRONT_AND_BACK         , "gl.FRONT_AND_BACK"         , TYPE_I32, FromI32(0x408))
+	AddConstCode( CONST_GL_NO_ERROR               , "gl.NO_ERROR"               , TYPE_I32, FromI32(0))
+	AddConstCode( CONST_GL_INVALID_ENUM           , "gl.INVALID_ENUM"           , TYPE_I32, FromI32(0x500))
+	AddConstCode( CONST_GL_INVALID_VALUE          , "gl.INVALID_VALUE"          , TYPE_I32, FromI32(0x501))
+	AddConstCode( CONST_GL_INVALID_OPERATION      , "gl.INVALID_OPERATION"      , TYPE_I32, FromI32(0x502))
+	AddConstCode( CONST_GL_STACK_OVERFLOW         , "gl.STACK_OVERFLOW"         , TYPE_I32, FromI32(0x503))
+	AddConstCode( CONST_GL_STACK_UNDERFLOW        , "gl.STACK_UNDERFLOW"        , TYPE_I32, FromI32(0x504))
+	AddConstCode( CONST_GL_OUT_OF_MEMORY          , "gl.OUT_OF_MEMORY"          , TYPE_I32, FromI32(0x505))
+	AddConstCode( CONST_GL_LINE_SMOOTH            , "gl.LINE_SMOOTH"            , TYPE_I32, FromI32(0x0B20))
+	AddConstCode( CONST_GL_POLYGON_SMOOTH         , "gl.POLYGON_SMOOTH"         , TYPE_I32, FromI32(0x0B41))
+	AddConstCode( CONST_GL_CULL_FACE              , "gl.CULL_FACE"              , TYPE_I32, FromI32(0x0B44))
+	AddConstCode( CONST_GL_DEPTH_RANGE            , "gl.DEPTH_RANGE"            , TYPE_I32, FromI32(0x0B70))
+	AddConstCode( CONST_GL_DEPTH_TEST             , "gl.DEPTH_TEST"             , TYPE_I32, FromI32(0x0B71))
+	AddConstCode( CONST_GL_DEPTH_WRITEMASK        , "gl.DEPTH_WRITEMASK"        , TYPE_I32, FromI32(0x0B72))
+	AddConstCode( CONST_GL_DEPTH_CLEAR_VALUE      , "gl.DEPTH_CLEAR_VALUE"      , TYPE_I32, FromI32(0x0B73))
+	AddConstCode( CONST_GL_DEPTH_FUNC             , "gl.DEPTH_FUNC"             , TYPE_I32, FromI32(0x0B74))
+	AddConstCode( CONST_GL_STENCIL_TEST           , "gl.STENCIL_TEST"           , TYPE_I32, FromI32(0x0B90))
+	AddConstCode( CONST_GL_STENCIL_CLEAR_VALUE    , "gl.STENCIL_CLEAR_VALUE"    , TYPE_I32, FromI32(0x0B91))
+	AddConstCode( CONST_GL_STENCIL_FUNC           , "gl.STENCIL_FUNC"           , TYPE_I32, FromI32(0x0B92))
+	AddConstCode( CONST_GL_STENCIL_VALUE_MASK     , "gl.STENCIL_VALUE_MASK"     , TYPE_I32, FromI32(0x0B93))
+	AddConstCode( CONST_GL_STENCIL_FAIL           , "gl.STENCIL_FAIL"           , TYPE_I32, FromI32(0x0B94))
+	AddConstCode( CONST_GL_STENCIL_PASS_DEPTH_FAIL, "gl.STENCIL_PASS_DEPTH_FAIL", TYPE_I32, FromI32(0x0B95))
+	AddConstCode( CONST_GL_STENCIL_PASS_DEPTH_PASS, "gl.STENCIL_PASS_DEPTH_PASS", TYPE_I32, FromI32(0x0B96))
+	AddConstCode( CONST_GL_STENCIL_REF            , "gl.STENCIL_REF"            , TYPE_I32, FromI32(0x0B97))
+	AddConstCode( CONST_GL_STENCIL_WRITEMASK      , "gl.STENCIL_WRITE_MASK"     , TYPE_I32, FromI32(0x0B98))
+	AddConstCode( CONST_GL_DITHER                 , "gl.DITHER"                 , TYPE_I32, FromI32(0x0BD0))
+	AddConstCode( CONST_GL_BLEND                  , "gl.BLEND"                  , TYPE_I32, FromI32(0x0BE2))
+	AddConstCode( CONST_GL_SCISSOR_TEST           , "gl.SCISSOR_TEST"           , TYPE_I32, FromI32(0x0C11))
+	AddConstCode( CONST_GL_POLYGON_SMOOTH_HINT    , "gl.POLYGON_SMOOTH_HINT"    , TYPE_I32, FromI32(0x0C53))
+	AddConstCode( CONST_GL_TEXTURE_2D             , "gl.TEXTURE_2D"             , TYPE_I32, FromI32(0x0DE1))
+	AddConstCode( CONST_GL_TEXTURE_WIDTH          , "gl.TEXTURE_WIDTH"          , TYPE_I32, FromI32(0x1000))
+	AddConstCode( CONST_GL_TEXTURE_HEIGHT         , "gl.TEXTURE_HEIGHT"         , TYPE_I32, FromI32(0x1001))
+	AddConstCode( CONST_GL_DONT_CARE              , "gl.DONT_CARE"              , TYPE_I32, FromI32(0x1100))
+	AddConstCode( CONST_GL_UNSIGNED_BYTE          , "gl.UNSIGNED_BYTE"          , TYPE_I32, FromI32(0x1401))
+	AddConstCode( CONST_GL_FLOAT                  , "gl.FLOAT"                  , TYPE_I32, FromI32(0x1406))
+	AddConstCode( CONST_GL_INVERT                 , "gl.INVERT"                 , TYPE_I32, FromI32(0x150A))
+	AddConstCode( CONST_GL_TEXTURE                , "gl.TEXTURE"                , TYPE_I32, FromI32(0x1702))
+	AddConstCode( CONST_GL_COLOR                  , "gl.COLOR"                  , TYPE_I32, FromI32(0x1800))
+	AddConstCode( CONST_GL_DEPTH                  , "gl.DEPTH"                  , TYPE_I32, FromI32(0x1801))
+	AddConstCode( CONST_GL_STENCIL                , "gl.STENCIL"                , TYPE_I32, FromI32(0x1802))
+	AddConstCode( CONST_GL_STENCIL_INDEX          , "gl.STENCIL_INDEX"          , TYPE_I32, FromI32(0x1901))
+	AddConstCode( CONST_GL_DEPTH_COMPONENT        , "gl.DEPTH_COMPONENT"        , TYPE_I32, FromI32(0x1902))
+	AddConstCode( CONST_GL_RGBA                   , "gl.RGBA"                   , TYPE_I32, FromI32(0x1908))
+	AddConstCode( CONST_GL_KEEP                   , "gl.KEEP"                   , TYPE_I32, FromI32(0x1E00))
+	AddConstCode( CONST_GL_REPLACE                , "gl.REPLACE"                , TYPE_I32, FromI32(0x1E01))
+	AddConstCode( CONST_GL_INCR                   , "gl.INCR"                   , TYPE_I32, FromI32(0x1E02))
+	AddConstCode( CONST_GL_DECR                   , "gl.DECR"                   , TYPE_I32, FromI32(0x1E03))
+	AddConstCode( CONST_GL_NEAREST                , "gl.NEAREST"                , TYPE_I32, FromI32(0x2600))
+	AddConstCode( CONST_GL_LINEAR                 , "gl.LINEAR"                 , TYPE_I32, FromI32(0x2601))
+	AddConstCode( CONST_GL_NEAREST_MIPMAP_NEAREST , "gl.NEAREST_MIPMAP_NEAREST" , TYPE_I32, FromI32(0x2700))
+	AddConstCode( CONST_GL_LINEAR_MIPMAP_NEAREST  , "gl.LINEAR_MIPMAP_NEAREST"  , TYPE_I32, FromI32(0x2701))
+	AddConstCode( CONST_GL_NEAREST_MIPMAP_LINEAR  , "gl.NEAREST_MIPMAP_LINEAR"  , TYPE_I32, FromI32(0x2702))
+	AddConstCode( CONST_GL_LINEAR_MIPMAP_LINEAR   , "gl.LINEAR_MIPMAP_LINEAR"   , TYPE_I32, FromI32(0x2703))
+	AddConstCode( CONST_GL_TEXTURE_MAG_FILTER     , "gl.TEXTURE_MAG_FILTER"     , TYPE_I32, FromI32(0x2800))
+	AddConstCode( CONST_GL_TEXTURE_MIN_FILTER     , "gl.TEXTURE_MIN_FILTER"     , TYPE_I32, FromI32(0x2801))
+	AddConstCode( CONST_GL_TEXTURE_WRAP_S         , "gl.TEXTURE_WRAP_S"         , TYPE_I32, FromI32(0x2802))
+	AddConstCode( CONST_GL_TEXTURE_WRAP_T         , "gl.TEXTURE_WRAP_T"         , TYPE_I32, FromI32(0x2803))
+	AddConstCode( CONST_GL_REPEAT                 , "gl.REPEAT"                 , TYPE_I32, FromI32(0x2901))
 
 	// gl_1_1
 	AddConstCode( CONST_GL_RGBA8                 , "gl.RGBA8"                 , TYPE_I32, FromI32(0x8058))
@@ -258,7 +323,12 @@ func init() {
 	AddConstCode( CONST_GL_CLAMP_TO_BORDER       , "gl.CLAMP_TO_BORDER"       , TYPE_I32, FromI32(0x812D))
 
 	// gl_1_4
+	AddConstCode( CONST_GL_DEPTH_COMPONENT16     , "gl.DEPTH_COMPONENT16"     , TYPE_I32, FromI32(0x81A5))
+	AddConstCode( CONST_GL_DEPTH_COMPONENT24     , "gl.DEPTH_COMPONENT24"     , TYPE_I32, FromI32(0x81A6))
+	AddConstCode( CONST_GL_DEPTH_COMPONENT32     , "gl.DEPTH_COMPONENT32"     , TYPE_I32, FromI32(0x81A7))
 	AddConstCode( CONST_GL_MIRRORED_REPEAT       , "gl.MIRRORED_REPEAT"       , TYPE_I32, FromI32(0x8370))
+	AddConstCode( CONST_GL_INCR_WRAP             , "gl.INCR_WRAP"             , TYPE_I32, FromI32(0x8507))
+	AddConstCode( CONST_GL_DECR_WRAP             , "gl.DECR_WRAP"             , TYPE_I32, FromI32(0x8508))
 
 	// gl_1_5
 	AddConstCode( CONST_GL_ARRAY_BUFFER          , "gl.ARRAY_BUFFER"          , TYPE_I32, FromI32(0x8892))
@@ -273,11 +343,23 @@ func init() {
 	AddConstCode( CONST_GL_DYNAMIC_COPY          , "gl.DYNAMIC_COPY"          , TYPE_I32, FromI32(0x88EA))
 
 	// gl_2_0
-	AddConstCode( CONST_GL_FRAGMENT_SHADER       , "gl.FRAGMENT_SHADER"       , TYPE_I32, FromI32(0x8B30))
-	AddConstCode( CONST_GL_VERTEX_SHADER         , "gl.VERTEX_SHADER"         , TYPE_I32, FromI32(0x8B31))
+	AddConstCode( CONST_GL_STENCIL_BACK_FUNC           , "gl.STENCIL_BACK_FUNC"           , TYPE_I32, FromI32(0x8800))
+	AddConstCode( CONST_GL_STENCIL_BACK_FAIL           , "gl.STENCIL_BACK_FAIL"           , TYPE_I32, FromI32(0x8801))
+	AddConstCode( CONST_GL_STENCIL_BACK_PASS_DEPTH_FAIL, "gl.STENCIL_BACK_PASS_DEPTH_FAIL", TYPE_I32, FromI32(0x8802))
+	AddConstCode( CONST_GL_STENCIL_BACK_PASS_DEPTH_PASS, "gl.STENCIL_BACK_PASS_DEPTH_PASS", TYPE_I32, FromI32(0x8803))
+	AddConstCode( CONST_GL_FRAGMENT_SHADER             , "gl.FRAGMENT_SHADER"             , TYPE_I32, FromI32(0x8B30))
+	AddConstCode( CONST_GL_VERTEX_SHADER               , "gl.VERTEX_SHADER"               , TYPE_I32, FromI32(0x8B31))
+	AddConstCode( CONST_GL_STENCIL_BACK_REF            , "gl.STENCIL_BACK_REF"            , TYPE_I32, FromI32(0x8CA3))
+	AddConstCode( CONST_GL_STENCIL_BACK_VALUE_MASK     , "gl.STENCIL_BACK_VALUE_MASK"     , TYPE_I32, FromI32(0x8CA4))
+	AddConstCode( CONST_GL_STENCIL_BACK_WRITEMASK      , "gl.STENCIL_BACK_WRITEMASK"      , TYPE_I32, FromI32(0x8CA5))
 
 	// gl_3_0
+	AddConstCode( CONST_GL_DEPTH_COMPONENT32F                        , "gl.DEPTH_COMPONENT32F"                       , TYPE_I32, FromI32(0x8CAC))
+	AddConstCode( CONST_GL_DEPTH32F_STENCIL8                         , "gl.DEPTH32F_STENCIL8"                        , TYPE_I32, FromI32(0x8CAD))
 	AddConstCode( CONST_GL_FRAMEBUFFER_UNDEFINED                     , "gl.FRAMEBUFFER_UNDEFINED"                    , TYPE_I32, FromI32(0x8219))
+	AddConstCode( CONST_GL_DEPTH_STENCIL_ATTACHMENT                  , "gl.DEPTH_STENCIL_ATTACHMENT"                 , TYPE_I32, FromI32(0x821A))
+	AddConstCode( CONST_GL_DEPTH_STENCIL                             , "gl.DEPTH_STENCIL"                            , TYPE_I32, FromI32(0x84F9))
+	AddConstCode( CONST_GL_DEPTH24_STENCIL8                          , "gl.DEPTH24_STENCIL8"                         , TYPE_I32, FromI32(0x88F0))
 	AddConstCode( CONST_GL_FRAMEBUFFER_COMPLETE                      , "gl.FRAMEBUFFER_COMPLETE"                     , TYPE_I32, FromI32(0x8CD5))
 	AddConstCode( CONST_GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT         , "gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT"        , TYPE_I32, FromI32(0x8CD6))
 	AddConstCode( CONST_GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT , "gl.FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT", TYPE_I32, FromI32(0x8CD7))
@@ -290,6 +372,10 @@ func init() {
 	AddConstCode( CONST_GL_FRAMEBUFFER                               , "gl.FRAMEBUFFER"                              , TYPE_I32, FromI32(0x8D40))
 	AddConstCode( CONST_GL_RENDERBUFFER                              , "gl.RENDERBUFFER"                             , TYPE_I32, FromI32(0x8D41))
 	AddConstCode( CONST_GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE        , "gl.FRAMEBUFFER_INCOMPLETE_MULTISAMPLE"       , TYPE_I32, FromI32(0x8D56))
+	AddConstCode( CONST_GL_STENCIL_INDEX1                            , "gl.STENCIL_INDEX1"                           , TYPE_I32, FromI32(0x8D46))
+	AddConstCode( CONST_GL_STENCIL_INDEX4                            , "gl.STENCIL_INDEX4"                           , TYPE_I32, FromI32(0x8D47))
+	AddConstCode( CONST_GL_STENCIL_INDEX8                            , "gl.STENCIL_INDEX8"                           , TYPE_I32, FromI32(0x8D48))
+	AddConstCode( CONST_GL_STENCIL_INDEX16                           , "gl.STENCIL_INDEX16"                          , TYPE_I32, FromI32(0x8D49))
 
 	// gl_3_2
 	AddConstCode( CONST_GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS      , "gl.FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS"     , TYPE_I32, FromI32(0x8DA8))

--- a/cx/op_f32.go
+++ b/cx/op_f32.go
@@ -27,6 +27,12 @@ func op_f32_f32(expr *CXExpression, fp int) {
 	}
 }
 
+func op_f32_isnan(expr *CXExpression, fp int) {
+	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
+	outB1 := FromBool(math.IsNaN(float64(ReadF32(fp, inp1))))
+	WriteMemory(GetFinalOffset(fp, out1), outB1)
+}
+
 func op_f32_print(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	fmt.Println(ReadF32(fp, inp1))
@@ -193,3 +199,4 @@ func op_f32_min(expr *CXExpression, fp int) {
 	outB1 := FromF32(float32(math.Min(float64(ReadF32(fp, inp1)), float64(ReadF32(fp, inp2)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
+

--- a/cx/op_glfw.go
+++ b/cx/op_glfw.go
@@ -92,12 +92,9 @@ func op_glfw_GetTime(expr *CXExpression, fp int) {
 	WriteMemory(GetFinalOffset(fp, out1), FromF64(glfw.GetTime()))
 }
 
-func op_glfw_SetKeyCallback(expr *CXExpression, fp int) {
-	inp1, inp2 := expr.Inputs[0], expr.Inputs[1]
-	// prgrm := expr.Program
-
+func SetKeyCallback(expr *CXExpression, window string, functionName string, packageName string) {
 	callback := func(w *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
-		if fn, err := PROGRAM.GetFunction(ReadStr(fp, inp2), expr.Package.Name); err == nil {
+		if fn, err := PROGRAM.GetFunction(functionName, packageName); err == nil {
 			var winName []byte
 			for key, win := range windows {
 				if w == win {
@@ -140,15 +137,22 @@ func op_glfw_SetKeyCallback(expr *CXExpression, fp int) {
 		}
 	}
 
-	windows[ReadStr(fp, inp1)].SetKeyCallback(callback)
+	windows[window].SetKeyCallback(callback)
 }
 
-func op_glfw_SetCursorPosCallback(expr *CXExpression, fp int) {
-	inp1, inp2 := expr.Inputs[0], expr.Inputs[1]
-	// prgrm := expr.Program
+func op_glfw_SetKeyCallback(expr *CXExpression, fp int) {
+	inp0, inp1 := expr.Inputs[0], expr.Inputs[1]
+    SetKeyCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), expr.Package.Name)
+}
 
+func op_glfw_SetKeyCallbackEx(expr *CXExpression, fp int) {
+	inp0, inp1, inp2  := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
+    SetKeyCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), ReadStr(fp, inp2))
+}
+
+func SetCursorPosCallback(expr *CXExpression, window string, functionName string, packageName string) {
 	callback := func(w *glfw.Window, xpos float64, ypos float64) {
-		if fn, err := PROGRAM.GetFunction(ReadStr(fp, inp2), expr.Package.Name); err == nil {
+		if fn, err := PROGRAM.GetFunction(functionName, packageName); err == nil {
 			var winName []byte
 			for key, win := range windows {
 				if w == win {
@@ -185,7 +189,17 @@ func op_glfw_SetCursorPosCallback(expr *CXExpression, fp int) {
 		}
 	}
 
-	windows[ReadStr(fp, inp1)].SetCursorPosCallback(callback)
+	windows[window].SetCursorPosCallback(callback)
+}
+
+func op_glfw_SetCursorPosCallback(expr *CXExpression, fp int) {
+	inp0, inp1 := expr.Inputs[0], expr.Inputs[1]
+    SetCursorPosCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), expr.Package.Name)
+}
+
+func op_glfw_SetCursorPosCallbackEx(expr *CXExpression, fp int) {
+	inp0, inp1, inp2 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
+    SetCursorPosCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), ReadStr(fp, inp2))
 }
 
 func op_glfw_SetShouldClose(expr *CXExpression, fp int) {
@@ -197,12 +211,9 @@ func op_glfw_SetShouldClose(expr *CXExpression, fp int) {
 	}
 }
 
-func op_glfw_SetMouseButtonCallback(expr *CXExpression, fp int) {
-	inp1, inp2 := expr.Inputs[0], expr.Inputs[1]
-	// prgrm := expr.Program
-
+func SetMouseButtonCallback(expr *CXExpression, window string, functionName string, packageName string) {
 	callback := func(w *glfw.Window, key glfw.MouseButton, action glfw.Action, mods glfw.ModifierKey) {
-		if fn, err := PROGRAM.GetFunction(ReadStr(fp, inp2), expr.Package.Name); err == nil {
+		if fn, err := PROGRAM.GetFunction(functionName, packageName); err == nil {
 			var winName []byte
 			for key, win := range windows {
 				if w == win {
@@ -244,5 +255,16 @@ func op_glfw_SetMouseButtonCallback(expr *CXExpression, fp int) {
 		}
 	}
 
-	windows[ReadStr(fp, inp1)].SetMouseButtonCallback(callback)
+	windows[window].SetMouseButtonCallback(callback)
 }
+
+func op_glfw_SetMouseButtonCallback(expr *CXExpression, fp int) {
+	inp0, inp1 := expr.Inputs[0], expr.Inputs[1]
+    SetMouseButtonCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), expr.Package.Name)
+}
+
+func op_glfw_SetMouseButtonCallbackEx(expr *CXExpression, fp int) {
+	inp0, inp1, inp2 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
+    SetMouseButtonCallback(expr, ReadStr(fp, inp0), ReadStr(fp ,inp1), ReadStr(fp, inp2))
+}
+

--- a/cx/op_glfw.go
+++ b/cx/op_glfw.go
@@ -142,12 +142,12 @@ func SetKeyCallback(expr *CXExpression, window string, functionName string, pack
 
 func op_glfw_SetKeyCallback(expr *CXExpression, fp int) {
 	inp0, inp1 := expr.Inputs[0], expr.Inputs[1]
-    SetKeyCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), expr.Package.Name)
+	SetKeyCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), expr.Package.Name)
 }
 
 func op_glfw_SetKeyCallbackEx(expr *CXExpression, fp int) {
 	inp0, inp1, inp2  := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
-    SetKeyCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), ReadStr(fp, inp2))
+	SetKeyCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), ReadStr(fp, inp2))
 }
 
 func SetCursorPosCallback(expr *CXExpression, window string, functionName string, packageName string) {
@@ -194,12 +194,12 @@ func SetCursorPosCallback(expr *CXExpression, window string, functionName string
 
 func op_glfw_SetCursorPosCallback(expr *CXExpression, fp int) {
 	inp0, inp1 := expr.Inputs[0], expr.Inputs[1]
-    SetCursorPosCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), expr.Package.Name)
+	SetCursorPosCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), expr.Package.Name)
 }
 
 func op_glfw_SetCursorPosCallbackEx(expr *CXExpression, fp int) {
 	inp0, inp1, inp2 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
-    SetCursorPosCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), ReadStr(fp, inp2))
+	SetCursorPosCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), ReadStr(fp, inp2))
 }
 
 func op_glfw_SetShouldClose(expr *CXExpression, fp int) {
@@ -260,11 +260,11 @@ func SetMouseButtonCallback(expr *CXExpression, window string, functionName stri
 
 func op_glfw_SetMouseButtonCallback(expr *CXExpression, fp int) {
 	inp0, inp1 := expr.Inputs[0], expr.Inputs[1]
-    SetMouseButtonCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), expr.Package.Name)
+	SetMouseButtonCallback(expr, ReadStr(fp, inp0), ReadStr(fp, inp1), expr.Package.Name)
 }
 
 func op_glfw_SetMouseButtonCallbackEx(expr *CXExpression, fp int) {
 	inp0, inp1, inp2 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
-    SetMouseButtonCallback(expr, ReadStr(fp, inp0), ReadStr(fp ,inp1), ReadStr(fp, inp2))
+	SetMouseButtonCallback(expr, ReadStr(fp, inp0), ReadStr(fp ,inp1), ReadStr(fp, inp2))
 }
 

--- a/cx/op_gltext.go
+++ b/cx/op_gltext.go
@@ -41,7 +41,7 @@ func op_gltext_Texture(expr *CXExpression, fp int) {
 	WriteMemory(GetFinalOffset(fp, out1), FromI32(int32(fonts[ReadStr(fp, inp1)].Texture())))
 }
 
-func op_gltext_NextRune(expr *CXExpression, fp int) { // not really effective...
+func op_gltext_NextGlyph(expr *CXExpression, fp int) { // refactor
 	inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
 	out1, out2, out3, out4, out5, out6, out7 := expr.Outputs[0], expr.Outputs[1], expr.Outputs[2], expr.Outputs[3], expr.Outputs[4],  expr.Outputs[5], expr.Outputs[6]
 	font := fonts[ReadStr(fp, inp1)]
@@ -63,7 +63,7 @@ func op_gltext_NextRune(expr *CXExpression, fp int) { // not really effective...
 		h = g.Height
 		advance = g.Advance
 	}
-//	fmt.Println("NextRune : ", str, /*" slice : ", str[index:], */" index : ", index, " runeValue : ", runeValue, " width : ", width)
+
 	WriteMemory(GetFinalOffset(fp, out1), FromI32(int32(runeValue - font.Low())))
 	WriteMemory(GetFinalOffset(fp, out2), FromI32(int32(width)))
 	WriteMemory(GetFinalOffset(fp, out3), FromI32(int32(x)))
@@ -80,3 +80,38 @@ func op_gltext_GlyphBounds(expr *CXExpression, fp int) {
 	WriteMemory(GetFinalOffset(fp, out1), FromI32(int32(maxGlyphWidth)))
 	WriteMemory(GetFinalOffset(fp, out2), FromI32(int32(maxGlyphHeight)))
 }
+
+func op_gltext_GlyphMetrics(expr *CXExpression, fp int) { // refactor
+	inp1, inp2, out1, out2 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0], expr.Outputs[1]
+
+	width, height := fonts[ReadStr(fp, inp1)].GlyphMetrics(uint32(ReadI32(fp, inp2)))
+
+	WriteMemory(GetFinalOffset(fp, out1), FromI32(int32(width)))
+	WriteMemory(GetFinalOffset(fp, out2), FromI32(int32(height)))
+}
+
+func op_gltext_GlyphInfo(expr *CXExpression, fp int) { // refactor
+	inp1, inp2 := expr.Inputs[0], expr.Inputs[1]
+	out1, out2, out3, out4, out5 := expr.Outputs[0], expr.Outputs[1], expr.Outputs[2], expr.Outputs[3], expr.Outputs[4]
+	font := fonts[ReadStr(fp, inp1)]
+	glyph := ReadI32(fp, inp2)
+	var x int = 0
+	var y int = 0
+	var w int = 0
+	var h int = 0
+	var advance int = 0
+	g := font.Glyphs()[glyph]
+	x = g.X
+	y = g.Y
+	w = g.Width
+	h = g.Height
+	advance = g.Advance
+
+	WriteMemory(GetFinalOffset(fp, out1), FromI32(int32(x)))
+	WriteMemory(GetFinalOffset(fp, out2), FromI32(int32(y)))
+	WriteMemory(GetFinalOffset(fp, out3), FromI32(int32(w)))
+	WriteMemory(GetFinalOffset(fp, out4), FromI32(int32(h)))
+	WriteMemory(GetFinalOffset(fp, out5), FromI32(int32(advance)))
+}
+
+

--- a/cx/op_opengl.go
+++ b/cx/op_opengl.go
@@ -231,9 +231,24 @@ func op_gl_ClearColor(expr *CXExpression, fp int) {
 	gl.ClearColor(ReadF32(fp, inp1), ReadF32(fp, inp2), ReadF32(fp, inp3), ReadF32(fp, inp4))
 }
 
+func op_gl_ClearStencil(expr *CXExpression, fp int) {
+	inp0 := expr.Inputs[0]
+	gl.ClearStencil(ReadI32(fp, inp0))
+}
+
 func op_gl_ClearDepth(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	gl.ClearDepth(ReadF64(fp, inp1))
+}
+
+func op_gl_StencilMask(expr *CXExpression, fp int) {
+	inp0 := expr.Inputs[0]
+	gl.StencilMask(uint32(ReadI32(fp, inp0)))
+}
+
+func op_gl_ColorMask(expr *CXExpression, fp int) {
+	inp0, inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Inputs[3]
+	gl.ColorMask(ReadBool(fp, inp0), ReadBool(fp, inp1), ReadBool(fp, inp2), ReadBool(fp, inp3))
 }
 
 func op_gl_DepthMask(expr *CXExpression, fp int) {
@@ -256,6 +271,16 @@ func op_gl_BlendFunc(expr *CXExpression, fp int) {
 	gl.BlendFunc(uint32(ReadI32(fp, inp1)), uint32(ReadI32(fp, inp2)))
 }
 
+func op_gl_StencilFunc(expr *CXExpression, fp int) {
+	inp0, inp1, inp2 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
+	gl.StencilFunc(uint32(ReadI32(fp, inp0)), ReadI32(fp, inp1), uint32(ReadI32(fp, inp2)))
+}
+
+func op_gl_StencilOp(expr *CXExpression, fp int) {
+	inp0, inp1, inp2 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
+	gl.StencilOp(uint32(ReadI32(fp, inp0)), uint32(ReadI32(fp, inp1)), uint32(ReadI32(fp, inp2)))
+}
+
 func op_gl_DepthFunc(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	gl.DepthFunc(uint32(ReadI32(fp, inp1)))
@@ -272,6 +297,11 @@ func op_gl_GetTexLevelParameteriv(expr *CXExpression, fp int) {
 	var outValue int32 = 0
 	gl.GetTexLevelParameteriv(uint32(ReadI32(fp, inp1)), ReadI32(fp, inp2), uint32(ReadI32(fp, inp3)), &outValue)
 	WriteMemory(GetFinalOffset(fp, out1), FromI32(outValue))
+}
+
+func op_gl_DepthRange(expr *CXExpression, fp int) {
+	inp0, inp1 := expr.Inputs[0], expr.Inputs[1]
+	gl.DepthRange(ReadF64(fp, inp0), ReadF64(fp, inp1))
 }
 
 func op_gl_Viewport(expr *CXExpression, fp int) {
@@ -341,6 +371,21 @@ func op_gl_BufferSubData(expr *CXExpression, fp int) {
 }
 
 // gl_2_0
+func op_gl_StencilOpSeparate(expr *CXExpression, fp int) {
+	inp0, inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Inputs[3]
+	gl.StencilOpSeparate(uint32(ReadI32(fp, inp0)), uint32(ReadI32(fp, inp1)), uint32(ReadI32(fp, inp2)), uint32(ReadI32(fp, inp3)))
+}
+
+func op_gl_StencilFuncSeparate(expr *CXExpression, fp int) {
+	inp0, inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Inputs[3]
+	gl.StencilFuncSeparate(uint32(ReadI32(fp, inp0)), uint32(ReadI32(fp, inp1)), ReadI32(fp, inp2), uint32(ReadI32(fp, inp3)))
+}
+
+func op_gl_StencilMaskSeparate(expr *CXExpression, fp int) {
+	inp0, inp1 := expr.Inputs[0], expr.Inputs[1]
+	gl.StencilMaskSeparate(uint32(ReadI32(fp, inp0)), uint32(ReadI32(fp, inp1)))
+}
+
 func op_gl_AttachShader(expr *CXExpression, fp int) {
 	inp1, inp2 := expr.Inputs[0], expr.Inputs[1]
 	gl.AttachShader(uint32(ReadI32(fp, inp1)), uint32(ReadI32(fp, inp2)))

--- a/cx/opcodes_bare.go
+++ b/cx/opcodes_bare.go
@@ -87,7 +87,6 @@ const (
 	OP_I32_LOG
 	OP_I32_LOG2
 	OP_I32_LOG10
-
 	OP_I32_MAX
 	OP_I32_MIN
 
@@ -126,6 +125,7 @@ const (
 	OP_I64_MAX
 	OP_I64_MIN
 
+	OP_F32_IS_NAN
 	OP_F32_BYTE
 	OP_F32_STR
 	OP_F32_I32
@@ -375,6 +375,7 @@ func init () {
 	AddOpCode(OP_I64_MAX, "i64.max", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
 	AddOpCode(OP_I64_MIN, "i64.min", []int{TYPE_I64, TYPE_I64}, []int{TYPE_I64})
 
+	AddOpCode(OP_F32_IS_NAN, "f32.isnan", []int{TYPE_F32}, []int{TYPE_BOOL})
 	AddOpCode(OP_F32_BYTE, "f32.byte", []int{TYPE_F32}, []int{TYPE_BYTE})
 	AddOpCode(OP_F32_STR, "f32.str", []int{TYPE_F32}, []int{TYPE_STR})
 	AddOpCode(OP_F32_I32, "f32.i32", []int{TYPE_F32}, []int{TYPE_I32})
@@ -678,6 +679,8 @@ func init () {
 		case OP_I64_MIN:
 			op_i64_min(expr, fp)
 
+		case OP_F32_IS_NAN:
+			op_f32_isnan(expr, fp)
 		case OP_F32_BYTE:
 			op_f32_f32(expr, fp)
 		case OP_F32_STR:
@@ -690,7 +693,6 @@ func init () {
 			op_f32_f32(expr, fp)
 		case OP_F32_F64:
 			op_f32_f32(expr, fp)
-
 		case OP_F32_PRINT:
 			op_f32_print(expr, fp)
 		case OP_F32_ADD:

--- a/cx/opcodes_extra.go
+++ b/cx/opcodes_extra.go
@@ -127,9 +127,12 @@ const (
 	OP_GLFW_GET_FRAMEBUFFER_SIZE
 	OP_GLFW_SWAP_INTERVAL
 	OP_GLFW_SET_KEY_CALLBACK
+	OP_GLFW_SET_KEY_CALLBACK_EX
 	OP_GLFW_GET_TIME
 	OP_GLFW_SET_MOUSE_BUTTON_CALLBACK
+	OP_GLFW_SET_MOUSE_BUTTON_CALLBACK_EX
 	OP_GLFW_SET_CURSOR_POS_CALLBACK
+	OP_GLFW_SET_CURSOR_POS_CALLBACK_EX
 	OP_GLFW_GET_CURSOR_POS
 	OP_GLFW_SET_INPUT_MODE
 	OP_GLFW_SET_WINDOW_POS
@@ -272,9 +275,12 @@ func init () {
 	AddOpCode(OP_GLFW_GET_FRAMEBUFFER_SIZE, "glfw.GetFramebufferSize", []int{TYPE_STR}, []int{TYPE_I32, TYPE_I32})
 	AddOpCode(OP_GLFW_SWAP_INTERVAL, "glfw.SwapInterval", []int{TYPE_I32}, []int{})
 	AddOpCode(OP_GLFW_SET_KEY_CALLBACK, "glfw.SetKeyCallback", []int{TYPE_STR, TYPE_STR}, []int{})
+	AddOpCode(OP_GLFW_SET_KEY_CALLBACK_EX, "glfw.SetKeyCallbackEx", []int{TYPE_STR, TYPE_STR, TYPE_STR}, []int{})
 	AddOpCode(OP_GLFW_GET_TIME, "glfw.GetTime", []int{}, []int{TYPE_F64})
 	AddOpCode(OP_GLFW_SET_MOUSE_BUTTON_CALLBACK, "glfw.SetMouseButtonCallback", []int{TYPE_STR, TYPE_STR}, []int{})
+	AddOpCode(OP_GLFW_SET_MOUSE_BUTTON_CALLBACK_EX, "glfw.SetMouseButtonCallbackEx", []int{TYPE_STR, TYPE_STR, TYPE_STR}, []int{})
 	AddOpCode(OP_GLFW_SET_CURSOR_POS_CALLBACK, "glfw.SetCursorPosCallback", []int{TYPE_STR, TYPE_STR}, []int{})
+	AddOpCode(OP_GLFW_SET_CURSOR_POS_CALLBACK_EX, "glfw.SetCursorPosCallbackEx", []int{TYPE_STR, TYPE_STR, TYPE_STR}, []int{})
 	AddOpCode(OP_GLFW_GET_CURSOR_POS, "glfw.GetCursorPos", []int{TYPE_STR}, []int{TYPE_F64, TYPE_F64})
 	AddOpCode(OP_GLFW_SET_INPUT_MODE, "glfw.SetInputMode", []int{TYPE_STR, TYPE_I32, TYPE_I32}, []int{})
 	AddOpCode(OP_GLFW_SET_WINDOW_POS, "glfw.SetWindowPos", []int{TYPE_STR, TYPE_I32, TYPE_I32}, []int{})
@@ -524,12 +530,18 @@ func init () {
 					op_glfw_SwapInterval(expr, fp)
 				case OP_GLFW_SET_KEY_CALLBACK:
 					op_glfw_SetKeyCallback(expr, fp)
+				case OP_GLFW_SET_KEY_CALLBACK_EX:
+					op_glfw_SetKeyCallbackEx(expr, fp)
 				case OP_GLFW_GET_TIME:
 					op_glfw_GetTime(expr, fp)
 				case OP_GLFW_SET_MOUSE_BUTTON_CALLBACK:
 					op_glfw_SetMouseButtonCallback(expr, fp)
+				case OP_GLFW_SET_MOUSE_BUTTON_CALLBACK_EX:
+					op_glfw_SetMouseButtonCallbackEx(expr, fp)
 				case OP_GLFW_SET_CURSOR_POS_CALLBACK:
 					op_glfw_SetCursorPosCallback(expr, fp)
+				case OP_GLFW_SET_CURSOR_POS_CALLBACK_EX:
+					op_glfw_SetCursorPosCallbackEx(expr, fp)
 				case OP_GLFW_GET_CURSOR_POS:
 					op_glfw_GetCursorPos(expr, fp)
 				case OP_GLFW_SET_INPUT_MODE:

--- a/cx/opcodes_extra.go
+++ b/cx/opcodes_extra.go
@@ -137,6 +137,8 @@ const (
 	OP_GLFW_SET_INPUT_MODE
 	OP_GLFW_SET_WINDOW_POS
 	OP_GLFW_GET_KEY
+	OP_GLFW_FUNC_I32_I32
+	OP_GLFW_CALL_I32_I32
 
 	// gltext
 	OP_GLTEXT_LOAD_TRUE_TYPE
@@ -283,6 +285,8 @@ func init () {
 	AddOpCode(OP_GLFW_SET_INPUT_MODE, "glfw.SetInputMode", []int{TYPE_STR, TYPE_I32, TYPE_I32}, []int{})
 	AddOpCode(OP_GLFW_SET_WINDOW_POS, "glfw.SetWindowPos", []int{TYPE_STR, TYPE_I32, TYPE_I32}, []int{})
 	AddOpCode(OP_GLFW_GET_KEY, "glfw.GetKey", []int{TYPE_STR, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_GLFW_FUNC_I32_I32, "glfw.func_i32_i32", []int{TYPE_STR, TYPE_STR}, []int{TYPE_I32})
+	AddOpCode(OP_GLFW_CALL_I32_I32, "glfw.call_i32_i32", []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
 
 	// gltext
 	AddOpCode(OP_GLTEXT_LOAD_TRUE_TYPE, "gltext.LoadTrueType", []int{TYPE_STR, TYPE_STR, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
@@ -550,6 +554,10 @@ func init () {
 					op_glfw_SetWindowPos(expr, fp)
 				case OP_GLFW_GET_KEY:
 					op_glfw_GetKey(expr, fp)
+				case OP_GLFW_FUNC_I32_I32:
+					op_glfw_func_i32_i32(expr, fp)
+				case OP_GLFW_CALL_I32_I32:
+					op_glfw_call_i32_i32(expr, fp)
 
 				// gltext
 				case OP_GLTEXT_LOAD_TRUE_TYPE:

--- a/cx/opcodes_extra.go
+++ b/cx/opcodes_extra.go
@@ -137,18 +137,16 @@ const (
 	OP_GLFW_SET_INPUT_MODE
 	OP_GLFW_SET_WINDOW_POS
 	OP_GLFW_GET_KEY
-	OP_GLFW_FUNC_I32_I32
-	OP_GLFW_CALL_I32_I32
 
 	// gltext
 	OP_GLTEXT_LOAD_TRUE_TYPE
 	OP_GLTEXT_LOAD_TRUE_TYPE_EX
 	OP_GLTEXT_PRINTF
 	OP_GLTEXT_METRICS
-	OP_GLTEXT_METRICS_GLYPH
 	OP_GLTEXT_TEXTURE
-	OP_GLTEXT_NEXT_RUNE
+	OP_GLTEXT_NEXT_GLYPH
 	OP_GLTEXT_GLYPH_BOUNDS
+	OP_GLTEXT_GLYPH_METRICS
 	OP_GLTEXT_GLYPH_INFO
 )
 
@@ -291,8 +289,10 @@ func init () {
 	AddOpCode(OP_GLTEXT_PRINTF, "gltext.Printf", []int{TYPE_STR, TYPE_F32, TYPE_F32, TYPE_STR}, []int{})
 	AddOpCode(OP_GLTEXT_METRICS, "gltext.Metrics", []int{TYPE_STR, TYPE_STR}, []int{TYPE_I32, TYPE_I32})
 	AddOpCode(OP_GLTEXT_TEXTURE, "gltext.Texture", []int{TYPE_STR}, []int{TYPE_I32})
-	AddOpCode(OP_GLTEXT_NEXT_RUNE, "gltext.NextRune", []int{TYPE_STR, TYPE_STR, TYPE_I32}, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32})
+	AddOpCode(OP_GLTEXT_NEXT_GLYPH, "gltext.NextGlyph", []int{TYPE_STR, TYPE_STR, TYPE_I32}, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32})
 	AddOpCode(OP_GLTEXT_GLYPH_BOUNDS, "gltext.GlyphBounds", []int{}, []int{TYPE_I32, TYPE_I32})
+	AddOpCode(OP_GLTEXT_GLYPH_METRICS, "gltext.GlyphMetrics", []int{TYPE_STR, TYPE_I32}, []int{TYPE_I32, TYPE_I32})
+	AddOpCode(OP_GLTEXT_GLYPH_INFO, "gltext.GlyphInfo", []int{TYPE_STR, TYPE_I32}, []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32})
 
 	// exec
 	execNativeExtra = func (prgrm *CXProgram) {
@@ -560,10 +560,14 @@ func init () {
 					op_gltext_Metrics(expr, fp)
 				case OP_GLTEXT_TEXTURE:
 					op_gltext_Texture(expr, fp)
-				case OP_GLTEXT_NEXT_RUNE:
-					op_gltext_NextRune(expr, fp)
+				case OP_GLTEXT_NEXT_GLYPH:
+					op_gltext_NextGlyph(expr, fp)
 				case OP_GLTEXT_GLYPH_BOUNDS:
 					op_gltext_GlyphBounds(expr, fp)
+				case OP_GLTEXT_GLYPH_METRICS:
+					op_gltext_GlyphMetrics(expr, fp)
+				case OP_GLTEXT_GLYPH_INFO:
+					op_gltext_GlyphInfo(expr, fp)
 				default:
 					// DumpOpCodes(opCode)
 					panic("invalid extra opcode")

--- a/cx/opcodes_extra.go
+++ b/cx/opcodes_extra.go
@@ -44,14 +44,20 @@ const (
 	OP_GL_TEX_IMAGE_2D
 	OP_GL_CLEAR
 	OP_GL_CLEAR_COLOR
+	OP_GL_CLEAR_STENCIL
 	OP_GL_CLEAR_DEPTH
+	OP_GL_STENCIL_MASK
+	OP_GL_COLOR_MASK
 	OP_GL_DEPTH_MASK
 	OP_GL_DISABLE
 	OP_GL_ENABLE
 	OP_GL_BLEND_FUNC
+	OP_GL_STENCIL_FUNC
+	OP_GL_STENCIL_OP
 	OP_GL_DEPTH_FUNC
 	OP_GL_GET_ERROR
 	OP_GL_GET_TEX_LEVEL_PARAMETERIV
+	OP_GL_DEPTH_RANGE
 	OP_GL_VIEWPORT
 
 	// gl_1_1
@@ -71,6 +77,9 @@ const (
 	OP_GL_BUFFER_SUB_DATA
 
 	// gl_2_0
+	OP_GL_STENCIL_OP_SEPARATE
+	OP_GL_STENCIL_FUNC_SEPARATE
+	OP_GL_STENCIL_MASK_SEPARATE
 	OP_GL_ATTACH_SHADER
 	OP_GL_BIND_ATTRIB_LOCATION
 	OP_GL_COMPILE_SHADER
@@ -125,14 +134,19 @@ const (
 	OP_GLFW_SET_INPUT_MODE
 	OP_GLFW_SET_WINDOW_POS
 	OP_GLFW_GET_KEY
+	OP_GLFW_FUNC_I32_I32
+	OP_GLFW_CALL_I32_I32
 
 	// gltext
 	OP_GLTEXT_LOAD_TRUE_TYPE
+	OP_GLTEXT_LOAD_TRUE_TYPE_EX
 	OP_GLTEXT_PRINTF
 	OP_GLTEXT_METRICS
+	OP_GLTEXT_METRICS_GLYPH
 	OP_GLTEXT_TEXTURE
 	OP_GLTEXT_NEXT_RUNE
 	OP_GLTEXT_GLYPH_BOUNDS
+	OP_GLTEXT_GLYPH_INFO
 )
 
 var execNativeExtra func(*CXProgram)
@@ -142,6 +156,7 @@ func init () {
 	AddOpCode(OP_GL_INIT, "gl.Init", []int{}, []int{})
 	AddOpCode(OP_GL_STRS, "gl.Strs", []int{TYPE_STR, TYPE_STR}, []int{})
 	AddOpCode(OP_GL_FREE, "gl.Free", []int{TYPE_STR}, []int{})
+	AddOpCode(OP_GL_NEW_TEXTURE, "gl.NewTexture", []int{TYPE_STR}, []int{TYPE_I32})
 
 	// gl_0.0
 	AddOpCode(OP_GL_MATRIX_MODE, "gl.MatrixMode", []int{TYPE_I32}, []int{})
@@ -160,7 +175,6 @@ func init () {
 	AddOpCode(OP_GL_VERTEX_3F, "gl.Vertex3f", []int{TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
 	AddOpCode(OP_GL_LIGHTFV, "gl.Lightfv", []int{TYPE_I32, TYPE_I32, TYPE_F32}, []int{})
 	AddOpCode(OP_GL_FRUSTUM, "gl.Frustum", []int{TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64}, []int{})
-	AddOpCode(OP_GL_NEW_TEXTURE, "gl.NewTexture", []int{TYPE_STR}, []int{TYPE_I32})
 	AddOpCode(OP_GL_TEX_ENVI, "gl.TexEnvi", []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
 	AddOpCode(OP_GL_ORTHO, "gl.Ortho", []int{TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64, TYPE_F64}, []int{})
 	AddOpCode(OP_GL_SCALEF, "gl.Scalef", []int{TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
@@ -175,14 +189,20 @@ func init () {
 	AddOpCode(OP_GL_TEX_IMAGE_2D, "gl.TexImage2D", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
 	AddOpCode(OP_GL_CLEAR, "gl.Clear", []int{TYPE_I32}, []int{})
 	AddOpCode(OP_GL_CLEAR_COLOR, "gl.ClearColor", []int{TYPE_F32, TYPE_F32, TYPE_F32, TYPE_F32}, []int{})
+	AddOpCode(OP_GL_CLEAR_STENCIL, "gl.ClearStencil", []int{TYPE_I32}, []int{})
 	AddOpCode(OP_GL_CLEAR_DEPTH, "gl.ClearDepth", []int{TYPE_F64}, []int{})
+	AddOpCode(OP_GL_STENCIL_MASK, "gl.StencilMask", []int{TYPE_I32}, []int{})
+	AddOpCode(OP_GL_COLOR_MASK, "gl.ColorMask", []int{TYPE_BOOL, TYPE_BOOL, TYPE_BOOL, TYPE_BOOL}, []int{})
 	AddOpCode(OP_GL_DEPTH_MASK, "gl.DepthMask", []int{TYPE_BOOL}, []int{})
 	AddOpCode(OP_GL_DISABLE, "gl.Disable", []int{TYPE_I32}, []int{})
 	AddOpCode(OP_GL_ENABLE, "gl.Enable", []int{TYPE_I32}, []int{})
 	AddOpCode(OP_GL_BLEND_FUNC, "gl.BlendFunc", []int{TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_STENCIL_FUNC, "gl.StencilFunc", []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_STENCIL_OP, "gl.StencilOp", []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
 	AddOpCode(OP_GL_DEPTH_FUNC, "gl.DepthFunc", []int{TYPE_I32}, []int{})
 	AddOpCode(OP_GL_GET_ERROR, "gl.GetError", []int{}, []int{TYPE_I32})
 	AddOpCode(OP_GL_GET_TEX_LEVEL_PARAMETERIV, "gl.GetTexLevelParameteriv", []int{TYPE_I32, TYPE_I32, TYPE_I32}, []int{TYPE_I32})
+	AddOpCode(OP_GL_DEPTH_RANGE, "gl.DepthRange", []int{TYPE_F64, TYPE_F64}, []int{})
 	AddOpCode(OP_GL_VIEWPORT, "gl.Viewport", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
 
 	// gl_1_1
@@ -202,6 +222,9 @@ func init () {
 	AddOpCode(OP_GL_BUFFER_SUB_DATA, "gl.BufferSubData", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_F32}, []int{})
 
 	//gl_2_0
+	AddOpCode(OP_GL_STENCIL_OP_SEPARATE, "gl.StencilOpSeparate", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_STENCIL_FUNC_SEPARATE, "gl.StencilFuncSeparate", []int{TYPE_I32, TYPE_I32, TYPE_I32, TYPE_I32}, []int{})
+	AddOpCode(OP_GL_STENCIL_MASK_SEPARATE, "gl.StencilMaskSeparate", []int{TYPE_I32, TYPE_I32}, []int{})
 	AddOpCode(OP_GL_ATTACH_SHADER, "gl.AttachShader", []int{TYPE_I32, TYPE_I32}, []int{})
 	AddOpCode(OP_GL_BIND_ATTRIB_LOCATION, "gl.BindAttribLocation", []int{TYPE_I32, TYPE_I32, TYPE_STR}, []int{})
 	AddOpCode(OP_GL_COMPILE_SHADER, "gl.CompileShader", []int{TYPE_I32}, []int{})
@@ -285,6 +308,8 @@ func init () {
 					op_gl_Strs(expr, fp)
 				case OP_GL_FREE:
 					op_gl_Free(expr, fp)
+				case OP_GL_NEW_TEXTURE:
+					op_gl_NewTexture(expr, fp)
 
 				// gl_0_0
 				case OP_GL_MATRIX_MODE:
@@ -319,8 +344,6 @@ func init () {
 					op_gl_Lightfv(expr, fp)
 				case OP_GL_FRUSTUM:
 					op_gl_Frustum(expr, fp)
-				case OP_GL_NEW_TEXTURE:
-					op_gl_NewTexture(expr, fp)
 				case OP_GL_TEX_ENVI:
 					op_gl_TexEnvi(expr, fp)
 				case OP_GL_ORTHO:
@@ -347,8 +370,14 @@ func init () {
 					op_gl_Clear(expr, fp)
 				case OP_GL_CLEAR_COLOR:
 					op_gl_ClearColor(expr, fp)
+				case OP_GL_CLEAR_STENCIL:
+					op_gl_ClearStencil(expr, fp)
 				case OP_GL_CLEAR_DEPTH:
 					op_gl_ClearDepth(expr, fp)
+				case OP_GL_STENCIL_MASK:
+					op_gl_StencilMask(expr, fp)
+				case OP_GL_COLOR_MASK:
+					op_gl_ColorMask(expr, fp)
 				case OP_GL_DEPTH_MASK:
 					op_gl_DepthMask(expr, fp)
 				case OP_GL_DISABLE:
@@ -357,12 +386,18 @@ func init () {
 					op_gl_Enable(expr, fp)
 				case OP_GL_BLEND_FUNC:
 					op_gl_BlendFunc(expr, fp)
+				case OP_GL_STENCIL_FUNC:
+					op_gl_StencilFunc(expr, fp)
+				case OP_GL_STENCIL_OP:
+					op_gl_StencilOp(expr, fp)
 				case OP_GL_DEPTH_FUNC:
 					op_gl_DepthFunc(expr, fp)
 				case OP_GL_GET_ERROR:
 					op_gl_GetError(expr, fp)
 				case OP_GL_GET_TEX_LEVEL_PARAMETERIV:
 					op_gl_GetTexLevelParameteriv(expr, fp)
+				case OP_GL_DEPTH_RANGE:
+					op_gl_DepthRange(expr, fp)
 				case OP_GL_VIEWPORT:
 					op_gl_Viewport(expr, fp)
 
@@ -393,6 +428,12 @@ func init () {
 					op_gl_BufferSubData(expr, fp)
 
 				// gl_2_0
+				case OP_GL_STENCIL_OP_SEPARATE:
+					op_gl_StencilOpSeparate(expr, fp)
+				case OP_GL_STENCIL_FUNC_SEPARATE:
+					op_gl_StencilFuncSeparate(expr, fp)
+				case OP_GL_STENCIL_MASK_SEPARATE:
+					op_gl_StencilMaskSeparate(expr, fp)
 				case OP_GL_ATTACH_SHADER:
 					op_gl_AttachShader(expr, fp)
 				case OP_GL_BIND_ATTRIB_LOCATION:

--- a/vendor/github.com/go-gl/gltext/font.go
+++ b/vendor/github.com/go-gl/gltext/font.go
@@ -148,6 +148,22 @@ func (f *Font) Metrics(text string) (int, int) {
 	return f.advanceSize(text), gh
 }
 
+// GlyphMetrics returns the pixel width and height for the given glyph index.
+// This takes the scale and rendering direction of the font into account.
+//
+// Unknown runes will be counted as having the maximum glyph bounds as
+// defined by Font.GlyphBounds().
+func (f *Font) GlyphMetrics(index uint32) (int, int) {
+
+	gw, gh := f.GlyphBounds()
+	advance := f.config.Glyphs[index].Advance
+	if f.config.Dir == TopToBottom {
+		return gw, advance
+	}
+
+	return advance, gh
+}
+
 // advanceSize computes the pixel width or height for the given single-line
 // input string. This iterates over all of its runes, finds the matching
 // Charset entry and adds up the Advance values.


### PR DESCRIPTION
Additions:
- ogl depth and stencil functions.
- glfw's callbacks can be setup with function declared in any package
- f32.isnan
- gltext functions to render glyph by their index in the font instead of their utf8 code
- callbacks/events workaround (until we have native function objects in cx)