### PR TITLE
Fix #167: Passing the address of a slice element is now possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
   * #105: Dubious error message when inline initializing a slice
   * #131: Problem with struct literals in short variable declarations
   * #154: Sending pointers to slices to functions is now possible
+  * #167: Passing the address of a slice element is now possible
   * #218: Type checking now works with receiving variables of unexpected types
 * Documentation
   * CONTRIBUTING.md: Information about how to contribute to CX

--- a/cxgo/actions/expressions.go
+++ b/cxgo/actions/expressions.go
@@ -306,7 +306,7 @@ func UnaryExpression(op string, prevExprs []*CXExpression) []*CXExpression {
 		os.Exit(CX_COMPILATION_ERROR)
 	}
 	
-	exprOut := prevExprs[len(prevExprs)-1].Outputs[0]
+	exprOut := GetAssignmentElement(prevExprs[len(prevExprs)-1].Outputs[0])
 	switch op {
 	case "*":
 		exprOut.DereferenceLevels++

--- a/tests/main.cx
+++ b/tests/main.cx
@@ -400,7 +400,7 @@ func main ()() {
 	runTest("issue-157.cx", cx.SUCCESS, "Cx memory stomped")
 	runTest("issue-158.cx", cx.SUCCESS, "Invalid offset calculation of non literal strings when appended to a slice")
 	runTestEx("issue-166.cx", cx.SUCCESS, "Panic when calling a function from another package where the package name alias a local variable name", TEST_ISSUE, 0)
-	runTestEx("issue-167.cx", cx.SUCCESS, "Garbage memory when passing the address of slice element to a function", TEST_ISSUE, 0)
+	runTest("issue-167.cx", cx.SUCCESS, "Garbage memory when passing the address of slice element to a function")
 	runTestEx("issue-168.cx", cx.SUCCESS, "Type deduction of struct field fails", TEST_ISSUE, 0)
 	runTestEx("issue-169.cx", cx.COMPILATION_ERROR, "No compilation error when assigning a i32 value to a []i32 variable", TEST_ISSUE, 0)
 	runTestEx("issue-170.cx", cx.COMPILATION_ERROR, "No compilation error when comparing value of different types", TEST_ISSUE, 0)

--- a/tests/testdata/tokens/main.cx.txt
+++ b/tests/testdata/tokens/main.cx.txt
@@ -3175,7 +3175,7 @@ STRLIT Panic when calling a function from another package where the package name
 INTLIT 0
 RPAREN 
 SCOLON 
- IDENT runTestEx
+ IDENT runTest
 LPAREN 
 STRLIT issue-167.cx
  COMMA 
@@ -3184,10 +3184,6 @@ PERIOD
  IDENT SUCCESS
  COMMA 
 STRLIT Garbage memory when passing the address of slice element to a function
- COMMA 
- IDENT TEST_ISSUE
- COMMA 
-INTLIT 0
 RPAREN 
 SCOLON 
  IDENT runTestEx


### PR DESCRIPTION
Fixes #167

Changes:
- Passing the address of a slice element is now possible

Does this change need to mentioned in CHANGELOG.md?
Yes.