### PR TITLE
Part 1 of fixing #188: idiomatic go

### DIFF
--- a/cx/op_bool.go
+++ b/cx/op_bool.go
@@ -4,36 +4,36 @@ import (
 	"fmt"
 )
 
-func op_bool_print(expr *CXExpression, fp int) {
+func opBoolPrint(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	fmt.Println(ReadBool(fp, inp1))
 }
 
-func op_bool_equal(expr *CXExpression, fp int) {
+func opBoolEqual(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadBool(fp, inp1) == ReadBool(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_bool_unequal(expr *CXExpression, fp int) {
+func opBoolUnequal(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadBool(fp, inp1) != ReadBool(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_bool_not(expr *CXExpression, fp int) {
+func opBoolNot(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromBool(!ReadBool(fp, inp1))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_bool_and(expr *CXExpression, fp int) {
+func opBoolAnd(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadBool(fp, inp1) && ReadBool(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_bool_or(expr *CXExpression, fp int) {
+func opBoolOr(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadBool(fp, inp1) || ReadBool(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)

--- a/cx/op_byte.go
+++ b/cx/op_byte.go
@@ -6,7 +6,7 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 )
 
-func op_byte_byte(expr *CXExpression, fp int) {
+func opByteByte(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	out1Offset := GetFinalOffset(fp, out1)
 	switch out1.Type {
@@ -25,7 +25,7 @@ func op_byte_byte(expr *CXExpression, fp int) {
 	}
 }
 
-func op_byte_print(expr *CXExpression, fp int) {
+func opBytePrint(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	fmt.Println(ReadByte(fp, inp1))
 }

--- a/cx/op_i32.go
+++ b/cx/op_i32.go
@@ -8,7 +8,7 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 )
 
-func op_i32_i32 (expr *CXExpression, fp int) {
+func opI32I32(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	out1Offset := GetFinalOffset(fp, out1)
 
@@ -28,104 +28,104 @@ func op_i32_i32 (expr *CXExpression, fp int) {
 	}
 }
 
-func op_i32_print(expr *CXExpression, fp int) {
+func opI32Print(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	fmt.Println(ReadI32(fp, inp1))
 }
 
-// op_i32_add. The add built-in function returns the add of two numbers
-func op_i32_add(expr *CXExpression, fp int) {
+// The built-in add function returns the sum of two i32 numbers
+func opI32Add(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(ReadI32(fp, inp1) + ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_sub. The sub built-in function returns the substract of two numbers
-func op_i32_sub(expr *CXExpression, fp int) {
+// The built-in sub function returns the difference of two i32 numbers
+func opI32Sub(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(ReadI32(fp, inp1) - ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_sub. The mul built-in function returns the multiplication of two numbers
-func op_i32_mul(expr *CXExpression, fp int) {
+// The built-in mul function returns the product of two i32 numbers
+func opI32Mul(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(ReadI32(fp, inp1) * ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_sub. The div built-in function returns the divides two numbers
-func op_i32_div(expr *CXExpression, fp int) {
+// The built-in div function returns the quotient of two i32 numbers
+func opI32Div(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(ReadI32(fp, inp1) / ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_abs. The div built-in function returns the absolute number of the number
-func op_i32_abs(expr *CXExpression, fp int) {
+// The built-in abs function returns the absolute number of the number
+func opI32Abs(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromI32(int32(math.Abs(float64(ReadI32(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_pow. The div built-in function returns x**n for n>0 otherwise 1
-func op_i32_pow(expr *CXExpression, fp int) {
+// The div built-in function returns x**n for n>0 otherwise 1
+func opI32Pow(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(int32(math.Pow(float64(ReadI32(fp, inp1)), float64(ReadI32(fp, inp2)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_gt. The gt built-in function returns true if x number is greater than a y number
-func op_i32_gt(expr *CXExpression, fp int) {
+// The built-in gt function returns true if operand 1 is greater than operand 2.
+func opI32Gt(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadI32(fp, inp1) > ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_gteq. The gteq built-in function returns true if x number is greater or
-// equal than a y number
-func op_i32_gteq(expr *CXExpression, fp int) {
+// The built-in gteq function returns true if operand 1 is greater than or
+// equal to operand 2.
+func opI32Gteq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadI32(fp, inp1) >= ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_lt. The lt built-in function returns true if x number is less then
-func op_i32_lt(expr *CXExpression, fp int) {
+// The built-in lt function returns true if operand 1 is less than operand 2.
+func opI32Lt(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadI32(fp, inp1) < ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_lteq. The lteq built-in function returns true if x number is less or
-// equal than a y number
-func op_i32_lteq(expr *CXExpression, fp int) {
+// The built-in lteq function returns true if operand 1 is less than or equal
+// to operand 1.
+func opI32Lteq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadI32(fp, inp1) <= ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_eq. The eq built-in function returns true if x number is equal to the y number
-func op_i32_eq(expr *CXExpression, fp int) {
+// The built-in eq function returns true if operand 1 is equal to operand 2.
+func opI32Eq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadI32(fp, inp1) == ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_uneq. The uneq built-in function returns true if x number is diferent to the y number
-func op_i32_uneq(expr *CXExpression, fp int) {
+// The built-in uneq function returns true if operand 1 is different from operand 2.
+func opI32Uneq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadI32(fp, inp1) != ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i32_mod(expr *CXExpression, fp int) {
+func opI32Mod(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(ReadI32(fp, inp1) % ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i32_rand(expr *CXExpression, fp int) {
+func opI32Rand(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 
 	minimum := ReadI32(fp, inp1)
@@ -136,79 +136,79 @@ func op_i32_rand(expr *CXExpression, fp int) {
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i32_bitand(expr *CXExpression, fp int) {
+func opI32Bitand(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(ReadI32(fp, inp1) & ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i32_bitor(expr *CXExpression, fp int) {
+func opI32Bitor(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(ReadI32(fp, inp1) | ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i32_bitxor(expr *CXExpression, fp int) {
+func opI32Bitxor(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(ReadI32(fp, inp1) ^ ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i32_bitclear(expr *CXExpression, fp int) {
+func opI32Bitclear(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(ReadI32(fp, inp1) &^ ReadI32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i32_bitshl(expr *CXExpression, fp int) {
+func opI32Bitshl(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(int32(uint32(ReadI32(fp, inp1)) << uint32(ReadI32(fp, inp2))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i32_bitshr(expr *CXExpression, fp int) {
+func opI32Bitshr(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(int32(uint32(ReadI32(fp, inp1)) >> uint32(ReadI32(fp, inp2))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_sqrt. The sqrt built-in function returns the square root of x number
-func op_i32_sqrt(expr *CXExpression, fp int) {
+// The built-in sqrt function returns the square root of the operand.
+func opI32Sqrt(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromI32(int32(math.Sqrt(float64(ReadI32(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_log. The log built-in function returns the natural logarithm of x number
-func op_i32_log(expr *CXExpression, fp int) {
+// The built-in log function returns the natural logarithm of the operand.
+func opI32Log(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromI32(int32(math.Log(float64(ReadI32(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_log2. The log2 built-in function returns the natural logarithm based 2 of x number
-func op_i32_log2(expr *CXExpression, fp int) {
+// The built-in log2 function returns the 2-logarithm of the operand.
+func opI32Log2(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromI32(int32(math.Log2(float64(ReadI32(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_log10. The log10 built-in function returns the natural logarithm based 2 of x number
-func op_i32_log10(expr *CXExpression, fp int) {
+// The built-in log10 function returns the 10-logarithm of the operand
+func opI32Log10(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromI32(int32(math.Log10(float64(ReadI32(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i32_max. The max built-in function returns the max value between x and y numbers
-func op_i32_max(expr *CXExpression, fp int) {
+// The built-in max function returns the biggest of the two operands.
+func opI32Max(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(int32(math.Max(float64(ReadI32(fp, inp1)), float64(ReadI32(fp, inp2)))))
-	WriteMemory(GetFinalOffset(fp, out1), outB1)
+	WriteMemory(GetFinalOffset(fp, out1), outB1?)
 }
 
-// op_i32_min. The min built-in function returns the min value between x and y numbers
-func op_i32_min(expr *CXExpression, fp int) {
+// The built-in min function returns the smallest of the two operands.
+func opI32Min(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(int32(math.Min(float64(ReadI32(fp, inp1)), float64(ReadI32(fp, inp2)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)

--- a/cx/op_i32.go
+++ b/cx/op_i32.go
@@ -204,7 +204,7 @@ func opI32Log10(expr *CXExpression, fp int) {
 func opI32Max(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI32(int32(math.Max(float64(ReadI32(fp, inp1)), float64(ReadI32(fp, inp2)))))
-	WriteMemory(GetFinalOffset(fp, out1), outB1?)
+	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
 // The built-in min function returns the smallest of the two operands.

--- a/cx/opcodes_bare.go
+++ b/cx/opcodes_bare.go
@@ -564,73 +564,73 @@ func init () {
 			opBoolAnd(expr, fp)
 
 		case OP_I32_BYTE:
-			op_i32_i32(expr, fp)
+			opI32I32(expr, fp)
 		case OP_I32_STR:
-			op_i32_i32(expr, fp)
+			opI32I32(expr, fp)
 		case OP_I32_I32:
-			op_i32_i32(expr, fp)
+			opI32I32(expr, fp)
 		case OP_I32_I64:
-			op_i32_i32(expr, fp)
+			opI32I32(expr, fp)
 		case OP_I32_F32:
-			op_i32_i32(expr, fp)
+			opI32I32(expr, fp)
 		case OP_I32_F64:
-			op_i32_i32(expr, fp)
+			opI32I32(expr, fp)
 
 		case OP_I32_PRINT:
-			op_i32_print(expr, fp)
+			opI32Print(expr, fp)
 		case OP_I32_ADD:
-			op_i32_add(expr, fp)
+			opI32Add(expr, fp)
 		case OP_I32_SUB:
-			op_i32_sub(expr, fp)
+			opI32Sub(expr, fp)
 		case OP_I32_MUL:
-			op_i32_mul(expr, fp)
+			opI32Mul(expr, fp)
 		case OP_I32_DIV:
-			op_i32_div(expr, fp)
+			opI32Div(expr, fp)
 		case OP_I32_ABS:
-			op_i32_abs(expr, fp)
+			opI32Abs(expr, fp)
 		case OP_I32_POW:
-			op_i32_pow(expr, fp)
+			opI32Pow(expr, fp)
 		case OP_I32_GT:
-			op_i32_gt(expr, fp)
-		case OP_I32_GTEQ:
-			op_i32_gteq(expr, fp)
+			opI32Gt(expr, fp)
+		case OP_I32_GTEQ
+			OpI32Gteq(expr, fp)
 		case OP_I32_LT:
-			op_i32_lt(expr, fp)
+			opI32Lt(expr, fp)
 		case OP_I32_LTEQ:
-			op_i32_lteq(expr, fp)
+			opI32Lteq(expr, fp)
 		case OP_I32_EQ:
-			op_i32_eq(expr, fp)
+			opI32Eq(expr, fp)
 		case OP_I32_UNEQ:
-			op_i32_uneq(expr, fp)
+			opI32Uneq(expr, fp)
 		case OP_I32_MOD:
-			op_i32_mod(expr, fp)
+			opI32Mod(expr, fp)
 		case OP_I32_RAND:
-			op_i32_rand(expr, fp)
+			opI32Rand(expr, fp)
 		case OP_I32_BITAND:
-			op_i32_bitand(expr, fp)
+			opI32Bitand(expr, fp)
 		case OP_I32_BITOR:
-			op_i32_bitor(expr, fp)
+			opI32Bitor(expr, fp)
 		case OP_I32_BITXOR:
-			op_i32_bitxor(expr, fp)
+			opI32Bitxor(expr, fp)
 		case OP_I32_BITCLEAR:
-			op_i32_bitclear(expr, fp)
+			opI32Bitclear(expr, fp)
 		case OP_I32_BITSHL:
-			op_i32_bitshl(expr, fp)
+			opI32Bitshl(expr, fp)
 		case OP_I32_BITSHR:
-			op_i32_bitshr(expr, fp)
+			opI32Bitshr(expr, fp)
 		case OP_I32_SQRT:
-			op_i32_sqrt(expr, fp)
+			opI32Sqrt(expr, fp)
 		case OP_I32_LOG:
-			op_i32_log(expr, fp)
+			opI32Log(expr, fp)
 		case OP_I32_LOG2:
-			op_i32_log2(expr, fp)
+			opI32Log2(expr, fp)
 		case OP_I32_LOG10:
-			op_i32_log10(expr, fp)
+			opI32Log10(expr, fp)
 
 		case OP_I32_MAX:
-			op_i32_max(expr, fp)
+			opI32Max(expr, fp)
 		case OP_I32_MIN:
-			op_i32_min(expr, fp)
+			opI32Min(expr, fp)
 
 		case OP_I64_BYTE:
 			op_i64_i64(expr, fp)

--- a/cx/opcodes_bare.go
+++ b/cx/opcodes_bare.go
@@ -535,17 +535,17 @@ func init () {
 			op_read(expr, fp)
 
 		case OP_BYTE_BYTE:
-			op_byte_byte(expr, fp)
+			opByteByte(expr, fp)
 		case OP_BYTE_STR:
-			op_byte_byte(expr, fp)
+			opByteByte(expr, fp)
 		case OP_BYTE_I32:
-			op_byte_byte(expr, fp)
+			opByteByte(expr, fp)
 		case OP_BYTE_I64:
-			op_byte_byte(expr, fp)
+			opByteByte(expr, fp)
 		case OP_BYTE_F32:
-			op_byte_byte(expr, fp)
+			opByteByte(expr, fp)
 		case OP_BYTE_F64:
-			op_byte_byte(expr, fp)
+			opByteByte(expr, fp)
 
 		case OP_BYTE_PRINT:
 			op_byte_print(expr, fp)

--- a/cx/opcodes_bare.go
+++ b/cx/opcodes_bare.go
@@ -551,17 +551,17 @@ func init () {
 			op_byte_print(expr, fp)
 
 		case OP_BOOL_PRINT:
-			op_bool_print(expr, fp)
+			opBoolPrint(expr, fp)
 		case OP_BOOL_EQUAL:
-			op_bool_equal(expr, fp)
+			opBoolEqual(expr, fp)
 		case OP_BOOL_UNEQUAL:
-			op_bool_unequal(expr, fp)
+			opBoolUnequal(expr, fp)
 		case OP_BOOL_NOT:
-			op_bool_not(expr, fp)
+			opBoolNot(expr, fp)
 		case OP_BOOL_OR:
-			op_bool_or(expr, fp)
+			opBoolOr(expr, fp)
 		case OP_BOOL_AND:
-			op_bool_and(expr, fp)
+			opBoolAnd(expr, fp)
 
 		case OP_I32_BYTE:
 			op_i32_i32(expr, fp)

--- a/cx/opcodes_bare.go
+++ b/cx/opcodes_bare.go
@@ -548,7 +548,7 @@ func init () {
 			opByteByte(expr, fp)
 
 		case OP_BYTE_PRINT:
-			op_byte_print(expr, fp)
+			opBytePrint(expr, fp)
 
 		case OP_BOOL_PRINT:
 			opBoolPrint(expr, fp)
@@ -592,8 +592,8 @@ func init () {
 			opI32Pow(expr, fp)
 		case OP_I32_GT:
 			opI32Gt(expr, fp)
-		case OP_I32_GTEQ
-			OpI32Gteq(expr, fp)
+		case OP_I32_GTEQ:
+			opI32Gteq(expr, fp)
 		case OP_I32_LT:
 			opI32Lt(expr, fp)
 		case OP_I32_LTEQ:

--- a/tests/test-i32.cx
+++ b/tests/test-i32.cx
@@ -12,7 +12,35 @@ func I32ArithmeticFunctions() () {
 	test(i32.bitor(10, 5), 15, "Bit OR error")
 	test(i32.bitxor(10, 5), 15, "Bit XOR error")
 	test(i32.bitclear(10, 2), 8, "Bit CLEAR error")
-	test(i32.pow(10, 5), 100000, "Pow error")
+
+	// Should return x**n if n>0, 1 otherwise, according to a comment in the op_i32.go
+	// This seems wrong to me.  Please look into these tests below and
+	// remove this comment.  /IW
+	test(i32.pow(10, 0), 1, "Pow(10, 0) error")
+	test(i32.pow(10, 1), 10, "Pow(10, 1) error")
+	test(i32.pow(10, 5), 100000, "Pow(10, 5) error")
+	test(i32.pow(10, -1), 0, "Pow(10, -1) error")
+	test(i32.pow(10, -2), 0, "Pow(10, -2) error")	  
+	//test(i32.pow(0, 0), 1, "Pow(0, 0) error")  What should this yield?
+	test(i32.pow(0, 1), 0, "Pow(0, 1) error")
+	test(i32.pow(0, 2), 0, "Pow(0, 2) error")
+	//test(i32.pow(0, -1), 1, "Pow(0, -1) error")  Should yield an error.  How to test for that?
+	//test(i32.pow(0, -2), 1, "Pow(0, -2) error")  Should yield an error.  How to test for that?
+	test(i32.pow(1, 0), 1, "Pow(1, 0) error")
+	test(i32.pow(1, 1), 1, "Pow(1, 1) error")
+	test(i32.pow(1, 2), 1, "Pow(1, 2) error")
+	test(i32.pow(1, -1), 1, "Pow(1, -1) error")
+	test(i32.pow(1, -2), 1, "Pow(1, -2) error")
+	test(i32.pow(-1, 0), 1, "Pow(-1, 0) error")
+	test(i32.pow(-1, 1), -1, "Pow(-1, 1) error")
+	test(i32.pow(-1, 2), 1, "Pow(-1, 2) error")
+	test(i32.pow(-1, 3), -1, "Pow(-1, 3) error")
+	test(i32.pow(-1, 4), 1, "Pow(-1, 4) error")
+	test(i32.pow(-1, -1), -1, "Pow(-1, -1) error")
+	test(i32.pow(-2, -1), 0, "Pow(-2, -1) error")
+	test(i32.pow(-2, -2), 0, "Pow(-2, -2) error")
+
+
 	test(i32.abs(-10), 10, "Absolute Value error")
 	test(i32.sqrt(4), 2, "Square Root error")
 	test(i32.log(1), 0, "Log error")


### PR DESCRIPTION
Fixes #188 (partly)

Changes:
-name changes to functions for opcodes i32, byte and bool

Does this change need to mentioned in CHANGELOG.md?
No