### PR TITLE
Fix #108: Solved a bug that occured when two functions were named the same in different packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 		assigning references to struct literals
   * #104: Dubious error message when indexing an array with a substraction expression
   * #105: Dubious error message when inline initializing a slice
+  * #108: Solved a bug that occured when two functions were named the same in
+    different packages
   * #131: Problem with struct literals in short variable declarations
   * #154: Sending pointers to slices to functions is now possible
   * #167: Passing the address of a slice element is now possible

--- a/cx/execute.go
+++ b/cx/execute.go
@@ -316,6 +316,9 @@ func (call *CXCall) ccall(prgrm *CXProgram) error {
 			*/
 			// we're going to use the next call in the callstack
 			prgrm.CallCounter++
+			if prgrm.CallCounter >= CALLSTACK_SIZE {
+				panic(STACK_OVERFLOW_ERROR)
+			}
 			newCall := &prgrm.CallStack[prgrm.CallCounter]
 			// setting the new call
 			newCall.Operator = expr.Operator

--- a/cxgo/actions/postfix.go
+++ b/cxgo/actions/postfix.go
@@ -282,7 +282,7 @@ func PostfixExpressionField (prevExprs []*CXExpression, ident string) []*CXExpre
 			prevExprs[len(prevExprs)-1].Outputs[0].IsSlice = glbl.IsSlice
 			prevExprs[len(prevExprs)-1].Outputs[0].IsStruct = glbl.IsStruct
 			prevExprs[len(prevExprs)-1].Outputs[0].Package = glbl.Package
-		} else if fn, err := PRGRM.GetFunction(ident, imp.Name); err == nil {
+		} else if fn, err := imp.GetFunction(ident); err == nil {
 			// then it's a function
 			// not sure about this next line
 			prevExprs[len(prevExprs)-1].Outputs = nil

--- a/tests/main.cx
+++ b/tests/main.cx
@@ -384,7 +384,7 @@ func main ()() {
 	runTest("issue-104.cx", cx.SUCCESS, "Dubious error message when indexing an array with a substraction expression")
 	runTest("issue-105.cx", cx.SUCCESS, "Dubious error message when inline initializing a slice")
 	runTest("issue-106a.cx issue-106.cx", cx.SUCCESS, "Troubles when accessing a global var from another package")
-	runTestEx("issue-108.cx", cx.SUCCESS, "same func names (but in different packages) collide", TEST_ISSUE, 0)
+	runTest("issue-108.cx", cx.SUCCESS, "same func names (but in different packages) collide")
 	runTest("issue-111.cx", cx.COMPILATION_ERROR, "can use vars from other packages without a 'packageName.' prefix")
 	runTest("issue-120.cx", cx.SUCCESS, "False positive when detecting variable redeclaration.")
 	runTestEx("issue-120a.cx", cx.SUCCESS, "False positive when detecting variable redeclaration.", TEST_ISSUE, 0)

--- a/tests/testdata/tokens/main.cx.txt
+++ b/tests/testdata/tokens/main.cx.txt
@@ -2959,7 +2959,7 @@ PERIOD
 STRLIT Troubles when accessing a global var from another package
 RPAREN 
 SCOLON 
- IDENT runTestEx
+ IDENT runTest
 LPAREN 
 STRLIT issue-108.cx
  COMMA 
@@ -2968,10 +2968,6 @@ PERIOD
  IDENT SUCCESS
  COMMA 
 STRLIT same func names (but in different packages) collide
- COMMA 
- IDENT TEST_ISSUE
- COMMA 
-INTLIT 0
 RPAREN 
 SCOLON 
  IDENT runTest


### PR DESCRIPTION
Fixes #108

Changes:
- Solved a bug that occured when two functions were named the same in different packages

Does this change need to mentioned in CHANGELOG.md?
Yes.