### PR TITLE
Part 2 of fixing #188: Idiomatic go

### DIFF
--- a/cx/op_f32.go
+++ b/cx/op_f32.go
@@ -7,7 +7,7 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 )
 
-func op_f32_f32(expr *CXExpression, fp int) {
+func opF32F32(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	out1Offset := GetFinalOffset(fp, out1)
 
@@ -27,174 +27,174 @@ func op_f32_f32(expr *CXExpression, fp int) {
 	}
 }
 
-func op_f32_isnan(expr *CXExpression, fp int) {
+func opF32Isnan(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromBool(math.IsNaN(float64(ReadF32(fp, inp1))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_f32_print(expr *CXExpression, fp int) {
+func opF32Print(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	fmt.Println(ReadF32(fp, inp1))
 }
 
-// op_f32_add. The add built-in function returns the add of two numbers
-
-func op_f32_add(expr *CXExpression, fp int) {
+// The built-in add function returns the sum of the two operands.
+//
+func opF32Add(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF32(ReadF32(fp, inp1) + ReadF32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f32_sub. The sub built-in function returns the substract of two numbers
-
-func op_f32_sub(expr *CXExpression, fp int) {
+// The built-in sub function returns the difference between the two operands.
+//
+func opF32Sub(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF32(ReadF32(fp, inp1) - ReadF32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f32_sub. The mul built-in function returns the multiplication of two numbers
-
-func op_f32_mul(expr *CXExpression, fp int) {
+// The built-in mul function returns the product of the two operands.
+//
+func opF32Mul(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF32(ReadF32(fp, inp1) * ReadF32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f32_sub. The div built-in function returns the divides two numbers
-
-func op_f32_div(expr *CXExpression, fp int) {
+// The built-in div function returns the quotient between the two operands.
+//
+func opF32Div(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF32(ReadF32(fp, inp1) / ReadF32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f32_abs. The div built-in function returns the absolute number of the number
-
-func op_f32_abs(expr *CXExpression, fp int) {
+// The built-in abs function returns the absolute value of the operand.
+//
+func opF32Abs(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF32(float32(math.Abs(float64(ReadF32(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_pow. The div built-in function returns x**n for n>0 otherwise 1
-
-func op_f32_pow(expr *CXExpression, fp int) {
+// The built-in pow function returns x**n for n>0 otherwise 1
+//
+func opF32Pow(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF32(float32(math.Pow(float64(ReadF32(fp, inp1)), float64(ReadF32(fp, inp2)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_gt. The gt built-in function returns true if x number is greater than a y number
-
-func op_f32_gt(expr *CXExpression, fp int) {
+// The built-in gt function returns true if operand 1 is greater than operand 2.
+//
+func opF32Gt(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadF32(fp, inp1) > ReadF32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f32_gteq. The gteq built-in function returns true if x number is greater or
-// equal than a y number
-
-func op_f32_gteq(expr *CXExpression, fp int) {
+// The built-in gteq function returns true if the operand 1 is greater than or
+// equal to operand 2.
+//
+func opF32Gteq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadF32(fp, inp1) >= ReadF32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_lt. The lt built-in function returns true if x number is less then
+// The built-in lt function returns true if operand 1 is less than operand 2.
 
-func op_f32_lt(expr *CXExpression, fp int) {
+func opF32Lt(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadF32(fp, inp1) < ReadF32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_lteq. The lteq built-in function returns true if x number is less or
-// equal than a y number
-
-func op_f32_lteq(expr *CXExpression, fp int) {
+// The built-in lteq function returns true if operand 1 is less than or
+// equal to operand 2.
+//
+func opF32Lteq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadF32(fp, inp1) <= ReadF32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_eq. The eq built-in function returns true if x number is equal to the y number
-
-func op_f32_eq(expr *CXExpression, fp int) {
+// The built-in eq function returns true if operand 1 is equal to operand 2.
+//
+func opF32Eq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadF32(fp, inp1) == ReadF32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_uneq. The uneq built-in function returns true if x number is diferent to the y number
-
-func op_f32_uneq(expr *CXExpression, fp int) {
+// The built-in uneq function returns true operand1 is different from operand 2.
+//
+func opF32Uneq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadF32(fp, inp1) != ReadF32(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_cos. The cos built-in function returns the cosine of x number.
-
-func op_f32_cos(expr *CXExpression, fp int) {
+// The built-in cos function returns the cosine of the operand.
+//
+func opF32Cos(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF32(float32(math.Cos(float64(ReadF32(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_cos. The cos built-in function returns the sine of x number.
-
-func op_f32_sin(expr *CXExpression, fp int) {
+// The built-in sin function returns the sine of the operand.
+//
+func opF32Sin(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF32(float32(math.Sin(float64(ReadF32(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_sqrt. The sqrt built-in function returns the square root of x number
-
-func op_f32_sqrt(expr *CXExpression, fp int) {
+// The built-in sqrt function returns the square root of the operand.
+//
+func opF32Sqrt(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF32(float32(math.Sqrt(float64(ReadF32(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_log. The log built-in function returns the natural logarithm of x number
-
-func op_f32_log(expr *CXExpression, fp int) {
+// The built-in log function returns the natural logarithm of the operand.
+//
+func opF32Log(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF32(float32(math.Log(float64(ReadF32(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_log2. The log2 built-in function returns the natural logarithm based 2 of x number
-
-func op_f32_log2(expr *CXExpression, fp int) {
+// The built-in log2 function returns the 2-logarithm of the operand.
+//
+func opF32Log2(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF32(float32(math.Log2(float64(ReadF32(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_log10. The log10 built-in function returns the natural logarithm based 2 of x number
-
-func op_f32_log10(expr *CXExpression, fp int) {
+// The built-in log10 function returns the 10-logarithm of the operand.
+//
+func opF32Log10(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF32(float32(math.Log10(float64(ReadF32(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_max. The max built-in function returns the max value between x and y numbers
-
-func op_f32_max(expr *CXExpression, fp int) {
+// The built-in max function returns the largest value of the two operands.
+//
+func opF32Max(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF32(float32(math.Max(float64(ReadF32(fp, inp1)), float64(ReadF32(fp, inp2)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_min. The min built-in function returns the min value between x and y numbers
-
-func op_f32_min(expr *CXExpression, fp int) {
+// The built-in min function returns the smallest value of the two operands.
+//
+func opF32Min(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF32(float32(math.Min(float64(ReadF32(fp, inp1)), float64(ReadF32(fp, inp2)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)

--- a/cx/op_f64.go
+++ b/cx/op_f64.go
@@ -7,7 +7,7 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 )
 
-func op_f64_f64(expr *CXExpression, fp int) {
+func opF64F64(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	out1Offset := GetFinalOffset(fp, out1)
 
@@ -27,171 +27,170 @@ func op_f64_f64(expr *CXExpression, fp int) {
 	}
 }
 
-// op_f64_print. The print built-in function formats its arguments in an
-// implementation-specific
-
-func op_f64_print(expr *CXExpression, fp int) {
+// The print built-in function formats its arguments and prints them.
+//
+func opF64Print(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	fmt.Println(ReadF64(fp, inp1))
 }
 
-// op_f64_add. The add built-in function returns the add of two numbers
-
-func op_f64_add(expr *CXExpression, fp int) {
+// The built-in add function returns the sum of the two operands.
+//
+func opF64Add(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF64(ReadF64(fp, inp1) + ReadF64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_sub. The sub built-in function returns the substract of two numbers
-
-func op_f64_sub(expr *CXExpression, fp int) {
+// The built-in sub function returns the difference between the two operands.
+//
+func opF64Sub(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF64(ReadF64(fp, inp1) - ReadF64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_sub. The mul built-in function returns the multiplication of two numbers
-
-func op_f64_mul(expr *CXExpression, fp int) {
+// The built-in mul function returns the product of the two operands.
+//
+func opF64Mul(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF64(ReadF64(fp, inp1) * ReadF64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_sub. The div built-in function returns the divides two numbers
-
-func op_f64_div(expr *CXExpression, fp int) {
+// The built-in div function returns the quotient between the two operands.
+//
+func opF64Div(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF64(ReadF64(fp, inp1) / ReadF64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_abs. The div built-in function returns the absolute number of the number
-
-func op_f64_abs(expr *CXExpression, fp int) {
+// The built-in abs function returns the absolute value of the operand.
+//
+func opF64Abs(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF64(math.Abs(ReadF64(fp, inp1)))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_pow. The div built-in function returns x**n for n>0 otherwise 1
-
-func op_f64_pow(expr *CXExpression, fp int) {
+// The built-in pow function returns x**n for n>0 otherwise 1
+//
+func opF64Pow(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF64(math.Pow(ReadF64(fp, inp1), ReadF64(fp, inp2)))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_gt. The gt built-in function returns true if x number is greater than a y number
-
-func op_f64_gt(expr *CXExpression, fp int) {
+// The built-in gt function returns true if operand 1 is larger than operand 2.
+//
+func opF64Gt(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadF64(fp, inp1) > ReadF64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_gteq. The gteq built-in function returns true if x number is greater or
-// equal than a y number
-
-func op_f64_gteq(expr *CXExpression, fp int) {
+// The built-in gteq function returns true if operand 1 is greater than or
+// equal to operand 2.
+//
+func opF64Gteq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadF64(fp, inp1) >= ReadF64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_lt. The lt built-in function returns true if x number is less then
-
-func op_f64_lt(expr *CXExpression, fp int) {
+// The built-in lt function returns true if operand 1 is less than operand 2.
+//
+func opF64Lt(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadF64(fp, inp1) < ReadF64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_lteq. The lteq built-in function returns true if x number is less or
-// equal than a y number
-
-func op_f64_lteq(expr *CXExpression, fp int) {
+// The built-in lteq function returns true if operand 1 is less than or equal
+// to operand 2.
+//
+func opF64Lteq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadF64(fp, inp1) <= ReadF64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_eq. The eq built-in function returns true if x number is equal to the y number
-
-func op_f64_eq(expr *CXExpression, fp int) {
+// The built-in eq function returns true if operand 1 is equal to operand 2.
+//
+func opF64Eq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadF64(fp, inp1) == ReadF64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_uneq. The uneq built-in function returns true if x number is diferent to the y number
-
-func op_f64_uneq(expr *CXExpression, fp int) {
+// The built-in uneq function returns true if operand 1 is different from operand 2.
+//
+func opF64Uneq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadF64(fp, inp1) != ReadF64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_cos. The cos built-in function returns the cosine of x number.
-
-func op_f64_cos(expr *CXExpression, fp int) {
+// The built-in cos function returns the cosine of the operand.
+//
+func opF64Cos(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF64(math.Cos(ReadF64(fp, inp1)))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_cos. The cos built-in function returns the sine of x number.
-
-func op_f64_sin(expr *CXExpression, fp int) {
+// The built-in sin function returns the sine of the operand.
+//
+func opF64Sin(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF64(math.Sin(ReadF64(fp, inp1)))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_sqrt. The sqrt built-in function returns the square root of x number
-
-func op_f64_sqrt(expr *CXExpression, fp int) {
+// The built-in sqrt function returns the square root of the operand.
+//
+func opF64Sqrt(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF64(math.Sqrt(ReadF64(fp, inp1)))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_log. The log built-in function returns the natural logarithm of x number
-
-func op_f64_log(expr *CXExpression, fp int) {
+// The built-in log function returns the natural logarithm of the operand.
+//
+func opF64Log(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF64(math.Log(ReadF64(fp, inp1)))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_log2. The log2 built-in function returns the natural logarithm based 2 of x number
-
-func op_f64_log2(expr *CXExpression, fp int) {
+// The built-in log2 function returns the 2-logarithm of the operand.
+//
+func opF64Log2(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF64(math.Log2(ReadF64(fp, inp1)))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_log10. The log10 built-in function returns the natural logarithm based 2 of x number
-
-func op_f64_log10(expr *CXExpression, fp int) {
+// The built-in log10 function returns the 10-logarithm of the operand.
+//
+func opF64Log10(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromF64(math.Log10(ReadF64(fp, inp1)))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_max. The max built-in function returns the max value between x and y numbers
-
-func op_f64_max(expr *CXExpression, fp int) {
+// The built-in max function returns the largest value of the two operands.
+//
+func opF64Max(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF64(math.Max(ReadF64(fp, inp1), ReadF64(fp, inp2)))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_f64_min. The min built-in function returns the min value between x and y numbers
-
-func op_f64_min(expr *CXExpression, fp int) {
+// The built-in min function returns the smallest value of the two operands.
+//
+func opF64Min(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromF64(math.Min(ReadF64(fp, inp1), ReadF64(fp, inp2)))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)

--- a/cx/op_i64.go
+++ b/cx/op_i64.go
@@ -8,7 +8,7 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 )
 
-func op_i64_i64(expr *CXExpression, fp int) {
+func opI64I64(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	out1Offset := GetFinalOffset(fp, out1)
 
@@ -28,120 +28,120 @@ func op_i64_i64(expr *CXExpression, fp int) {
 	}
 }
 
-// op_i64_print. The print built-in function formats its arguments in an
+// The built-in print function formats its arguments in an
 // implementation-specific
 
-func op_i64_print(expr *CXExpression, fp int) {
+func opI64Print(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	fmt.Println(ReadI64(fp, inp1))
 }
 
-// op_i64_add. The add built-in function returns the add of two numbers
+// The built-in add function returns the sum of the two operands.
 
-func op_i64_add(expr *CXExpression, fp int) {
+func opI64Add(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(ReadI64(fp, inp1) + ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_sub. The sub built-in function returns the substract of two numbers
+// The built-in sub function returns the difference between the two operands.
 
-func op_i64_sub(expr *CXExpression, fp int) {
+func opI64Sub(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(ReadI64(fp, inp1) - ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_sub. The mul built-in function returns the multiplication of two numbers
+// The built-in mul function returns the product of the two operands.
 
-func op_i64_mul(expr *CXExpression, fp int) {
+func opI64Mul(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(ReadI64(fp, inp1) * ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_sub. The div built-in function returns the divides two numbers
+// The built-in div function returns the quotient of the two operands.
 
-func op_i64_div(expr *CXExpression, fp int) {
+func opI64Div(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(ReadI64(fp, inp1) / ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_abs. The div built-in function returns the absolute number of the number
+// The built-in abs function returns the absolute value of the operand.
 
-func op_i64_abs(expr *CXExpression, fp int) {
+func opI64Abs(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromI64(int64(math.Abs(float64(ReadI64(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_pow. The div built-in function returns x**n for n>0 otherwise 1
+// The built-in pow function returns x**n for n>0 otherwise 1
 
-func op_i64_pow(expr *CXExpression, fp int) {
+func opI64Pow(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(int64(math.Pow(float64(ReadI64(fp, inp1)), float64(ReadI64(fp, inp2)))))
 
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_gt. The gt built-in function returns true if x number is greater than a y number
+// The built-in gt function returns true if operand 1 is greater than operand 2.
 
-func op_i64_gt(expr *CXExpression, fp int) {
+func opI64Gt(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadI64(fp, inp1) > ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_gteq. The gteq built-in function returns true if x number is greater or
-// equal than a y number
+// The built-in gteq function returns true if operand 1 is greater than or
+// equal to operand 2.
 
-func op_i64_gteq(expr *CXExpression, fp int) {
+func opI64Gteq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadI64(fp, inp1) >= ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_lt. The lt built-in function returns true if x number is less then
+// The built-in lt function returns true if operand 1 is less than oeprand 2.
 
-func op_i64_lt(expr *CXExpression, fp int) {
+func opI64Lt(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadI64(fp, inp1) < ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_lteq. The lteq built-in function returns true if x number is less or
-// equal than a y number
+// The built-in lteq function returns true if operand 1 is less than or
+// equal to operand 2.
 
-func op_i64_lteq(expr *CXExpression, fp int) {
+func opI64Lteq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadI64(fp, inp1) <= ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_eq. The eq built-in function returns true if x number is equal to the y number
+// The built-in eq function returns true if operand 1 is equal to operand 2.
 
-func op_i64_eq(expr *CXExpression, fp int) {
+func opI64Eq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadI64(fp, inp1) == ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_uneq. The uneq built-in function returns true if x number is diferent to the y number
+// The built-in uneq function returns true if operand 1 is different from operand 2.
 
-func op_i64_uneq(expr *CXExpression, fp int) {
+func opI64Uneq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadI64(fp, inp1) != ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i64_mod(expr *CXExpression, fp int) {
+func opI64Mod(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(ReadI64(fp, inp1) % ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i64_rand(expr *CXExpression, fp int) {
+func opI64Rand(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 
 	minimum := ReadI64(fp, inp1)
@@ -152,85 +152,85 @@ func op_i64_rand(expr *CXExpression, fp int) {
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i64_bitand(expr *CXExpression, fp int) {
+func opI64Bitand(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(ReadI64(fp, inp1) & ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i64_bitor(expr *CXExpression, fp int) {
+func opI64Bitor(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(ReadI64(fp, inp1) | ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i64_bitxor(expr *CXExpression, fp int) {
+func opI64Bitxor(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(ReadI64(fp, inp1) ^ ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i64_bitclear(expr *CXExpression, fp int) {
+func opI64Bitclear(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(ReadI64(fp, inp1) &^ ReadI64(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i64_bitshl(expr *CXExpression, fp int) {
+func opI64Bitshl(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(int64(uint64(ReadI64(fp, inp1)) << uint64(ReadI64(fp, inp2))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i64_bitshr(expr *CXExpression, fp int) {
+func opI64Bitshr(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(int64(uint64(ReadI64(fp, inp1)) >> uint64(ReadI64(fp, inp2))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_sqrt. The sqrt built-in function returns the square root of x number
+// The built-in sqrt function returns the square root of the operand.
 
-func op_i64_sqrt(expr *CXExpression, fp int) {
+func opI64Sqrt(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromI64(int64(math.Sqrt(float64(ReadI64(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_log. The log built-in function returns the natural logarithm of x number
+// The built-in log function returns the natural logarithm of the operand.
 
-func op_i64_log(expr *CXExpression, fp int) {
+func opI64Log(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromI64(int64(math.Log(float64(ReadI64(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_log2. The log2 built-in function returns the natural logarithm based 2 of x number
+// The built-in log2 function returns the 2-logarithm of the operand.
 
-func op_i64_log2(expr *CXExpression, fp int) {
+func opI64Log2(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromI64(int64(math.Log2(float64(ReadI64(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_log10. The log10 built-in function returns the natural logarithm based 2 of x number
+// The built-in log10 function returns the 10-logarithm of the operand.
 
-func op_i64_log10(expr *CXExpression, fp int) {
+func opI64Log10(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	outB1 := FromI64(int64(math.Log10(float64(ReadI64(fp, inp1)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_max. The max built-in function returns the max value between x and y numbers
+// The built-in max function returns the greatest value of the two operands.
 
-func op_i64_max(expr *CXExpression, fp int) {
+func opI64Max(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(int64(math.Max(float64(ReadI64(fp, inp1)), float64(ReadI64(fp, inp2)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-// op_i64_min. The min built-in function returns the min value between x and y numbers
+// The built-in min function returns the smallest value of the two operands.
 
-func op_i64_min(expr *CXExpression, fp int) {
+func opI64Min(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI64(int64(math.Min(float64(ReadI64(fp, inp1)), float64(ReadI64(fp, inp2)))))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)

--- a/cx/op_i8.go
+++ b/cx/op_i8.go
@@ -3,90 +3,90 @@ package base
 import "fmt"
 
 
-func op_i8_print (expr *CXExpression, fp int) {
+func opI8Print(expr *CXExpression, fp int) {
 	inp1 :=	expr.Inputs[0]
 	fmt.Println(ReadI8(fp, inp1))
 }
 
-func op_i8_add (expr *CXExpression, fp int) {
+func opI8Add(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI8(ReadI8(fp, inp1) +  ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i8_sub (expr *CXExpression, fp int) {
+func opI8Sub(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI8(ReadI8(fp, inp1) -  ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i8_mul (expr *CXExpression, fp int) {
+func opI8Mul(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI8(ReadI8(fp, inp1) *  ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i8_div (expr *CXExpression, fp int) {
+func opI8Div(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI8(ReadI8(fp, inp1) /  ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i8_gt (expr *CXExpression, fp int) {
+func opI8Gt(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1:= FromBool(ReadI8(fp, inp1) > ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i8_gteq (expr *CXExpression, fp int) {
+func opI8Gteq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1:= FromBool(ReadI8(fp, inp1) >= ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i8_lt (expr *CXExpression, fp int) {
+func opI8Lt(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1:= FromBool(ReadI8(fp, inp1) < ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i8_lteq (expr *CXExpression, fp int) {
+func opI8Lteq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1:= FromBool(ReadI8(fp, inp1) <= ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i8_eq (expr *CXExpression, fp int) {
+func opI8Eq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1:= FromBool(ReadI8(fp, inp1) == ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i8_uneq (expr *CXExpression, fp int) {
+func opI8Uneq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1:= FromBool(ReadI8(fp, inp1) != ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i8_bitand (expr *CXExpression, fp int) {
+func opI8Bitand(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI8(ReadI8(fp, inp1) & ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i8_bitor (expr *CXExpression, fp int) {
+func opI8Bitor(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI8(ReadI8(fp, inp1) | ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i8_bitxor (expr *CXExpression, fp int) {
+func opI8Bitxor(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI8(ReadI8(fp, inp1) ^ ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
 }
 
-func op_i8_bitclear (expr *CXExpression, fp int) {
+func opI8Bitclear(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromI8(ReadI8(fp, inp1) &^ ReadI8(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)

--- a/cx/op_misc.go
+++ b/cx/op_misc.go
@@ -27,7 +27,7 @@ func EscapeAnalysis (fp int, inpOffset, outOffset int, arg *CXArgument) {
 	WriteMemory(outOffset, off)
 }
 
-func op_identity(expr *CXExpression, fp int) {
+func opIdentity(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	inp1Offset := GetFinalOffset(fp, inp1)
 	out1Offset := GetFinalOffset(fp, out1)
@@ -51,7 +51,7 @@ func op_identity(expr *CXExpression, fp int) {
 	}
 }
 
-func op_jmp(expr *CXExpression, fp int, call *CXCall) {
+func opJmp(expr *CXExpression, fp int, call *CXCall) {
 	inp1 := expr.Inputs[0]
 	var predicate bool
 	
@@ -70,5 +70,4 @@ func op_jmp(expr *CXExpression, fp int, call *CXCall) {
 			call.Line = call.Line + expr.ElseLines
 		}
 	}
-
 }

--- a/cx/op_str.go
+++ b/cx/op_str.go
@@ -7,7 +7,7 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 )
 
-func op_str_str(expr *CXExpression, fp int) {
+func opStrStr(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	out1Offset := GetFinalOffset(fp, out1)
 
@@ -47,12 +47,12 @@ func op_str_str(expr *CXExpression, fp int) {
 	}
 }
 
-func op_str_print(expr *CXExpression, fp int) {
+func opStrPrint(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	fmt.Println(ReadStr(fp, inp1))
 }
 
-func op_str_eq(expr *CXExpression, fp int) {
+func opStrEq(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 	outB1 := FromBool(ReadStr(fp, inp1) == ReadStr(fp, inp2))
 	WriteMemory(GetFinalOffset(fp, out1), outB1)
@@ -78,11 +78,11 @@ func writeString(expr *CXExpression, fp int, str string, out *CXArgument) {
 	WriteMemory(GetFinalOffset(fp, out), off)
 }
 
-func op_str_concat(expr *CXExpression, fp int) {
+func opStrConcat(expr *CXExpression, fp int) {
 	writeString(expr, fp, ReadStr(fp, expr.Inputs[0]) + ReadStr(fp, expr.Inputs[1]), expr.Outputs[0])
 }
 
-func op_str_substr(expr *CXExpression, fp int) {
+func opStrSubstr(expr *CXExpression, fp int) {
 	str := ReadStr(fp, expr.Inputs[0])
 	begin := ReadI32(fp, expr.Inputs[1])
 	end := ReadI32(fp, expr.Inputs[2])
@@ -90,12 +90,12 @@ func op_str_substr(expr *CXExpression, fp int) {
 	writeString(expr, fp, str[begin:end], expr.Outputs[0])
 }
 
-func op_str_index(expr *CXExpression, fp int) {
+func opStrIndex(expr *CXExpression, fp int) {
 	str := ReadStr(fp, expr.Inputs[0])
 	substr := ReadStr(fp, expr.Inputs[1])
 	WriteMemory(GetFinalOffset(fp, expr.Outputs[0]), FromI32(int32(strings.Index(str, substr))))
 }
 
-func op_str_trim_space(expr *CXExpression, fp int) {
+func opStrTrimSpace(expr *CXExpression, fp int) {
 	writeString(expr, fp, strings.TrimSpace(ReadStr(fp, expr.Inputs[0])), expr.Outputs[0])
 }

--- a/cx/opcodes_bare.go
+++ b/cx/opcodes_bare.go
@@ -814,30 +814,30 @@ func init () {
 			opF64Min(expr, fp)
 
 		case OP_STR_PRINT:
-			op_str_print(expr, fp)
-		case OP_STR_CONCAT:
-			op_str_concat(expr, fp)
-		case OP_STR_SUBSTR:
-			op_str_substr(expr, fp)
-		case OP_STR_INDEX:
-			op_str_index(expr, fp)
-		case OP_STR_TRIM_SPACE:
-			op_str_trim_space(expr, fp)
+			opStrPrint(expr, fp)
 		case OP_STR_EQ:
-			op_str_eq(expr, fp)
+			opStrEq(expr, fp)
+		case OP_STR_CONCAT:
+			opStrConcat(expr, fp)
+		case OP_STR_SUBSTR:
+			opStrSubstr(expr, fp)
+		case OP_STR_INDEX:
+			opStrIndex(expr, fp)
+		case OP_STR_TRIM_SPACE:
+			opStrTrimSpace(expr, fp)
 
 		case OP_STR_BYTE:
-			op_str_str(expr, fp)
+			opStrStr(expr, fp)
 		case OP_STR_STR:
-			op_str_str(expr, fp)
+			opStrStr(expr, fp)
 		case OP_STR_I32:
-			op_str_str(expr, fp)
+			opStrStr(expr, fp)
 		case OP_STR_I64:
-			op_str_str(expr, fp)
+			opStrStr(expr, fp)
 		case OP_STR_F32:
-			op_str_str(expr, fp)
+			opStrStr(expr, fp)
 		case OP_STR_F64:
-			op_str_str(expr, fp)
+			opStrStr(expr, fp)
 
 		case OP_MAKE:
 		case OP_READ:

--- a/cx/opcodes_bare.go
+++ b/cx/opcodes_bare.go
@@ -633,72 +633,72 @@ func init () {
 			opI32Min(expr, fp)
 
 		case OP_I64_BYTE:
-			op_i64_i64(expr, fp)
+			opI64I64(expr, fp)
 		case OP_I64_STR:
-			op_i64_i64(expr, fp)
+			opI64I64(expr, fp)
 		case OP_I64_I32:
-			op_i64_i64(expr, fp)
+			opI64I64(expr, fp)
 		case OP_I64_I64:
-			op_i64_i64(expr, fp)
+			opI64I64(expr, fp)
 		case OP_I64_F32:
-			op_i64_i64(expr, fp)
+			opI64I64(expr, fp)
 		case OP_I64_F64:
-			op_i64_i64(expr, fp)
+			opI64I64(expr, fp)
 
 		case OP_I64_PRINT:
-			op_i64_print(expr, fp)
+			opI64Print(expr, fp)
 		case OP_I64_ADD:
-			op_i64_add(expr, fp)
+			opI64Add(expr, fp)
 		case OP_I64_SUB:
-			op_i64_sub(expr, fp)
+			opI64Sub(expr, fp)
 		case OP_I64_MUL:
-			op_i64_mul(expr, fp)
+			opI64Mul(expr, fp)
 		case OP_I64_DIV:
-			op_i64_div(expr, fp)
+			opI64Div(expr, fp)
 		case OP_I64_ABS:
-			op_i64_abs(expr, fp)
+			opI64Abs(expr, fp)
 		case OP_I64_POW:
-			op_i64_pow(expr, fp)
+			opI64Pow(expr, fp)
 		case OP_I64_GT:
-			op_i64_gt(expr, fp)
+			opI64Gt(expr, fp)
 		case OP_I64_GTEQ:
-			op_i64_gteq(expr, fp)
+			opI64Gteq(expr, fp)
 		case OP_I64_LT:
-			op_i64_lt(expr, fp)
+			opI64Lt(expr, fp)
 		case OP_I64_LTEQ:
-			op_i64_lteq(expr, fp)
+			opI64Lteq(expr, fp)
 		case OP_I64_EQ:
-			op_i64_eq(expr, fp)
+			opI64Eq(expr, fp)
 		case OP_I64_UNEQ:
-			op_i64_uneq(expr, fp)
+			opI64Uneq(expr, fp)
 		case OP_I64_MOD:
-			op_i64_mod(expr, fp)
+			opI64Mod(expr, fp)
 		case OP_I64_RAND:
-			op_i64_rand(expr, fp)
+			opI64Rand(expr, fp)
 		case OP_I64_BITAND:
-			op_i64_bitand(expr, fp)
+			opI64Bitand(expr, fp)
 		case OP_I64_BITOR:
-			op_i64_bitor(expr, fp)
+			opI64Bitor(expr, fp)
 		case OP_I64_BITXOR:
-			op_i64_bitxor(expr, fp)
+			opI64Bitxor(expr, fp)
 		case OP_I64_BITCLEAR:
-			op_i64_bitclear(expr, fp)
+			opI64Bitclear(expr, fp)
 		case OP_I64_BITSHL:
-			op_i64_bitshl(expr, fp)
+			opI64Bitshl(expr, fp)
 		case OP_I64_BITSHR:
-			op_i64_bitshr(expr, fp)
+			opI64Bitshr(expr, fp)
 		case OP_I64_SQRT:
-			op_i64_sqrt(expr, fp)
+			opI64Sqrt(expr, fp)
 		case OP_I64_LOG:
-			op_i64_log(expr, fp)
+			opI64Log(expr, fp)
 		case OP_I64_LOG2:
-			op_i64_log2(expr, fp)
+			opI64Log2(expr, fp)
 		case OP_I64_LOG10:
-			op_i64_log10(expr, fp)
+			opI64Log10(expr, fp)
 		case OP_I64_MAX:
-			op_i64_max(expr, fp)
+			opI64Max(expr, fp)
 		case OP_I64_MIN:
-			op_i64_min(expr, fp)
+			opI64Min(expr, fp)
 
 		case OP_F32_IS_NAN:
 			op_f32_isnan(expr, fp)

--- a/cx/opcodes_bare.go
+++ b/cx/opcodes_bare.go
@@ -701,61 +701,61 @@ func init () {
 			opI64Min(expr, fp)
 
 		case OP_F32_IS_NAN:
-			op_f32_isnan(expr, fp)
+			opF32Isnan(expr, fp)
 		case OP_F32_BYTE:
-			op_f32_f32(expr, fp)
+			opF32F32(expr, fp)
 		case OP_F32_STR:
-			op_f32_f32(expr, fp)
+			opF32F32(expr, fp)
 		case OP_F32_I32:
-			op_f32_f32(expr, fp)
+			opF32F32(expr, fp)
 		case OP_F32_I64:
-			op_f32_f32(expr, fp)
+			opF32F32(expr, fp)
 		case OP_F32_F32:
-			op_f32_f32(expr, fp)
+			opF32F32(expr, fp)
 		case OP_F32_F64:
-			op_f32_f32(expr, fp)
+			opF32F32(expr, fp)
 		case OP_F32_PRINT:
-			op_f32_print(expr, fp)
+			opF32Print(expr, fp)
 		case OP_F32_ADD:
-			op_f32_add(expr, fp)
+			opF32Add(expr, fp)
 		case OP_F32_SUB:
-			op_f32_sub(expr, fp)
+			opF32Sub(expr, fp)
 		case OP_F32_MUL:
-			op_f32_mul(expr, fp)
+			opF32Mul(expr, fp)
 		case OP_F32_DIV:
-			op_f32_div(expr, fp)
+			opF32Div(expr, fp)
 		case OP_F32_ABS:
-			op_f32_abs(expr, fp)
+			opF32Abs(expr, fp)
 		case OP_F32_POW:
-			op_f32_pow(expr, fp)
+			opF32Pow(expr, fp)
 		case OP_F32_GT:
-			op_f32_gt(expr, fp)
+			opF32Gt(expr, fp)
 		case OP_F32_GTEQ:
-			op_f32_gteq(expr, fp)
+			opF32Gteq(expr, fp)
 		case OP_F32_LT:
-			op_f32_lt(expr, fp)
+			opF32Lt(expr, fp)
 		case OP_F32_LTEQ:
-			op_f32_lteq(expr, fp)
+			opF32Lteq(expr, fp)
 		case OP_F32_EQ:
-			op_f32_eq(expr, fp)
+			opF32Eq(expr, fp)
 		case OP_F32_UNEQ:
-			op_f32_uneq(expr, fp)
+			opF32Uneq(expr, fp)
 		case OP_F32_COS:
-			op_f32_cos(expr, fp)
+			opF32Cos(expr, fp)
 		case OP_F32_SIN:
-			op_f32_sin(expr, fp)
+			opF32Sin(expr, fp)
 		case OP_F32_SQRT:
-			op_f32_sqrt(expr, fp)
+			opF32Sqrt(expr, fp)
 		case OP_F32_LOG:
-			op_f32_log(expr, fp)
+			opF32Log(expr, fp)
 		case OP_F32_LOG2:
-			op_f32_log2(expr, fp)
+			opF32Log2(expr, fp)
 		case OP_F32_LOG10:
-			op_f32_log10(expr, fp)
+			opF32Log10(expr, fp)
 		case OP_F32_MAX:
-			op_f32_max(expr, fp)
+			opF32Max(expr, fp)
 		case OP_F32_MIN:
-			op_f32_min(expr, fp)
+			opF32Min(expr, fp)
 
 		case OP_F64_BYTE:
 			op_f64_f64(expr, fp)

--- a/cx/opcodes_bare.go
+++ b/cx/opcodes_bare.go
@@ -758,60 +758,61 @@ func init () {
 			opF32Min(expr, fp)
 
 		case OP_F64_BYTE:
-			op_f64_f64(expr, fp)
+			opF64F64(expr, fp)
 		case OP_F64_STR:
-			op_f64_f64(expr, fp)
+			opF64F64(expr, fp)
 		case OP_F64_I32:
-			op_f64_f64(expr, fp)
+			opF64F64(expr, fp)
 		case OP_F64_I64:
-			op_f64_f64(expr, fp)
+			opF64F64(expr, fp)
 		case OP_F64_F32:
-			op_f64_f64(expr, fp)
+			opF64F64(expr, fp)
 		case OP_F64_F64:
-			op_f64_f64(expr, fp)
+			opF64F64(expr, fp)
 
 		case OP_F64_PRINT:
-			op_f64_print(expr, fp)
+			opF64Print(expr, fp)
 		case OP_F64_ADD:
-			op_f64_add(expr, fp)
+			opF64Add(expr, fp)
 		case OP_F64_SUB:
-			op_f64_sub(expr, fp)
+			opF64Sub(expr, fp)
 		case OP_F64_MUL:
-			op_f64_mul(expr, fp)
+			opF64Mul(expr, fp)
 		case OP_F64_DIV:
-			op_f64_div(expr, fp)
+			opF64Div(expr, fp)
 		case OP_F64_ABS:
-			op_f64_abs(expr, fp)
+			opF64Abs(expr, fp)
 		case OP_F64_POW:
-			op_f64_pow(expr, fp)
+			opF64Pow(expr, fp)
 		case OP_F64_GT:
-			op_f64_gt(expr, fp)
+			opF64Gt(expr, fp)
 		case OP_F64_GTEQ:
-			op_f64_gteq(expr, fp)
+			opF64Gteq(expr, fp)
 		case OP_F64_LT:
-			op_f64_lt(expr, fp)
+			opF64Lt(expr, fp)
 		case OP_F64_LTEQ:
-			op_f64_lteq(expr, fp)
+			opF64Lteq(expr, fp)
 		case OP_F64_EQ:
-			op_f64_eq(expr, fp)
+			opF64Eq(expr, fp)
 		case OP_F64_UNEQ:
-			op_f64_uneq(expr, fp)
+			opF64Uneq(expr, fp)
 		case OP_F64_COS:
-			op_f64_cos(expr, fp)
+			opF64Cos(expr, fp)
 		case OP_F64_SIN:
-			op_f64_sin(expr, fp)
+			opF64Sin(expr, fp)
 		case OP_F64_SQRT:
-			op_f64_sqrt(expr, fp)
+			opF64Sqrt(expr, fp)
 		case OP_F64_LOG:
-			op_f64_log(expr, fp)
+			opF64Log(expr, fp)
 		case OP_F64_LOG2:
-			op_f64_log2(expr, fp)
+			opF64Log2(expr, fp)
 		case OP_F64_LOG10:
-			op_f64_log10(expr, fp)
+			opF64Log10(expr, fp)
 		case OP_F64_MAX:
-			op_f64_max(expr, fp)
+			opF64Max(expr, fp)
 		case OP_F64_MIN:
-			op_f64_min(expr, fp)
+			opF64Min(expr, fp)
+
 		case OP_STR_PRINT:
 			op_str_print(expr, fp)
 		case OP_STR_CONCAT:

--- a/cx/opcodes_bare.go
+++ b/cx/opcodes_bare.go
@@ -480,9 +480,9 @@ func init () {
 
 		switch opCode {
 		case OP_IDENTITY:
-			op_identity(expr, fp)
+			opIdentity(expr, fp)
 		case OP_JMP:
-			op_jmp(expr, fp, call)
+			opJmp(expr, fp, call)
 		case OP_DEBUG:
 			prgrm.PrintStack()
 


### PR DESCRIPTION
Fixes #188 (partly)

Changes:
- Renames functions in cx/op_i64.go to follow the conding standards (camel casing)
Also (since this is still pending):
 - Does the same for i8, f32, f64, str and 'misc' opcodes.

Does this change need to mentioned in CHANGELOG.md?
No