### PR TITLE
Fix #154: Sending pointers to slices to functions is now possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   * #104: Dubious error message when indexing an array with a substraction expression
   * #105: Dubious error message when inline initializing a slice
   * #131: Problem with struct literals in short variable declarations
+  * #154: Sending pointers to slices to functions is now possible
   * #218: Type checking now works with receiving variables of unexpected types
 * Documentation
   * CONTRIBUTING.md: Information about how to contribute to CX

--- a/cx/config.go
+++ b/cx/config.go
@@ -110,10 +110,10 @@ const (
 )
 
 const (
-	DEREF_ARRAY = iota
-	DEREF_FIELD
-	DEREF_POINTER
-	DEREF_DEREF
+	DEREF_ARRAY   = iota // 0
+	DEREF_FIELD          // 1
+	DEREF_POINTER        // 2
+	DEREF_DEREF          // 3
 )
 
 const (

--- a/cx/op.go
+++ b/cx/op.go
@@ -11,6 +11,7 @@ func CalculateDereferences(arg *CXArgument, finalOffset *int, fp int, dbg bool) 
 	var isPointer bool
 	var baseOffset int
 	var sizeofElement int
+
 	for _, op := range arg.DereferenceOperations {
 		switch op {
 		case DEREF_ARRAY:

--- a/cx/utilities.go
+++ b/cx/utilities.go
@@ -593,6 +593,7 @@ func IsValidSliceIndex(offset int, index int, sizeofElement int) bool {
 	sliceLen := GetSliceLen(int32(offset))
 	bytesLen := sliceLen * int32(sizeofElement)
 	index -= OBJECT_HEADER_SIZE + SLICE_HEADER_SIZE + offset
+
 	if index >= 0 && index < int(bytesLen) && (index%sizeofElement) == 0 {
 		return true
 	}

--- a/cxgo/actions/functions.go
+++ b/cxgo/actions/functions.go
@@ -563,7 +563,9 @@ func ProcessSliceAssignment(expr *CXExpression) {
 		for _, inp := range expr.Inputs {
 			assignElt := GetAssignmentElement(inp)
 
-			if assignElt.IsSlice && len(assignElt.Indexes) == 0 {
+			// we want to pass by value if we're sending the slice as a whole (no indexing)
+			// unless it's a pointer to the slice
+			if assignElt.IsSlice && len(assignElt.Indexes) == 0 && !hasDeclSpec(assignElt, DECL_POINTER) {
 				assignElt.PassBy = PASSBY_VALUE
 			}
 		}

--- a/cxgo/actions/misc.go
+++ b/cxgo/actions/misc.go
@@ -160,6 +160,17 @@ func SetCorrectArithmeticOp(expr *CXExpression) {
 	}
 }
 
+// hasDeclSpec determines if an argument has certain declaration specifier
+func hasDeclSpec (arg *CXArgument, spec int) bool {
+	found := false
+	for _, s := range arg.DeclarationSpecifiers {
+		if s == spec {
+			found = true
+		}
+	}
+	return found
+}
+
 // This function writes those bytes to PRGRM.Data
 func WritePrimary(typ int, byts []byte, isGlobal bool) []*CXExpression {
 	if pkg, err := PRGRM.GetCurrentPackage(); err == nil {

--- a/cxgo/cxgo.nex
+++ b/cxgo/cxgo.nex
@@ -653,6 +653,7 @@ func main () {
 	}
 	if options.stackSize != "" {
 		STACK_SIZE = parseMemoryString(options.stackSize)
+		DataOffset = STACK_SIZE + TYPE_POINTER_SIZE
 	}
 
 	MEMORY_SIZE = STACK_SIZE + INIT_HEAP_SIZE + TYPE_POINTER_SIZE

--- a/tests/main.cx
+++ b/tests/main.cx
@@ -394,7 +394,7 @@ func main ()() {
 	runTestEx("issue-135.cx", cx.COMPILATION_ERROR, "No compilation error when using arithmetic operators on struct instances", TEST_ISSUE, 0)
 	runTestEx("issue-141.cx", cx.SUCCESS, "Parser gets confused with `2 -2`", TEST_STABLE, 0)
 	runTestEx("issue-153.cx", cx.SUCCESS, "Panic in when assigning an empty initializer list to a []i32 variable", TEST_ISSUE, 0)
-	runTestEx("issue-154.cx", cx.SUCCESS, "Cx stack overflow when appending to a slice passed by address", TEST_ISSUE, 0)
+	runTest("issue-154.cx", cx.SUCCESS, "Cx stack overflow when appending to a slice passed by address")
 	runTestEx("issue-155.cx", cx.COMPILATION_ERROR, "Panic when trying to assign return value of a function returning void", TEST_ISSUE, 0)
 	runTest("issue-156.cx", cx.COMPILATION_ERROR, "Panic when using a function declared in another package without importing the package")
 	runTest("issue-157.cx", cx.SUCCESS, "Cx memory stomped")

--- a/tests/testdata/tokens/main.cx.txt
+++ b/tests/testdata/tokens/main.cx.txt
@@ -3101,7 +3101,7 @@ STRLIT Panic in when assigning an empty initializer list to a []i32 variable
 INTLIT 0
 RPAREN 
 SCOLON 
- IDENT runTestEx
+ IDENT runTest
 LPAREN 
 STRLIT issue-154.cx
  COMMA 
@@ -3110,10 +3110,6 @@ PERIOD
  IDENT SUCCESS
  COMMA 
 STRLIT Cx stack overflow when appending to a slice passed by address
- COMMA 
- IDENT TEST_ISSUE
- COMMA 
-INTLIT 0
 RPAREN 
 SCOLON 
  IDENT runTestEx


### PR DESCRIPTION
Fixes #154 

Changes:
- Sending pointers to slices to functions is now possible

Does this change need to mentioned in CHANGELOG.md?
Yes.