### PR TITLE
Fix #199: Trying to call an undefined function no longer throws a segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   * #104: Dubious error message when indexing an array with a substraction expression
   * #105: Dubious error message when inline initializing a slice
   * #131: Problem with struct literals in short variable declarations
+  * #199: Trying to call an undefined function no longer throws a segfault
   * #218: Type checking now works with receiving variables of unexpected types
 * Documentation
   * CONTRIBUTING.md: Information about how to contribute to CX

--- a/cxgo/cxgo.y
+++ b/cxgo/cxgo.y
@@ -1145,7 +1145,7 @@ expression_statement:
                 { $$ = nil }
 	|       expression SEMICOLON
                 {
-			if $1[len($1) - 1].Operator == nil && !$1[len($1) - 1].IsMethodCall {
+			if len($1) > 0 && $1[len($1) - 1].Operator == nil && !$1[len($1) - 1].IsMethodCall {
 				outs := $1[len($1) - 1].Outputs
 				if len(outs) > 0 {
 					println(CompilationError(outs[0].FileName, outs[0].FileLine), "invalid expression")


### PR DESCRIPTION
Fixes #199

CX was no longer throwing a segfault. It was most likely fixed by past fixes. It was tested on MacOS (Sierra), Windows and Linux (Debian).

Changes:
- If an undefined function was tried to be called, CX reported the appropriate error, but also a Golang error because it was not being handled properly. A check was added in the parser to avoid showing this Golang error.

Does this change need to mentioned in CHANGELOG.md?
Yes.