### PR TITLE
Fix issue #54: No compilation error when defining a struct with dupli…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-### v0.6 (NOT YET RELEASED)
+### v0.6.1 (NOT YET RELEASED)
+* Additions
+* Libraries
+* Fixed issues
+  * #54: No compilation error when defining a struct with duplicate fields.
+* Documentation
+* IDE (WiP)
+* Miscellaneous
+
+### v0.6
 * Additions
   * Serialization and deserialization
   * Functions as first-class objects

--- a/cxgo/actions/declarations.go
+++ b/cxgo/actions/declarations.go
@@ -141,23 +141,32 @@ func DeclareGlobalInPackage(pkg *CXPackage, declarator *CXArgument, declaration_
 	}
 }
 
-func DeclareStruct(ident string, strctFlds []*CXArgument) {
-	if pkg, err := PRGRM.GetCurrentPackage(); err == nil {
-		if strct, err := PRGRM.GetStruct(ident, pkg.Name); err == nil {
-			strct.Fields = nil
-			strct.Size = 0
-
-			// var size int
-			for _, fld := range strctFlds {
-				strct.AddField(fld)
-				// size += fld.TotalSize
-			}
-			// strct.Size = size
-		} else {
-			panic(err)
-		}
-	} else {
+// DeclareStruct takes a name of a struct and a slice of fields representing
+// the members and adds the struct to the package.
+//
+func DeclareStruct(ident string, strctFlds []*CXArgument, currentFile string, lineNo int) {
+	// Make sure we are inside a package.
+	pkg, err := PRGRM.GetCurrentPackage()
+	if err != nil {
+		// FIXME: Should give a relevant error message
 		panic(err)
+	}
+
+	// Make sure a struct with the same name is not yet defined.
+	strct, err := PRGRM.GetStruct(ident, pkg.Name)
+	if err != nil {
+		// FIXME: Should give a relevant error message
+		panic(err)
+	}
+
+	strct.Fields = nil
+	strct.Size = 0
+	for _, fld := range strctFlds {
+		if _, err := strct.GetField(fld.Name); err == nil {
+			println(CompilationError(currentFile, lineNo), "Multiply defined struct field:", fld.Name)
+		} else {
+			strct.AddField(fld)
+		}
 	}
 }
 

--- a/cxgo/cxgo.y
+++ b/cxgo/cxgo.y
@@ -282,7 +282,7 @@ global_declaration:
 struct_declaration:
                 TYPE IDENTIFIER STRUCT struct_fields
                 {
-			DeclareStruct($2, $4)
+		        DeclareStruct($2, $4, CurrentFile, LineNo)
                 }
                 ;
 

--- a/cxgo/cxgo0/cxgo0.y
+++ b/cxgo/cxgo0/cxgo0.y
@@ -236,36 +236,7 @@ global_declaration:
 struct_declaration:
                 TYPE IDENTIFIER STRUCT struct_fields
                 {
-			DeclareStruct($2, $4)
-			// if pkg, err := PRGRM0.GetCurrentPackage(); err == nil {
-			// 	if strct, err := PRGRM0.GetStruct($2, pkg.Name); err == nil {
-			// 		// strct := MakeStruct($2)
-
-			// 		var size int
-			// 		for _, fld := range $4 {
-			// 			strct.AddField(fld)
-			// 			size += fld.TotalSize
-			// 		}
-			// 		strct.Size = size
-			// 		pkg.AddStruct(strct)
-			// 	} else {
-			// 		panic(err)
-			// 	}
-				
-			// 	// if _, err := PRGRM0.GetStruct($2, pkg.Name); err == nil {
-			// 	// 	strct := MakeStruct($2)
-			// 	// 	pkg.AddStruct(strct)
-
-			// 	// 	var size int
-			// 	// 	for _, fld := range $4 {
-			// 	// 		strct.AddField(fld)
-			// 	// 		size += fld.TotalSize
-			// 	// 	}
-			// 	// 	strct.Size = size
-			// 	// }
-			// } else {
-			// 	panic(err)
-			// }
+			DeclareStruct($2, $4, CurrentFile, LineNo)
                 }
                 ;
 

--- a/tests/main.cx
+++ b/tests/main.cx
@@ -344,7 +344,7 @@ func main ()() {
 	runTest("issue-51.cx issue-51a.cx", cx.SUCCESS, "Silent name clash between packages")
 	runTest("issue-52.cx", cx.COMPILATION_ERROR, "Invalid implicit cast.")
 	runTest("issue-53.cx", cx.COMPILATION_ERROR, "Panic when using +* in an expression")
-	runTestEx("issue-54.cx", cx.COMPILATION_ERROR, "No compilation error when defining a struct with duplicate fields.", TEST_ISSUE, 0)
+	runTest("issue-54.cx", cx.COMPILATION_ERROR, "No compilation error when defining a struct with duplicate fields.")
 	runTest("issue-55.cx", cx.SUCCESS, "Can't define struct with a single character identifier.")
 	runTest("issue-56.cx", cx.SUCCESS, "Panic when variable used in if statement without parenthesis.")
 	runTest("issue-57.cx", cx.SUCCESS, "Struct field stomped")


### PR DESCRIPTION
Fixes #54 No compilation error when defining a struct with duplicate fields.

Changes:
- Fixes to DeclareStruct()

Does this change need to mentioned in CHANGELOG.md?
yes