### PR TITLE
Document the CXFunction struct

### DIFF
--- a/cx/makers.go
+++ b/cx/makers.go
@@ -40,34 +40,6 @@ func MakeDefaultValue(typName string) *[]byte {
 	return &zeroVal
 }
 
-// MakeNative ...
-func MakeNative(opCode int, inputs, outputs []*CXArgument) *CXFunction {
-	fn := &CXFunction{
-		ElementID: MakeElementID(),
-		OpCode:    opCode,
-		IsNative:  true,
-	}
-
-	offset := 0
-	for _, inp := range inputs {
-		// for _, typCode := range inputs {
-		// inp := MakeArgument("", "", -1).AddType(TypeNames[typCode])
-		inp.Offset = offset
-		offset += inp.Size
-		fn.Inputs = append(fn.Inputs, inp)
-	}
-	for _, out := range outputs {
-		// for _, typCode := range outputs {
-		// fn.Outputs = append(fn.Outputs, MakeArgument("", "", -1).AddType(TypeNames[typCode]))
-		// out := MakeArgument("", "", -1).AddType(TypeNames[typCode])
-		fn.Outputs = append(fn.Outputs, out)
-		out.Offset = offset
-		offset += out.Size
-	}
-
-	return fn
-}
-
 // MakeValue ...
 func MakeValue(value string) *[]byte {
 	byts := encoder.Serialize(value)

--- a/cx/opcodes_bare.go
+++ b/cx/opcodes_bare.go
@@ -257,7 +257,7 @@ var (
 func AddOpCode(code int, name string, inputs []*CXArgument, outputs []*CXArgument) {
 	OpNames[code] = name
 	OpCodes[name] = code
-	Natives[code] = MakeNative(code, inputs, outputs)
+	Natives[code] = MakeNativeFunction(code, inputs, outputs)
 }
 
 /*

--- a/cxgo/actions/functions.go
+++ b/cxgo/actions/functions.go
@@ -5,6 +5,13 @@ import (
 	. "github.com/skycoin/cx/cx"
 )
 
+// FunctionHeader takes a function name ('ident') and either creates the
+// function if it's not known before or returns the already existing function
+// if it is.
+//
+// If the function is a method (isMethod = true), then it adds the object that
+// it's called on as the first argument.
+//
 func FunctionHeader(ident string, receiver []*CXArgument, isMethod bool) *CXFunction {
 	if isMethod {
 		if len(receiver) > 1 {


### PR DESCRIPTION
Document the CXFunction struct

Fixes #
-

Changes:
- Reorganizes and documents the members of CXFunction
- Moves MakeNative() to cxfunction.go and rename it to MakeNativeFunction()
- A little documentation of functions that I came across while finding out what's going on.

Does this change need to mentioned in CHANGELOG.md?
No