### PR TITLE
CXProgram.go: Start on making the code more object oriented.

### DIFF
--- a/cx/CXProgram.go
+++ b/cx/CXProgram.go
@@ -1,0 +1,330 @@
+package base
+
+import (
+        . "github.com/satori/go.uuid"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+
+/*
+ * The CXProgram struct contains a full program.
+ *
+ * It is the root data structures for all code, variable and data structures
+ * declarations.
+*/
+
+type CXProgram struct {
+        Packages                        []*CXPackage
+	Memory                          []byte
+	Inputs                          []*CXArgument
+        Outputs                         []*CXArgument
+	CallStack                       []CXCall
+	Path                            string
+        CurrentPackage                  *CXPackage
+	CallCounter                     int
+        HeapPointer                     int
+        StackPointer                    int
+        HeapStartsAt                    int
+	ElementID                       UUID
+        Terminated                      bool
+}
+
+
+func MakeProgram() *CXProgram {
+	newPrgrm := &CXProgram{
+		ElementID: MakeElementID(),
+		Packages:  make([]*CXPackage, 0),
+		CallStack: make([]CXCall, CALLSTACK_SIZE),
+		Memory:    make([]byte, STACK_SIZE + TYPE_POINTER_SIZE + INIT_HEAP_SIZE),
+	}
+
+	return newPrgrm
+}
+
+
+// ----------------------------------------------------------------
+//                             Getters
+
+
+func (prgrm *CXProgram) GetCurrentPackage() (*CXPackage, error) {
+	if prgrm.CurrentPackage != nil {
+		return prgrm.CurrentPackage, nil
+	} else {
+		return nil, errors.New("current package is nil")
+	}
+}
+
+func (prgrm *CXProgram) GetCurrentStruct() (*CXStruct, error) {
+	if prgrm.CurrentPackage != nil {
+		if prgrm.CurrentPackage.CurrentStruct != nil {
+			return prgrm.CurrentPackage.CurrentStruct, nil
+		} else {
+			return nil, errors.New("current struct is nil")
+		}
+	} else {
+		return nil, errors.New("current package is nil")
+	}
+}
+
+func (prgrm *CXProgram) GetCurrentFunction() (*CXFunction, error) {
+	if prgrm.CurrentPackage != nil {
+		 if prgrm.CurrentPackage.CurrentFunction != nil {
+			 return prgrm.CurrentPackage.CurrentFunction, nil
+		 } else {
+			 return nil, errors.New("current function is nil")
+		 }
+	} else {
+		return nil, errors.New("current package is nil")
+	}
+}
+
+func (prgrm *CXProgram) GetCurrentExpression() (*CXExpression, error) {
+	if prgrm.CurrentPackage != nil &&
+		prgrm.CurrentPackage.CurrentFunction != nil &&
+		prgrm.CurrentPackage.CurrentFunction.CurrentExpression != nil {
+		return prgrm.CurrentPackage.CurrentFunction.CurrentExpression, nil
+	} else {
+		return nil, errors.New("current package, function or expression is nil")
+	}
+}
+
+func (prgrm *CXProgram) GetGlobal(name string) (*CXArgument, error) {
+	if mod, err := prgrm.GetCurrentPackage(); err == nil {
+		var found *CXArgument
+		for _, def := range mod.Globals {
+			if def.Name == name {
+				found = def
+				break
+			}
+		}
+
+		for _, imp := range mod.Imports {
+			for _, def := range imp.Globals {
+				if def.Name == name {
+					found = def
+					break
+				}
+			}
+		}
+
+		if found == nil {
+			return nil, fmt.Errorf("global '%s' not found", name)
+		} else {
+			return found, nil
+		}
+	} else {
+		return nil, err
+	}
+}
+
+func (prgrm *CXProgram) GetPackage(modName string) (*CXPackage, error) {
+	if prgrm.Packages != nil {
+		var found *CXPackage
+		for _, mod := range prgrm.Packages {
+			if modName == mod.Name {
+				found = mod
+				break
+			}
+		}
+		if found != nil {
+			return found, nil
+		} else {
+			return nil, fmt.Errorf("package '%s' not found", modName)
+		}
+	} else {
+		return nil, fmt.Errorf("package '%s' not found", modName)
+	}
+}
+
+func (prgrm *CXProgram) GetStruct(strctName string, modName string) (*CXStruct, error) {
+	var foundPkg *CXPackage
+	for _, mod := range prgrm.Packages {
+		if modName == mod.Name {
+
+			foundPkg = mod
+			break
+		}
+	}
+	
+	var foundStrct *CXStruct
+	
+	for _, strct := range foundPkg.Structs {
+		if strct.Name == strctName {
+			foundStrct = strct
+			break
+		}
+	}
+
+	if foundStrct == nil {
+		//looking in imports
+		typParts := strings.Split(strctName, ".")
+
+		if mod, err := prgrm.GetPackage(modName); err == nil {
+			for _, imp := range mod.Imports {
+				for _, strct := range imp.Structs {
+					if strct.Name == typParts[0] {
+						foundStrct = strct
+						break
+					}
+				}
+			}
+		}
+	}
+
+	if foundPkg != nil && foundStrct != nil {
+		return foundStrct, nil
+	} else {
+		return nil, fmt.Errorf("struct '%s' not found in package '%s'", strctName, modName)
+	}
+}
+
+func (prgrm *CXProgram) GetFunction (fnName string, pkgName string) (*CXFunction, error) {
+	// I need to first look for the function in the current package
+	if pkg, err := prgrm.GetCurrentPackage(); err == nil {
+		for _, fn := range pkg.Functions {
+			if fn.Name == fnName {
+				return fn, nil
+			}
+		}
+	}
+
+	var foundPkg *CXPackage
+	for _, pkg := range prgrm.Packages {
+		if pkgName == pkg.Name {
+			foundPkg = pkg
+			break
+		}
+	}
+
+	var foundFn *CXFunction
+	if foundPkg != nil {
+		for _, fn := range foundPkg.Functions {
+			if fn.Name == fnName {
+				foundFn = fn
+				break
+			}
+		}
+	} else {
+		return nil, fmt.Errorf("package '%s' not found", pkgName)
+	}
+
+	if foundPkg != nil && foundFn != nil {
+		return foundFn, nil
+	} else {
+		return nil, fmt.Errorf("function '%s' not found in package '%s'", fnName, pkgName)
+	}
+}
+
+
+// ----------------------------------------------------------------
+//                         Package handling
+
+
+func (prgrm *CXProgram) AddPackage(mod *CXPackage) *CXProgram {
+	found := false
+	for _, md := range prgrm.Packages {
+		if md.Name == mod.Name {
+			prgrm.CurrentPackage = md
+			found = true
+			break
+		}
+	}
+	if !found {
+		prgrm.Packages = append(prgrm.Packages, mod)
+		prgrm.CurrentPackage = mod
+	}
+	return prgrm
+}
+
+func (prgrm *CXProgram) RemovePackage(modName string) {
+	lenMods := len(prgrm.Packages)
+	for i, mod := range prgrm.Packages {
+		if mod.Name == modName {
+			if i == lenMods-1 {
+				prgrm.Packages = prgrm.Packages[:len(prgrm.Packages)-1]
+			} else {
+				prgrm.Packages = append(prgrm.Packages[:i], prgrm.Packages[i+1:]...)
+			}
+			break
+		}
+	}
+}
+
+
+// ----------------------------------------------------------------
+//                             Selectors
+
+
+func (cxt *CXProgram) SelectPackage(name string) (*CXPackage, error) {
+	// prgrmStep := &CXProgramStep{
+	// 	Action: func(cxt *CXProgram) {
+	// 		cxt.SelectPackage(name)
+	// 	},
+	// }
+	// saveProgramStep(prgrmStep, cxt)
+
+	var found *CXPackage
+	for _, mod := range cxt.Packages {
+		if mod.Name == name {
+			cxt.CurrentPackage = mod
+			found = mod
+		}
+	}
+
+	if found == nil {
+		return nil, fmt.Errorf("Package '%s' does not exist", name)
+	}
+
+	return found, nil
+}
+
+func (cxt *CXProgram) SelectFunction(name string) (*CXFunction, error) {
+	// prgrmStep := &CXProgramStep{
+	// 	Action: func(cxt *CXProgram) {
+	// 		cxt.SelectFunction(name)
+	// 	},
+	// }
+	// saveProgramStep(prgrmStep, cxt)
+
+	mod, err := cxt.GetCurrentPackage()
+	if err == nil {
+		return mod.SelectFunction(name)
+	} else {
+		return nil, err
+	}
+}
+
+func (cxt *CXProgram) SelectStruct(name string) (*CXStruct, error) {
+	// prgrmStep := &CXProgramStep{
+	// 	Action: func(cxt *CXProgram) {
+	// 		cxt.SelectStruct(name)
+	// 	},
+	// }
+	// saveProgramStep(prgrmStep, cxt)
+
+	mod, err := cxt.GetCurrentPackage()
+	if err == nil {
+		return mod.SelectStruct(name)
+	} else {
+		return nil, err
+	}
+}
+
+func (cxt *CXProgram) SelectExpression(line int) (*CXExpression, error) {
+	// prgrmStep := &CXProgramStep{
+	// 	Action: func(cxt *CXProgram) {
+	// 		cxt.SelectExpression(line)
+	// 	},
+	// }
+	// saveProgramStep(prgrmStep, cxt)
+
+	mod, err := cxt.GetCurrentPackage()
+	if err == nil {
+		return mod.SelectExpression(line)
+	} else {
+		return nil, err
+	}
+}
+

--- a/cx/adders.go
+++ b/cx/adders.go
@@ -5,22 +5,6 @@ import (
 	// "github.com/skycoin/skycoin/src/cipher/encoder"
 )
 
-func (prgrm *CXProgram) AddPackage(mod *CXPackage) *CXProgram {
-	found := false
-	for _, md := range prgrm.Packages {
-		if md.Name == mod.Name {
-			prgrm.CurrentPackage = md
-			found = true
-			break
-		}
-	}
-	if !found {
-		prgrm.Packages = append(prgrm.Packages, mod)
-		prgrm.CurrentPackage = mod
-	}
-	return prgrm
-}
-
 func (mod *CXPackage) AddGlobal (def *CXArgument) *CXPackage {
 	// def.Program = mod.Program
 	def.Package = mod

--- a/cx/getters.go
+++ b/cx/getters.go
@@ -6,14 +6,6 @@ import (
 	"strings"
 )
 
-func (prgrm *CXProgram) GetCurrentPackage() (*CXPackage, error) {
-	if prgrm.CurrentPackage != nil {
-		return prgrm.CurrentPackage, nil
-	} else {
-		return nil, errors.New("current package is nil")
-	}
-}
-
 func (pkg *CXPackage) GetImport(impName string) (*CXPackage, error) {
 	for _, imp := range pkg.Imports {
 		if imp.Name == impName {
@@ -21,18 +13,6 @@ func (pkg *CXPackage) GetImport(impName string) (*CXPackage, error) {
 		}
 	}
 	return nil, fmt.Errorf("package '%s' not imported", impName)
-}
-
-func (prgrm *CXProgram) GetCurrentStruct() (*CXStruct, error) {
-	if prgrm.CurrentPackage != nil {
-		if prgrm.CurrentPackage.CurrentStruct != nil {
-			return prgrm.CurrentPackage.CurrentStruct, nil
-		} else {
-			return nil, errors.New("current struct is nil")
-		}
-	} else {
-		return nil, errors.New("current package is nil")
-	}
 }
 
 func (mod *CXPackage) GetCurrentStruct() (*CXStruct, error) {
@@ -44,33 +24,11 @@ func (mod *CXPackage) GetCurrentStruct() (*CXStruct, error) {
 
 }
 
-func (prgrm *CXProgram) GetCurrentFunction() (*CXFunction, error) {
-	if prgrm.CurrentPackage != nil {
-		 if prgrm.CurrentPackage.CurrentFunction != nil {
-			 return prgrm.CurrentPackage.CurrentFunction, nil
-		 } else {
-			 return nil, errors.New("current function is nil")
-		 }
-	} else {
-		return nil, errors.New("current package is nil")
-	}
-}
-
 func (mod *CXPackage) GetCurrentFunction() (*CXFunction, error) {
 	if mod.CurrentFunction != nil {
 		return mod.CurrentFunction, nil
 	} else {
 		return nil, errors.New("current function is nil")
-	}
-}
-
-func (prgrm *CXProgram) GetCurrentExpression() (*CXExpression, error) {
-	if prgrm.CurrentPackage != nil &&
-		prgrm.CurrentPackage.CurrentFunction != nil &&
-		prgrm.CurrentPackage.CurrentFunction.CurrentExpression != nil {
-		return prgrm.CurrentPackage.CurrentFunction.CurrentExpression, nil
-	} else {
-		return nil, errors.New("current package, function or expression is nil")
 	}
 }
 
@@ -81,35 +39,6 @@ func (fn *CXFunction) GetCurrentExpression() (*CXExpression, error) {
 		return fn.Expressions[0], nil
 	} else {
 		return nil, errors.New("current expression is nil")
-	}
-}
-
-func (prgrm *CXProgram) GetGlobal(name string) (*CXArgument, error) {
-	if mod, err := prgrm.GetCurrentPackage(); err == nil {
-		var found *CXArgument
-		for _, def := range mod.Globals {
-			if def.Name == name {
-				found = def
-				break
-			}
-		}
-
-		for _, imp := range mod.Imports {
-			for _, def := range imp.Globals {
-				if def.Name == name {
-					found = def
-					break
-				}
-			}
-		}
-
-		if found == nil {
-			return nil, fmt.Errorf("global '%s' not found", name)
-		} else {
-			return found, nil
-		}
-	} else {
-		return nil, err
 	}
 }
 
@@ -139,25 +68,6 @@ func (mod *CXPackage) GetFunctions() ([]*CXFunction, error) {
 	}
 }
 
-func (prgrm *CXProgram) GetPackage(modName string) (*CXPackage, error) {
-	if prgrm.Packages != nil {
-		var found *CXPackage
-		for _, mod := range prgrm.Packages {
-			if modName == mod.Name {
-				found = mod
-				break
-			}
-		}
-		if found != nil {
-			return found, nil
-		} else {
-			return nil, fmt.Errorf("package '%s' not found", modName)
-		}
-	} else {
-		return nil, fmt.Errorf("package '%s' not found", modName)
-	}
-}
-
 func (pkg *CXPackage) GetStruct(strctName string) (*CXStruct, error) {
 	var foundStrct *CXStruct
 	for _, strct := range pkg.Structs {
@@ -183,48 +93,6 @@ func (pkg *CXPackage) GetStruct(strctName string) (*CXStruct, error) {
 		return foundStrct, nil
 	} else {
 		return nil, fmt.Errorf("struct '%s' not found in package '%s'", strctName, pkg.Name)
-	}
-}
-
-func (prgrm *CXProgram) GetStruct(strctName string, modName string) (*CXStruct, error) {
-	var foundPkg *CXPackage
-	for _, mod := range prgrm.Packages {
-		if modName == mod.Name {
-
-			foundPkg = mod
-			break
-		}
-	}
-	
-	var foundStrct *CXStruct
-	
-	for _, strct := range foundPkg.Structs {
-		if strct.Name == strctName {
-			foundStrct = strct
-			break
-		}
-	}
-
-	if foundStrct == nil {
-		//looking in imports
-		typParts := strings.Split(strctName, ".")
-
-		if mod, err := prgrm.GetPackage(modName); err == nil {
-			for _, imp := range mod.Imports {
-				for _, strct := range imp.Structs {
-					if strct.Name == typParts[0] {
-						foundStrct = strct
-						break
-					}
-				}
-			}
-		}
-	}
-
-	if foundPkg != nil && foundStrct != nil {
-		return foundStrct, nil
-	} else {
-		return nil, fmt.Errorf("struct '%s' not found in package '%s'", strctName, modName)
 	}
 }
 
@@ -283,43 +151,6 @@ func (pkg *CXPackage) GetMethod (fnName string, receiverType string) (*CXFunctio
 	}
 	
 	return nil, fmt.Errorf("method '%s' not found in package '%s'", fnName, pkg.Name)
-}
-
-func (prgrm *CXProgram) GetFunction (fnName string, pkgName string) (*CXFunction, error) {
-	// I need to first look for the function in the current package
-	if pkg, err := prgrm.GetCurrentPackage(); err == nil {
-		for _, fn := range pkg.Functions {
-			if fn.Name == fnName {
-				return fn, nil
-			}
-		}
-	}
-
-	var foundPkg *CXPackage
-	for _, pkg := range prgrm.Packages {
-		if pkgName == pkg.Name {
-			foundPkg = pkg
-			break
-		}
-	}
-
-	var foundFn *CXFunction
-	if foundPkg != nil {
-		for _, fn := range foundPkg.Functions {
-			if fn.Name == fnName {
-				foundFn = fn
-				break
-			}
-		}
-	} else {
-		return nil, fmt.Errorf("package '%s' not found", pkgName)
-	}
-
-	if foundPkg != nil && foundFn != nil {
-		return foundFn, nil
-	} else {
-		return nil, fmt.Errorf("function '%s' not found in package '%s'", fnName, pkgName)
-	}
 }
 
 func (fn *CXFunction) GetExpressions () ([]*CXExpression, error) {

--- a/cx/makers.go
+++ b/cx/makers.go
@@ -20,17 +20,6 @@ func MakeGenSym(name string) string {
 	return gensym
 }
 
-func MakeProgram() *CXProgram {
-	newPrgrm := &CXProgram{
-		ElementID: MakeElementID(),
-		Packages:  make([]*CXPackage, 0),
-		CallStack: make([]CXCall, CALLSTACK_SIZE),
-		Memory:    make([]byte, STACK_SIZE + TYPE_POINTER_SIZE + INIT_HEAP_SIZE),
-	}
-
-	return newPrgrm
-}
-
 func MakePackage(name string) *CXPackage {
 	return &CXPackage{
 		ElementID: MakeElementID(),

--- a/cx/removers.go
+++ b/cx/removers.go
@@ -2,20 +2,6 @@ package base
 
 import ()
 
-func (prgrm *CXProgram) RemovePackage(modName string) {
-	lenMods := len(prgrm.Packages)
-	for i, mod := range prgrm.Packages {
-		if mod.Name == modName {
-			if i == lenMods-1 {
-				prgrm.Packages = prgrm.Packages[:len(prgrm.Packages)-1]
-			} else {
-				prgrm.Packages = append(prgrm.Packages[:i], prgrm.Packages[i+1:]...)
-			}
-			break
-		}
-	}
-}
-
 func (mod *CXPackage) RemoveGlobal(defName string) {
 	lenGlobals := len(mod.Globals)
 	for i, def := range mod.Globals {

--- a/cx/selectors.go
+++ b/cx/selectors.go
@@ -5,45 +5,6 @@ import (
 	"fmt"
 )
 
-func (cxt *CXProgram) SelectPackage(name string) (*CXPackage, error) {
-	// prgrmStep := &CXProgramStep{
-	// 	Action: func(cxt *CXProgram) {
-	// 		cxt.SelectPackage(name)
-	// 	},
-	// }
-	// saveProgramStep(prgrmStep, cxt)
-
-	var found *CXPackage
-	for _, mod := range cxt.Packages {
-		if mod.Name == name {
-			cxt.CurrentPackage = mod
-			found = mod
-		}
-	}
-
-	if found == nil {
-		return nil, fmt.Errorf("Package '%s' does not exist", name)
-	}
-
-	return found, nil
-}
-
-func (cxt *CXProgram) SelectFunction(name string) (*CXFunction, error) {
-	// prgrmStep := &CXProgramStep{
-	// 	Action: func(cxt *CXProgram) {
-	// 		cxt.SelectFunction(name)
-	// 	},
-	// }
-	// saveProgramStep(prgrmStep, cxt)
-
-	mod, err := cxt.GetCurrentPackage()
-	if err == nil {
-		return mod.SelectFunction(name)
-	} else {
-		return nil, err
-	}
-}
-
 func (mod *CXPackage) SelectFunction(name string) (*CXFunction, error) {
 	// prgrmStep := &CXProgramStep{
 	// 	Action: func(cxt *CXProgram) {
@@ -70,22 +31,6 @@ func (mod *CXPackage) SelectFunction(name string) (*CXFunction, error) {
 	return found, nil
 }
 
-func (cxt *CXProgram) SelectStruct(name string) (*CXStruct, error) {
-	// prgrmStep := &CXProgramStep{
-	// 	Action: func(cxt *CXProgram) {
-	// 		cxt.SelectStruct(name)
-	// 	},
-	// }
-	// saveProgramStep(prgrmStep, cxt)
-
-	mod, err := cxt.GetCurrentPackage()
-	if err == nil {
-		return mod.SelectStruct(name)
-	} else {
-		return nil, err
-	}
-}
-
 func (mod *CXPackage) SelectStruct(name string) (*CXStruct, error) {
 	// prgrmStep := &CXProgramStep{
 	// 	Action: func(cxt *CXProgram) {
@@ -109,22 +54,6 @@ func (mod *CXPackage) SelectStruct(name string) (*CXStruct, error) {
 	}
 
 	return found, nil
-}
-
-func (cxt *CXProgram) SelectExpression(line int) (*CXExpression, error) {
-	// prgrmStep := &CXProgramStep{
-	// 	Action: func(cxt *CXProgram) {
-	// 		cxt.SelectExpression(line)
-	// 	},
-	// }
-	// saveProgramStep(prgrmStep, cxt)
-
-	mod, err := cxt.GetCurrentPackage()
-	if err == nil {
-		return mod.SelectExpression(line)
-	} else {
-		return nil, err
-	}
 }
 
 func (mod *CXPackage) SelectExpression(line int) (*CXExpression, error) {

--- a/cx/structs.go
+++ b/cx/structs.go
@@ -4,26 +4,6 @@ import (
         . "github.com/satori/go.uuid"
 )
 
-/*
-  Root Program
-*/
-
-type CXProgram struct {
-        Packages                        []*CXPackage
-	Memory                          []byte
-	Inputs                          []*CXArgument
-        Outputs                         []*CXArgument
-	CallStack                       []CXCall
-	Path                            string
-        CurrentPackage                  *CXPackage
-	CallCounter                     int
-        HeapPointer                     int
-        StackPointer                    int
-        HeapStartsAt                    int
-	ElementID                       UUID
-        Terminated                      bool
-}
-
 type CXCall struct {
         Operator                        *CXFunction
         Line                            int

--- a/cxgo/actions/declarations.go
+++ b/cxgo/actions/declarations.go
@@ -4,7 +4,8 @@ import (
 	. "github.com/skycoin/cx/cx"
 )
 
-func DeclareGlobal(declarator *CXArgument, declaration_specifiers *CXArgument, initializer []*CXExpression, doesInitialize bool) {
+func DeclareGlobal(declarator *CXArgument, declaration_specifiers *CXArgument,
+                   initializer []*CXExpression, doesInitialize bool) {
 	if pkg, err := PRGRM.GetCurrentPackage(); err == nil {
 		declaration_specifiers.Package = pkg
 		
@@ -15,9 +16,11 @@ func DeclareGlobal(declarator *CXArgument, declaration_specifiers *CXArgument, i
 				// then it was only added a reference to the symbol
 				var offExpr []*CXExpression
 				if declaration_specifiers.IsSlice {
-					offExpr = WritePrimary(declaration_specifiers.Type, make([]byte, declaration_specifiers.Size), true)
+					offExpr = WritePrimary(declaration_specifiers.Type,
+							       make([]byte, declaration_specifiers.Size), true)
 				} else {
-					offExpr = WritePrimary(declaration_specifiers.Type, make([]byte, declaration_specifiers.TotalSize), true)
+					offExpr = WritePrimary(declaration_specifiers.Type,
+							       make([]byte, declaration_specifiers.TotalSize), true)
 				}
 
 				glbl.Offset = offExpr[0].Outputs[0].Offset


### PR DESCRIPTION
This commit extracts the definition of and all methods on the struct CXProgram
into a new file called CXProgram.go.

This is a first commit in a series that aims at making CX implemented in a
amore object oriented fashion.

The commit does not touch serialization, execution or affordances.  Those may
be later, after we have had some discussion about it.

Note that I have tried to install my version of CX and run the tests, but I suspect that the cx.sh script is not adapted to working in a fork of the skycoin/cx repository.  I suspect that the script actually installs the original CX from skycoin.cx instead of, in my case, ingwal/cx.  Can the cx.sh script be adapted to handle this?