### PR TITLE
fixes #162 - Build status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # CX Programming Language
 
-[![Build Status](https://travis-ci.org/skycoin/cx.svg?branch=master)](https://travis-ci.org/skycoin/cx) [![Build status](https://ci.appveyor.com/api/projects/status/8o4bf71mwett6ib4/branch/stdevYuniers_t13_ci_in_appveyor_for_windows?svg=true)](https://ci.appveyor.com/project/stdevYuniers/cx/branch/stdevYuniers_t13_ci_in_appveyor_for_windows)
+[![Build Status](https://travis-ci.com/skycoin/cx.svg?branch=develop)](https://travis-ci.com/skycoin/cx) [![Build status](https://ci.appveyor.com/api/projects/status/y04pofhhfmpw8vef/branch/master?svg=true)](https://ci.appveyor.com/project/skycoin/cx/branch/master)
 
 CX is a general purpose, interpreted and compiled programming
 language, with a very strict type system and a syntax


### PR DESCRIPTION
Fixes #162

Changes:
- Appveyor build status badge for master branch
- Travis build status badge for master branch

Does this change need to mentioned in CHANGELOG.md?
no