### PR TITLE
fixes #175 - Refactor argument parsing

### DIFF
--- a/cxgo/cxgo.nex
+++ b/cxgo/cxgo.nex
@@ -602,11 +602,6 @@ func main () {
     return
   }
   if options.newProject {
-		if arg == "--pw" || arg == "-pw" {
-			WebPersistantMode = true
-			flagMode = true
-			continue
-		}
     initNewProject()
     return
   }
@@ -629,7 +624,7 @@ func main () {
 		return
 	}
 
-	if WebPersistantMode {
+	if options.webPersistantMode {
 		go ServiceMode()
 		PersistantServiceMode()
 		return

--- a/cxgo/cxgo.nex
+++ b/cxgo/cxgo.nex
@@ -201,7 +201,7 @@ import (
 
 	"regexp"
 	
-	// "flag"
+	"flag"
 
 	"path/filepath"
 
@@ -409,30 +409,6 @@ func IdeServiceMode() {
 	cmnd.Start()
 }
 
-func help () {
-	fmt.Printf(`Usage: cx [options] [source-files]
-
-CX options:
--b, --base                        Generate a "out.cx.go" file with the transcompiled CX Base source code.
--c, --compile                     Generate a "out" executable file of the program.
--co, --compile-output FILENAME    Specifies the filename for the generated executable.
--h, --help                        Prints this message.
--n, --new                         Creates a new project located at $CXPATH/src
--r, --repl                        Loads source files into memory and starts a read-eval-print loop.
--w, --web                         Start CX as a web service.
--ide, --ide						  Start CX as a web service, and Leaps service start also.
-
-Signal options:
--signal-client                   Run signal client
--signal-client-id UINT           Id of signal client (default 1)
--signal-server-address STRING    Address of signal server (default "localhost:7999")
-
-Notes:
-* Options --compile and --repl are mutually exclusive.
-* Option --web makes every other flag to be ignored.
-`)
-}
-
 func (yylex Lexer) Error (e string) {
 	// if InREPL {
 	// 	fmt.Printf("syntax error: %s\n", e)
@@ -564,7 +540,7 @@ func addInitFunction (PRGRM *CXProgram) {
 		PRGRM.SelectFunction(MAIN_FUNC)
 	} else {
 		panic(err)
-	}
+}
 }
 
 func main () {
@@ -573,152 +549,44 @@ func main () {
 	runtime.LockOSThread()
 	runtime.GOMAXPROCS(2)
 
-	args := os.Args[1:]
-	var sourceCode []*os.File
-	var fileNames []string
+  options := defaultCmdFlags()
+	compileOutput := "o"
 
-	if len(args) == 0 {
-		ReplMode = true
-	}
+  registerFlags(&options)
+  flag.Parse()
 
-	cxArgs := []string{}
-	flagMode := false
-	newProject := false
-	var compileOutput string = "o"
-	for i, arg := range args {
-		if arg == "--version" || arg == "-v" {
-			fmt.Println("CX version", VERSION)
-			return
-		}
-		if arg == "--new" || arg == "-n" {
-			flagMode = false
-			newProject = true
-		}
-		if arg == "--web" || arg == "-w" {
-			WebMode = true
-			flagMode = true
-			continue
-		}
-		if arg == "--ide" || arg == "-ide" {
-			IdeMode = true
-			flagMode = true
-			continue
-		}
-		if arg == "--repl" || arg == "-r" {
-			ReplMode = true
-			flagMode = true
-			continue
-		}
-		if arg == "--base" || arg == "-b" {
-			BaseOutput = true
-			flagMode = true
-			continue
-		}
-		if arg == "--interpret" || arg == "-i" {
-			InterpretMode = true
-			flagMode = true
-			continue
-		}
-		if arg == "--compile" || arg == "-c" {
-			CompileMode = true
-			BaseOutput = true
-			flagMode = true
-			continue
-		}
-		if arg == "--compile-output" || arg == "-co" {
-			compileOutput = args[i+1]
-			continue
-		}
-		if arg == "--help" || arg == "-h" {
-			HelpMode = true
-			flagMode = true
-			continue
-		}
-		if len(arg) > 2 && arg[0:2] == "++" {
-		   cxArgs = append(cxArgs, arg)
-			continue
-		}
-		// viscript options
-		if arg == "-signal-client" || arg == "-signal-client-id" || arg == "-signal-server-address" {
-			continue
-		}
-		if i > 0 && (args[i-1] == "-signal-client-id" || args[i-1] == "-signal-server-address") {
-			continue
-		}
-		if newProject {
-			initNewProject()
-			return
-		}
-		if !flagMode {
+  if options.printHelp {
+    printHelp()
+    return
+  }
+  if options.printVersion {
+    printVersion()
+    return
+  }
+  if options.newProject {
+    initNewProject()
+    return
+  }
+  if options.compileMode {
+    options.baseOutput = true
+  }
 
-			fi, err := os.Stat(arg)
-			_ = err
-
-			if err != nil {
-				panic(err)
-			}
-			
-			switch mode := fi.Mode(); {
-			case mode.IsDir():
-				var fileList []string
-
-				err := filepath.Walk(arg, func(path string, f os.FileInfo, err error) error {
-					fileList = append(fileList, path)
-					return nil
-				})
-
-				if err != nil {
-					panic(err)
-				}
-
-				for _, path := range fileList {
-					file, err := os.Open(path)
-					
-					if err != nil {
-						panic(err)
-					}
-
-					fiName := file.Name()
-					fiNameLen := len(fiName)
-					
-					if fiNameLen > 2 && fiName[fiNameLen - 3:] == ".cx" {
-						// only loading .cx files
-						sourceCode = append(sourceCode, file)
-						fileNames = append(fileNames, fiName)
-					}
-				}
-			case mode.IsRegular():
-				file, err := os.Open(arg)
-				
-				if err != nil {
-					panic(err)
-				}
-
-				fileNames = append(fileNames, file.Name())
-				sourceCode = append(sourceCode, file)
-			}
-		}
-	}
+  cxArgs, sourceCode, fileNames := parseArgsForCX(flag.Args())
 
 	PRGRM = MakeProgram()
 
-	if HelpMode {
-		help()
-		return
-	}
-
-	if WebMode {
+	if options.webMode {
 		ServiceMode()
 		return
 	}
 
-	if IdeMode {
+	if options.ideMode {
 		IdeServiceMode()
 		ServiceMode()
 		return
 	}
 
-	if CompileMode && ReplMode {
+	if options.compileMode && options.replMode {
 		fmt.Println("Error: Options --compile and --repl are mutually exclusive.")
 		return
 	}
@@ -726,7 +594,7 @@ func main () {
 	cxgo0.PRGRM0 = PRGRM
 
 	// setting project's working directory
-	if !ReplMode {
+	if !options.replMode {
 		cxgo0.PRGRM0.Path = getWorkingDirectory(sourceCode[0].Name())
 	}
 

--- a/cxgo/flags.go
+++ b/cxgo/flags.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"flag"
+	"os"
+)
+
+type cxCmdFlags struct {
+	baseOutput          bool
+	compileMode         bool
+	compileOutput       string
+	initProject         bool
+	replMode            bool
+	signalClientMode    bool
+	signalClientID      int
+	signalServerAddress string
+	webMode             bool
+	ideMode             bool
+	flagMode            bool
+	printHelp           bool
+	printVersion        bool
+	interpretMode       bool
+}
+
+func defaultCmdFlags() cxCmdOptions {
+	return cxCmdFlags{
+		baseOutput:          false,
+		compileMode:         false,
+		compileOutput:       "",
+		newProject:          false,
+		replMode:            false,
+		signalClientMode:    false,
+		signalClientID:      1,
+		signalServerAddress: "localhost:7999",
+		webMode:             false,
+		ideMode:             false,
+		printHelp:           false,
+		printVersion:        false,
+		interpretMode:       false,
+	}
+}
+
+func registerFlags(options *cxCmdFlags) {
+	args := os.Args
+	if len(args) <= 1 {
+		options.replMode = true
+	}
+
+	flag.BoolVar(&printVersion, "version", printVersion, "Print CX version")
+	flag.BoolVar(&printVersion, "v", printVersion, "alias for -version")
+	flag.BoolVar(&printHelp, "help", printHelp, "Print CX version")
+	flag.BoolVar(&printHelp, "h", printHelp, "alias for -help")
+	flag.BoolVar(&options.baseOutput, "base", options.baseOutput, "generate a 'out.cx.go' file with the transcompiled CX Base source code.")
+	flag.BoolVar(&options.baseOutput, "b", options.baseOutput, "alias for -base")
+	flag.BoolVar(&options.compileMode, "compile", options.compileMode, "generate a 'out' executable file of the program")
+	flag.BoolVar(&options.compileMode, "c", options.compileMode, "alias for -compile")
+	flag.BoolVar(&options.compileOutput, "compile-output", options.compileOutput, "Specifies the filename for the generated executable.")
+	flag.StringVar(&options.compileOutput, "co", options.compileOutput, "alias for -compile-output")
+	flag.BoolVar(&options.initProject, "new", options.initProject, "Creates a new project located at $CXPATH/src")
+	flag.BoolVar(&options.initProject, "n", options.initProject, "alias for -new")
+	flag.BoolVar(&options.replMode, "repl", options.replMode, "Loads source files into memory and starts a read-eval-print loop")
+	flag.BoolVar(&options.replMode, "r", options.replMode, "alias for -repl")
+	flag.BoolVar(&options.webMode, "web", options.webMode, "Start CX as a web service.")
+	flag.BoolVar(&options.webMode, "w", options.webMode, "alias for -web")
+	flag.BoolVar(&options.ideMode, "ide", options.ideMode, "Start CX as a web service, and Leaps service start also.")
+	// viscript options
+	flag.BoolVar(&options.signalClientMode, "signal-client", options.signalClientMode, "Run signal client")
+	flag.IntVar(&options.signalClientID, "signal-client-id", options.signalClientID, "Id of signal client (default 1)")
+	flag.StringVar(&options.signalSeverAddress, "signal-client-address", options.signalSeverAddress, "Address of signal server (default 'localhost:7999')")
+}
+
+func printHelp() {
+	fmt.Printf(`Usage: cx [options] [source-files]
+
+CX options:
+-b, --base                        Generate a "out.cx.go" file with the transcompiled CX Base source code.
+-c, --compile                     Generate a "out" executable file of the program.
+-co, --compile-output FILENAME    Specifies the filename for the generated executable.
+-h, --help                        Prints this message.
+-n, --new                         Creates a new project located at $CXPATH/src
+-r, --repl                        Loads source files into memory and starts a read-eval-print loop.
+-w, --web                         Start CX as a web service.
+-ide, --ide						  Start CX as a web service, and Leaps service start also.
+
+Signal options:
+-signal-client                   Run signal client
+-signal-client-id UINT           Id of signal client (default 1)
+-signal-server-address STRING    Address of signal server (default "localhost:7999")
+
+Notes:
+* Options --compile and --repl are mutually exclusive.
+* Option --web makes every other flag to be ignored.
+`)
+}
+
+func parseArgsForCX(args []string) (cxArgs []string, sourceCode []*os.File, fileNames []string) {
+	for i, arg := range args {
+		if len(arg) > 2 && arg[:2] == "++" {
+			cxArgs = append(cxArgs, arg)
+			continue
+		}
+		if !flagMode {
+
+			fi, err := os.Stat(arg)
+			_ = err
+
+			if err != nil {
+				panic(err)
+			}
+
+			switch mode := fi.Mode(); {
+			case mode.IsDir():
+				var fileList []string
+
+				err := filepath.Walk(arg, func(path string, f os.FileInfo, err error) error {
+					fileList = append(fileList, path)
+					return nil
+				})
+
+				if err != nil {
+					panic(err)
+				}
+
+				for _, path := range fileList {
+					file, err := os.Open(path)
+
+					if err != nil {
+						panic(err)
+					}
+
+					fiName := file.Name()
+					fiNameLen := len(fiName)
+
+					if fiNameLen > 2 && fiName[fiNameLen-3:] == ".cx" {
+						// only loading .cx files
+						sourceCode = append(sourceCode, file)
+						fileNames = append(fileNames, fiName)
+					}
+				}
+			case mode.IsRegular():
+				file, err := os.Open(arg)
+
+				if err != nil {
+					panic(err)
+				}
+
+				fileNames = append(fileNames, file.Name())
+				sourceCode = append(sourceCode, file)
+			}
+		}
+	}
+}
+
+func printVersion() {
+	fmt.Println("CX version", VERSION)
+}
+
+func parseCxArgs(args []string) {
+	a
+}

--- a/cxgo/flags.go
+++ b/cxgo/flags.go
@@ -2,14 +2,16 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"path/filepath"
 )
 
 type cxCmdFlags struct {
 	baseOutput          bool
 	compileMode         bool
 	compileOutput       string
-	initProject         bool
+	newProject          bool
 	replMode            bool
 	signalClientMode    bool
 	signalClientID      int
@@ -22,7 +24,7 @@ type cxCmdFlags struct {
 	interpretMode       bool
 }
 
-func defaultCmdFlags() cxCmdOptions {
+func defaultCmdFlags() cxCmdFlags {
 	return cxCmdFlags{
 		baseOutput:          false,
 		compileMode:         false,
@@ -46,18 +48,18 @@ func registerFlags(options *cxCmdFlags) {
 		options.replMode = true
 	}
 
-	flag.BoolVar(&printVersion, "version", printVersion, "Print CX version")
-	flag.BoolVar(&printVersion, "v", printVersion, "alias for -version")
-	flag.BoolVar(&printHelp, "help", printHelp, "Print CX version")
-	flag.BoolVar(&printHelp, "h", printHelp, "alias for -help")
+	flag.BoolVar(&options.printVersion, "version", options.printVersion, "Print CX version")
+	flag.BoolVar(&options.printVersion, "v", options.printVersion, "alias for -version")
+	flag.BoolVar(&options.printHelp, "help", options.printHelp, "Print CX version")
+	flag.BoolVar(&options.printHelp, "h", options.printHelp, "alias for -help")
 	flag.BoolVar(&options.baseOutput, "base", options.baseOutput, "generate a 'out.cx.go' file with the transcompiled CX Base source code.")
 	flag.BoolVar(&options.baseOutput, "b", options.baseOutput, "alias for -base")
 	flag.BoolVar(&options.compileMode, "compile", options.compileMode, "generate a 'out' executable file of the program")
 	flag.BoolVar(&options.compileMode, "c", options.compileMode, "alias for -compile")
-	flag.BoolVar(&options.compileOutput, "compile-output", options.compileOutput, "Specifies the filename for the generated executable.")
+	flag.StringVar(&options.compileOutput, "compile-output", options.compileOutput, "Specifies the filename for the generated executable.")
 	flag.StringVar(&options.compileOutput, "co", options.compileOutput, "alias for -compile-output")
-	flag.BoolVar(&options.initProject, "new", options.initProject, "Creates a new project located at $CXPATH/src")
-	flag.BoolVar(&options.initProject, "n", options.initProject, "alias for -new")
+	flag.BoolVar(&options.newProject, "new", options.newProject, "Creates a new project located at $CXPATH/src")
+	flag.BoolVar(&options.newProject, "n", options.newProject, "alias for -new")
 	flag.BoolVar(&options.replMode, "repl", options.replMode, "Loads source files into memory and starts a read-eval-print loop")
 	flag.BoolVar(&options.replMode, "r", options.replMode, "alias for -repl")
 	flag.BoolVar(&options.webMode, "web", options.webMode, "Start CX as a web service.")
@@ -66,7 +68,7 @@ func registerFlags(options *cxCmdFlags) {
 	// viscript options
 	flag.BoolVar(&options.signalClientMode, "signal-client", options.signalClientMode, "Run signal client")
 	flag.IntVar(&options.signalClientID, "signal-client-id", options.signalClientID, "Id of signal client (default 1)")
-	flag.StringVar(&options.signalSeverAddress, "signal-client-address", options.signalSeverAddress, "Address of signal server (default 'localhost:7999')")
+	flag.StringVar(&options.signalServerAddress, "signal-client-address", options.signalServerAddress, "Address of signal server (default 'localhost:7999')")
 }
 
 func printHelp() {
@@ -94,67 +96,61 @@ Notes:
 }
 
 func parseArgsForCX(args []string) (cxArgs []string, sourceCode []*os.File, fileNames []string) {
-	for i, arg := range args {
+	for _, arg := range args {
 		if len(arg) > 2 && arg[:2] == "++" {
 			cxArgs = append(cxArgs, arg)
 			continue
 		}
-		if !flagMode {
+		fi, err := os.Stat(arg)
+		_ = err
 
-			fi, err := os.Stat(arg)
-			_ = err
+		if err != nil {
+			panic(err)
+		}
+
+		switch mode := fi.Mode(); {
+		case mode.IsDir():
+			var fileList []string
+
+			err := filepath.Walk(arg, func(path string, f os.FileInfo, err error) error {
+				fileList = append(fileList, path)
+				return nil
+			})
 
 			if err != nil {
 				panic(err)
 			}
 
-			switch mode := fi.Mode(); {
-			case mode.IsDir():
-				var fileList []string
-
-				err := filepath.Walk(arg, func(path string, f os.FileInfo, err error) error {
-					fileList = append(fileList, path)
-					return nil
-				})
+			for _, path := range fileList {
+				file, err := os.Open(path)
 
 				if err != nil {
 					panic(err)
 				}
 
-				for _, path := range fileList {
-					file, err := os.Open(path)
+				fiName := file.Name()
+				fiNameLen := len(fiName)
 
-					if err != nil {
-						panic(err)
-					}
-
-					fiName := file.Name()
-					fiNameLen := len(fiName)
-
-					if fiNameLen > 2 && fiName[fiNameLen-3:] == ".cx" {
-						// only loading .cx files
-						sourceCode = append(sourceCode, file)
-						fileNames = append(fileNames, fiName)
-					}
+				if fiNameLen > 2 && fiName[fiNameLen-3:] == ".cx" {
+					// only loading .cx files
+					sourceCode = append(sourceCode, file)
+					fileNames = append(fileNames, fiName)
 				}
-			case mode.IsRegular():
-				file, err := os.Open(arg)
-
-				if err != nil {
-					panic(err)
-				}
-
-				fileNames = append(fileNames, file.Name())
-				sourceCode = append(sourceCode, file)
 			}
+		case mode.IsRegular():
+			file, err := os.Open(arg)
+
+			if err != nil {
+				panic(err)
+			}
+
+			fileNames = append(fileNames, file.Name())
+			sourceCode = append(sourceCode, file)
 		}
 	}
+	return
 }
 
 func printVersion() {
 	fmt.Println("CX version", VERSION)
-}
-
-func parseCxArgs(args []string) {
-	a
 }

--- a/cxgo/flags.go
+++ b/cxgo/flags.go
@@ -18,10 +18,9 @@ type cxCmdFlags struct {
 	signalServerAddress string
 	webMode             bool
 	ideMode             bool
-	flagMode            bool
+	webPersistantMode   bool
 	printHelp           bool
 	printVersion        bool
-	interpretMode       bool
 }
 
 func defaultCmdFlags() cxCmdFlags {
@@ -36,9 +35,9 @@ func defaultCmdFlags() cxCmdFlags {
 		signalServerAddress: "localhost:7999",
 		webMode:             false,
 		ideMode:             false,
+		webPersistantMode:   false,
 		printHelp:           false,
 		printVersion:        false,
-		interpretMode:       false,
 	}
 }
 
@@ -56,7 +55,6 @@ func registerFlags(options *cxCmdFlags) {
 	flag.BoolVar(&options.baseOutput, "b", options.baseOutput, "alias for -base")
 	flag.BoolVar(&options.compileMode, "compile", options.compileMode, "generate a 'out' executable file of the program")
 	flag.BoolVar(&options.compileMode, "c", options.compileMode, "alias for -compile")
-	flag.StringVar(&options.compileOutput, "compile-output", options.compileOutput, "Specifies the filename for the generated executable.")
 	flag.StringVar(&options.compileOutput, "co", options.compileOutput, "alias for -compile-output")
 	flag.BoolVar(&options.newProject, "new", options.newProject, "Creates a new project located at $CXPATH/src")
 	flag.BoolVar(&options.newProject, "n", options.newProject, "alias for -new")
@@ -65,6 +63,7 @@ func registerFlags(options *cxCmdFlags) {
 	flag.BoolVar(&options.webMode, "web", options.webMode, "Start CX as a web service.")
 	flag.BoolVar(&options.webMode, "w", options.webMode, "alias for -web")
 	flag.BoolVar(&options.ideMode, "ide", options.ideMode, "Start CX as a web service, and Leaps service start also.")
+	flag.BoolVar(&options.webPersistantMode, "pw", options.webPersistantMode, "Start CX as a web service with a persistent web REPL session")
 	// viscript options
 	flag.BoolVar(&options.signalClientMode, "signal-client", options.signalClientMode, "Run signal client")
 	flag.IntVar(&options.signalClientID, "signal-client-id", options.signalClientID, "Id of signal client (default 1)")


### PR DESCRIPTION
Fixes #175

Changes:
- Command line options parsed using `flag` module
- Non-flags arguments (e.g. CX, source files) returned by `ParseArgsForCX`

Does this change need to mentioned in CHANGELOG.md?
no
