### PR TITLE
Extract all affordances examples from the book

### DIFF
--- a/examples/book/affordances-expression.cx
+++ b/examples/book/affordances-expression.cx
@@ -1,0 +1,34 @@
+package main
+import "aff"
+
+func affIsI32 (arg aff.Argument) (res bool) {
+    if arg.Type == "i32" {
+        res = true
+    }
+}
+
+func main () {
+    var foo i32
+    
+    tgt := #{
+        expr(targetExpr)
+        inp(0)
+    }
+
+    fltrs := #{
+        filter(affIsI32)
+    }
+    
+    elts := aff.query(fltrs)
+
+    aff.of(elts, tgt) // show affordances of the target
+    // aff.on(elts, tgt) // show affordances on the target
+    
+    aff.request(elts, 1, tgt) // execute the second affordance on the target
+    //aff.inform(elts, 1, tgt) // execute the second affordance on the target
+
+targetExpr:
+    foo = i32.add(5, 6)
+
+    i32.print(foo)
+}

--- a/examples/book/affordances-filter.cx
+++ b/examples/book/affordances-filter.cx
@@ -1,0 +1,29 @@
+package main
+import "aff"
+
+func isMainBar (prgrm aff.Program) (res bool) {
+    if prgrm.Caller.FnName == "main.bar" && prgrm.Caller.FnSize == 0 {
+        res = true
+    }
+}
+
+func foo () {
+    fltrs := #{
+      filter(isMainBar)
+    }
+    affs := aff.query(fltrs)
+    if len(affs) < 1 {
+        return
+    }
+
+    str.print(`I will only print if "main.bar" calls me`)
+}
+
+func bar () {
+   foo()
+}
+
+func main () {
+    foo()
+    bar()
+}


### PR DESCRIPTION
This commit adds 2 more CX example files from the affordances chapter.  Both work with the current version of CX..