### PR TITLE
Fix #101: Using different types in shorthands now throws an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@
   * #63: Fixed a problem where inline initializations didn't work with dereferences
   * #65: Return statements now work in CX, with and without return arguments
   * #77: Fixed errors related to sending references of structs to functions and
-		assigning references to struct literals
+        assigning references to struct literals
+  * #101: Using different types in shorthands now throws an error
   * #104: Dubious error message when indexing an array with a substraction expression
   * #105: Dubious error message when inline initializing a slice
   * #131: Problem with struct literals in short variable declarations

--- a/cx/utilities.go
+++ b/cx/utilities.go
@@ -15,9 +15,8 @@ func Debug(args ...interface{}) {
 	fmt.Println(args...)
 }
 
-// IsUndOp It returns true if the operator receives undefined types as input parameters but also an operator that needs to mimic its input's type. For example, == should not return its input type, as it is always going to return a boolean
+// IsUndOp returns true if the operator receives undefined types as input parameters but also an operator that needs to mimic its input's type. For example, == should not return its input type, as it is always going to return a boolean
 func IsUndOp(fn *CXFunction) bool {
-	res := false
 	switch fn.OpCode {
 	case
 		OP_UND_BITAND,
@@ -31,10 +30,9 @@ func IsUndOp(fn *CXFunction) bool {
 		OP_UND_SUB,
 		OP_UND_NEG,
 		OP_UND_BITSHL, OP_UND_BITSHR:
-		res = true
+		return true
 	}
-
-	return res
+	return false
 }
 
 // ExprOpName ...

--- a/cxgo/actions/functions.go
+++ b/cxgo/actions/functions.go
@@ -231,8 +231,35 @@ func checkSameNativeType (expr *CXExpression) error {
 	return nil
 }
 
+// isUndSameNativeType checks if the received operator is a OP_UND_*** operator and
+// if this operator's inputs should all be of the same type
+func isUndSameNativeType (op *CXFunction) bool {
+	switch op.OpCode {
+	case
+		OP_UND_EQUAL,
+		OP_UND_UNEQUAL,
+		OP_UND_BITAND,
+		OP_UND_BITXOR,
+		OP_UND_BITOR,
+		OP_UND_BITCLEAR,
+		OP_UND_MUL,
+		OP_UND_DIV,
+		OP_UND_MOD,
+		OP_UND_ADD,
+		OP_UND_SUB,
+		OP_UND_NEG,
+		OP_UND_LT,
+		OP_UND_GT,
+		OP_UND_LTEQ,
+		OP_UND_GTEQ,
+		OP_UND_BITSHL, OP_UND_BITSHR:
+		return true
+	}
+	return false
+}
+
 func ProcessUndExpression(expr *CXExpression) {
-	if expr.Operator != nil && IsUndOp(expr.Operator) {
+	if expr.Operator != nil && isUndSameNativeType(expr.Operator) {
 		if err := checkSameNativeType(expr); err != nil {
 			println(CompilationError(CurrentFile, LineNo), err.Error())
 		}

--- a/cxgo/actions/functions.go
+++ b/cxgo/actions/functions.go
@@ -231,9 +231,9 @@ func checkSameNativeType (expr *CXExpression) error {
 	return nil
 }
 
-// isUndSameNativeType checks if the received operator is a OP_UND_*** operator and
-// if this operator's inputs should all be of the same type
-func isUndSameNativeType (op *CXFunction) bool {
+// isUndOpSameInputTypes checks if the received operator belongs to a list of OP_UND_***
+// where its inputs' types must be of the same type
+func isUndOpSameInputTypes (op *CXFunction) bool {
 	switch op.OpCode {
 	case
 		OP_UND_EQUAL,
@@ -259,7 +259,7 @@ func isUndSameNativeType (op *CXFunction) bool {
 }
 
 func ProcessUndExpression(expr *CXExpression) {
-	if expr.Operator != nil && isUndSameNativeType(expr.Operator) {
+	if expr.Operator != nil && isUndOpSameInputTypes(expr.Operator) {
 		if err := checkSameNativeType(expr); err != nil {
 			println(CompilationError(CurrentFile, LineNo), err.Error())
 		}

--- a/tests/main.cx
+++ b/tests/main.cx
@@ -378,7 +378,7 @@ func main ()() {
 	runTestEx("issue-93.cx", cx.SUCCESS, "when using 2 f32 out parameters, only the value of the 2nd gets through", TEST_GUI | TEST_STABLE, 0)
 	runTest("issue-98.cx", cx.COMPILATION_ERROR, "Variable redeclaration should not be allowed")
 	runTestEx("issue-99.cx", cx.SUCCESS, "Short variable declarations are not working with calls to methods or functions", TEST_ISSUE, 0)
-	runTestEx("issue-101.cx", cx.SUCCESS, "Panic when using equality operator between a bool and an i32", TEST_ISSUE, 0)
+	runTest("issue-101.cx", cx.COMPILATION_ERROR, "Panic when using equality operator between a bool and an i32")
 	runTestEx("issue-102.cx", cx.SUCCESS, "String concatenation using the + operator doesn't work", TEST_ISSUE, 0)
 	runTest("issue-103.cx", cx.SUCCESS, "Argument list is not parsed correctly")
 	runTest("issue-104.cx", cx.SUCCESS, "Dubious error message when indexing an array with a substraction expression")

--- a/tests/testdata/tokens/main.cx.txt
+++ b/tests/testdata/tokens/main.cx.txt
@@ -2885,19 +2885,15 @@ STRLIT Short variable declarations are not working with calls to methods or func
 INTLIT 0
 RPAREN 
 SCOLON 
- IDENT runTestEx
+ IDENT runTest
 LPAREN 
 STRLIT issue-101.cx
  COMMA 
  IDENT cx
 PERIOD 
- IDENT SUCCESS
+ IDENT COMPILATION_ERROR
  COMMA 
 STRLIT Panic when using equality operator between a bool and an i32
- COMMA 
- IDENT TEST_ISSUE
- COMMA 
-INTLIT 0
 RPAREN 
 SCOLON 
  IDENT runTestEx


### PR DESCRIPTION
Fixes #101 

Changes:
- Using different types in shorthands now throws an error

Does this change need to mentioned in CHANGELOG.md?
Yes.