### PR TITLE
Makefile: Add formatting of cxgo/actions/ using goimports to the form…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ check: check-golden-files test ## Perform self-tests
 
 format: ## Formats the code. Must have goimports installed (use make install-linters).
 	goimports -w -local github.com/skycoin/cx ./cx
+	goimports -w -local github.com/skycoin/cx ./cxgo/actions
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/cxgo/actions/assignment.go
+++ b/cxgo/actions/assignment.go
@@ -6,10 +6,10 @@ import (
 
 // assignStructLiteralFields converts a struct literal to a series of struct field assignments.
 // For example, `foo = Item{x: 10, y: 20}` is converted to: `foo.x = 10; foo.y = 20;`.
-func assignStructLiteralFields (to []*CXExpression, from []*CXExpression, name string) []*CXExpression {
+func assignStructLiteralFields(to []*CXExpression, from []*CXExpression, name string) []*CXExpression {
 	for _, f := range from {
 		f.Outputs[0].Name = name
-		
+
 		if len(to[0].Outputs[0].Indexes) > 0 {
 			f.Outputs[0].Lengths = to[0].Outputs[0].Lengths
 			f.Outputs[0].Indexes = to[0].Outputs[0].Indexes
@@ -24,7 +24,7 @@ func assignStructLiteralFields (to []*CXExpression, from []*CXExpression, name s
 
 // StructLiteralAssignment handles struct literals, e.g. `Item{x: 10, y: 20}`, and references to
 // struct literals, e.g. `&Item{x: 10, y: 20}` in assignment expressions.
-func StructLiteralAssignment (to []*CXExpression, from []*CXExpression) []*CXExpression {
+func StructLiteralAssignment(to []*CXExpression, from []*CXExpression) []*CXExpression {
 	lastFrom := from[len(from)-1]
 	// If the last expression in `from` is declared as pointer
 	// then it means the whole struct literal needs to be passed by reference.
@@ -94,7 +94,7 @@ func ShortAssignment(expr *CXExpression, to []*CXExpression, from []*CXExpressio
 // This function is needed because CX has some standard library functions that return TYPE_UNDEFINED
 // arguments. In these cases, the output type depends on its input arguments' type. In the rest of
 // the cases, we can simply use the function's return type.
-func getOutputType (expr *CXExpression) *CXArgument {
+func getOutputType(expr *CXExpression) *CXArgument {
 	if expr.Operator.Outputs[0].Type != TYPE_UNDEFINED {
 		return expr.Operator.Outputs[0]
 	}
@@ -103,7 +103,7 @@ func getOutputType (expr *CXExpression) *CXArgument {
 }
 
 // Assignment handles assignment statements with different operators, like =, :=, +=, *=.
-func Assignment (to []*CXExpression, assignOp string, from []*CXExpression) []*CXExpression {
+func Assignment(to []*CXExpression, assignOp string, from []*CXExpression) []*CXExpression {
 	idx := len(from) - 1
 
 	if pkg, err := PRGRM.GetCurrentPackage(); err == nil {
@@ -124,7 +124,7 @@ func Assignment (to []*CXExpression, assignOp string, from []*CXExpression) []*C
 				outTypeArg := getOutputType(from[idx])
 
 				sym = MakeArgument(to[0].Outputs[0].Name, CurrentFile, LineNo).AddType(TypeNames[outTypeArg.Type])
-				
+
 				if from[idx].IsArrayLiteral {
 					sym.Size = from[idx].Inputs[0].Size
 					sym.TotalSize = from[idx].Inputs[0].TotalSize

--- a/cxgo/actions/declarations.go
+++ b/cxgo/actions/declarations.go
@@ -14,7 +14,7 @@ import (
 //        Just use pkg=nil to indicate that CurrentPackage should be used.
 //
 func DeclareGlobal(declarator *CXArgument, declaration_specifiers *CXArgument,
-	           initializer []*CXExpression, doesInitialize bool) {
+	initializer []*CXExpression, doesInitialize bool) {
 	pkg, err := PRGRM.GetCurrentPackage()
 	if err != nil {
 		panic(err)
@@ -29,8 +29,8 @@ func DeclareGlobal(declarator *CXArgument, declaration_specifiers *CXArgument,
 // new variable.
 //
 func DeclareGlobalInPackage(pkg *CXPackage,
-			    declarator *CXArgument, declaration_specifiers *CXArgument,
-			    initializer []*CXExpression, doesInitialize bool) {
+	declarator *CXArgument, declaration_specifiers *CXArgument,
+	initializer []*CXExpression, doesInitialize bool) {
 	declaration_specifiers.Package = pkg
 
 	// Treat the name a bit different whether it's defined already or not.
@@ -203,7 +203,7 @@ func DeclarePackage(ident string) {
 // DeclareImport()
 //
 func DeclareImport(ident string, currentFile string, lineNo int) {
-        // Make sure we are inside a package
+	// Make sure we are inside a package
 	pkg, err := PRGRM.GetCurrentPackage()
 	if err != nil {
 		// FIXME: Should give a relevant error message
@@ -212,7 +212,7 @@ func DeclareImport(ident string, currentFile string, lineNo int) {
 
 	// If the package is already imported, then there is nothing more to be done.
 	if _, err := pkg.GetImport(ident); err == nil {
-		return;
+		return
 	}
 
 	// If the package is already defined in the program, just add it to
@@ -246,14 +246,14 @@ func DeclareImport(ident string, currentFile string, lineNo int) {
 // Returns a list of expressions that contains the initialization, if any.
 //
 func DeclareLocal(declarator *CXArgument, declaration_specifiers *CXArgument,
-     	          initializer []*CXExpression, doesInitialize bool) []*CXExpression {
+	initializer []*CXExpression, doesInitialize bool) []*CXExpression {
 	if FoundCompileErrors {
 		return nil
 	}
 
 	declaration_specifiers.IsLocalDeclaration = true
 
-        pkg, err := PRGRM.GetCurrentPackage()
+	pkg, err := PRGRM.GetCurrentPackage()
 	if err != nil {
 		panic(err)
 	}
@@ -291,7 +291,7 @@ func DeclareLocal(declarator *CXArgument, declaration_specifiers *CXArgument,
 			declaration_specifiers.FileLine = declarator.FileLine
 			declaration_specifiers.Package = pkg
 			declaration_specifiers.PreviouslyDeclared = true
-				
+
 			// THEN the expression has outputs created from the result of
 			// handling a dot notation initializer, and it needs to be replaced
 			// ELSE we simply add it using `AddOutput`
@@ -403,7 +403,7 @@ func DeclarationSpecifiersBasic(typ int) *CXArgument {
 
 // DeclarationSpecifiersStruct() declares a struct
 func DeclarationSpecifiersStruct(ident string, pkgName string,
-				 isExternal bool, currentFile string, lineNo int) *CXArgument {
+	isExternal bool, currentFile string, lineNo int) *CXArgument {
 	pkg, err := PRGRM.GetCurrentPackage()
 	if err != nil {
 		panic(err)

--- a/cxgo/actions/expressions.go
+++ b/cxgo/actions/expressions.go
@@ -3,16 +3,17 @@ package actions
 import (
 	"fmt"
 	"os"
-	
-	. "github.com/skycoin/cx/cx"
+
 	"github.com/skycoin/skycoin/src/cipher/encoder"
+
+	. "github.com/skycoin/cx/cx"
 )
 
 // ReturnExpressions stores the `Size` of the return arguments represented by `Expressions`.
 // For example: `return foo() + bar()` is a set of 3 expressions and they represent a single return argument
 type ReturnExpressions struct {
-	Size          int
-	Expressions   []*CXExpression
+	Size        int
+	Expressions []*CXExpression
 }
 
 func IterationExpressions(init []*CXExpression, cond []*CXExpression, incr []*CXExpression, statements []*CXExpression) []*CXExpression {
@@ -81,7 +82,7 @@ func IterationExpressions(init []*CXExpression, cond []*CXExpression, incr []*CX
 	return exprs
 }
 
-func trueJmpExpressions () []*CXExpression {
+func trueJmpExpressions() []*CXExpression {
 	pkg, err := PRGRM.GetCurrentPackage()
 	if err != nil {
 		panic(err)
@@ -97,7 +98,7 @@ func trueJmpExpressions () []*CXExpression {
 	return []*CXExpression{expr}
 }
 
-func BreakExpressions () []*CXExpression {
+func BreakExpressions() []*CXExpression {
 	exprs := trueJmpExpressions()
 	exprs[0].IsBreak = true
 	return exprs
@@ -170,7 +171,7 @@ func SelectionExpressions(condExprs []*CXExpression, thenExprs []*CXExpression, 
 }
 
 // resolveTypeForUnd tries to determine the type that will be returned from an expression
-func resolveTypeForUnd (expr *CXExpression) int {
+func resolveTypeForUnd(expr *CXExpression) int {
 	if len(expr.Inputs) > 0 {
 		// it's a literal
 		return expr.Inputs[0].Type
@@ -192,7 +193,7 @@ func resolveTypeForUnd (expr *CXExpression) int {
 	return -1
 }
 
-func UndefinedTypeOperation (leftExprs []*CXExpression, rightExprs []*CXExpression, operator *CXFunction) (out []*CXExpression) {
+func UndefinedTypeOperation(leftExprs []*CXExpression, rightExprs []*CXExpression, operator *CXFunction) (out []*CXExpression) {
 	pkg, err := PRGRM.GetCurrentPackage()
 	if err != nil {
 		panic(err)
@@ -348,7 +349,7 @@ func UnaryExpression(op string, prevExprs []*CXExpression) []*CXExpression {
 
 // AssociateReturnExpressions associates the output of `retExprs` to the
 // `idx`th output parameter of the current function.
-func AssociateReturnExpressions (idx int, retExprs []*CXExpression) []*CXExpression {
+func AssociateReturnExpressions(idx int, retExprs []*CXExpression) []*CXExpression {
 	var pkg *CXPackage
 	var fn *CXFunction
 	var err error
@@ -372,7 +373,7 @@ func AssociateReturnExpressions (idx int, retExprs []*CXExpression) []*CXExpress
 
 	if lastExpr.Operator == nil {
 		lastExpr.Operator = Natives[OP_IDENTITY]
-		
+
 		lastExpr.Inputs = lastExpr.Outputs
 		lastExpr.Outputs = nil
 		lastExpr.AddOutput(out)
@@ -386,13 +387,13 @@ func AssociateReturnExpressions (idx int, retExprs []*CXExpression) []*CXExpress
 		return append(retExprs, expr)
 	} else {
 		lastExpr.AddOutput(out)
-		
+
 		return retExprs
 	}
 }
 
 // AddJmpToReturnExpressions adds an jump expression that makes a function stop its execution
-func AddJmpToReturnExpressions (exprs ReturnExpressions) []*CXExpression {
+func AddJmpToReturnExpressions(exprs ReturnExpressions) []*CXExpression {
 	var pkg *CXPackage
 	var fn *CXFunction
 	var err error
@@ -408,10 +409,10 @@ func AddJmpToReturnExpressions (exprs ReturnExpressions) []*CXExpression {
 	}
 
 	retExprs := exprs.Expressions
-	
+
 	if len(fn.Outputs) != exprs.Size && exprs.Expressions != nil {
 		lastExpr := retExprs[len(retExprs)-1]
-		
+
 		var plural1 string
 		var plural2 string = "s"
 		var plural3 string = "were"
@@ -422,10 +423,10 @@ func AddJmpToReturnExpressions (exprs ReturnExpressions) []*CXExpression {
 			plural2 = ""
 			plural3 = "was"
 		}
-		
+
 		println(CompilationError(lastExpr.FileName, lastExpr.FileLine), fmt.Sprintf("function '%s' expects to return %d argument%s, but %d output argument%s %s provided", fn.Name, len(fn.Outputs), plural1, exprs.Size, plural2, plural3))
 	}
-	
+
 	// expression to jump to the end of the embedding function
 	expr := MakeExpression(Natives[OP_JMP], CurrentFile, LineNo)
 

--- a/cxgo/actions/functions.go
+++ b/cxgo/actions/functions.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	
+
 	. "github.com/skycoin/cx/cx"
 )
 
@@ -173,7 +173,7 @@ func FunctionCall(exprs []*CXExpression, args []*CXExpression) []*CXExpression {
 				} else {
 					out = MakeArgument(MakeGenSym(LOCAL_PREFIX), CurrentFile, inpExpr.FileLine).AddType(TypeNames[inpExpr.Operator.Outputs[0].Type])
 					out.DeclarationSpecifiers = inpExpr.Operator.Outputs[0].DeclarationSpecifiers
-					
+
 					out.CustomType = inpExpr.Operator.Outputs[0].CustomType
 
 					if inpExpr.Operator.Outputs[0].CustomType != nil {
@@ -217,7 +217,7 @@ func undOutputSize(expr *CXExpression) int {
 
 // checkSameNativeType checks if all the inputs of an expression are of the same type.
 // It is used mainly to prevent implicit castings in arithmetic operations
-func checkSameNativeType (expr *CXExpression) error {
+func checkSameNativeType(expr *CXExpression) error {
 	if len(expr.Inputs) < 1 {
 		return errors.New("cannot perform arithmetic without operands")
 	}
@@ -233,7 +233,7 @@ func checkSameNativeType (expr *CXExpression) error {
 
 // isUndOpSameInputTypes checks if the received operator belongs to a list of OP_UND_***
 // where its inputs' types must be of the same type
-func isUndOpSameInputTypes (op *CXFunction) bool {
+func isUndOpSameInputTypes(op *CXFunction) bool {
 	switch op.OpCode {
 	case
 		OP_UND_EQUAL,
@@ -387,13 +387,13 @@ func ProcessGoTos(fn *CXFunction, exprs []*CXExpression) {
 	}
 }
 
-func GetFormattedType (arg *CXArgument) string {
+func GetFormattedType(arg *CXArgument) string {
 	typ := ""
 	elt := GetAssignmentElement(arg)
 
 	// this is used to know what arg.Lengths index to use
 	// used for cases like [5]*[3]i32, where we jump to another decl spec
-	arrDeclCount := len(arg.Lengths)-1
+	arrDeclCount := len(arg.Lengths) - 1
 	// looping declaration specifiers
 	for _, spec := range elt.DeclarationSpecifiers {
 		switch spec {
@@ -418,11 +418,11 @@ func GetFormattedType (arg *CXArgument) string {
 			}
 		}
 	}
-	
+
 	return typ
 }
 
-func checkMatchParamTypes (expr *CXExpression, expected, received []*CXArgument, isInputs bool) {
+func checkMatchParamTypes(expr *CXExpression, expected, received []*CXArgument, isInputs bool) {
 	for i, inp := range expected {
 		expectedType := GetFormattedType(expected[i])
 		receivedType := GetFormattedType(received[i])
@@ -449,7 +449,7 @@ func checkMatchParamTypes (expr *CXExpression, expected, received []*CXArgument,
 			} else {
 				println(CompilationError(expr.Outputs[i].FileName, expr.Outputs[i].FileLine), fmt.Sprintf("function '%s' expected receiving variable of type '%s'; '%s' was provided", opName, expectedType, receivedType))
 			}
-			
+
 		}
 	}
 }
@@ -492,7 +492,7 @@ func CheckTypes(expr *CXExpression) {
 				plural2 = ""
 				plural3 = "was"
 			}
-			
+
 			println(CompilationError(expr.FileName, expr.FileLine), fmt.Sprintf("operator '%s' expects to return %d output%s, but %d receiving argument%s %s provided", opName, len(expr.Operator.Outputs), plural1, len(expr.Outputs), plural2, plural3))
 			os.Exit(CX_COMPILATION_ERROR)
 		}
@@ -518,7 +518,6 @@ func CheckTypes(expr *CXExpression) {
 				receivedType = TypeNames[GetAssignmentElement(expr.Inputs[i]).Type]
 			}
 
-			
 			// if GetAssignmentElement(expr.Outputs[i]).Type != GetAssignmentElement(inp).Type {
 			if receivedType != expectedType {
 				if expr.IsStructLiteral {
@@ -558,7 +557,7 @@ func ProcessStringAssignment(expr *CXExpression) {
 
 // ProcessReferenceAssignment checks if the reference of a symbol can be assigned to the expression's output.
 // For example: `var foo i32; var bar i32; bar = &foo` is not valid.
-func ProcessReferenceAssignment (expr *CXExpression) {
+func ProcessReferenceAssignment(expr *CXExpression) {
 	for _, out := range expr.Outputs {
 		if out.PassBy == PASSBY_REFERENCE &&
 			!hasDeclSpec(out, DECL_POINTER) &&
@@ -566,7 +565,7 @@ func ProcessReferenceAssignment (expr *CXExpression) {
 			println(CompilationError(CurrentFile, LineNo), "invalid reference assignment", out.Name)
 		}
 	}
-	
+
 }
 
 func ProcessSlice(inp *CXArgument) {
@@ -810,7 +809,7 @@ func CopyArgFields(sym *CXArgument, arg *CXArgument) {
 			case DECL_POINTER:
 				if sym.FileLine != arg.FileLine {
 					// This function is also called so it assigns offset and other fields to signature parameters
-					// 
+					//
 					declSpec = append(declSpec, DECL_POINTER)
 				}
 			}

--- a/cxgo/actions/interactive.go
+++ b/cxgo/actions/interactive.go
@@ -2,8 +2,9 @@ package actions
 
 import (
 	"fmt"
-	. "github.com/skycoin/cx/cx"
 	"time"
+
+	. "github.com/skycoin/cx/cx"
 )
 
 func Stepping(steps int, delay int, withDelay bool) {

--- a/cxgo/actions/literals.go
+++ b/cxgo/actions/literals.go
@@ -1,8 +1,9 @@
 package actions
 
 import (
-	. "github.com/skycoin/cx/cx"
 	"github.com/skycoin/skycoin/src/cipher/encoder"
+
+	. "github.com/skycoin/cx/cx"
 )
 
 func SliceLiteralExpression(typSpec int, exprs []*CXExpression) []*CXExpression {

--- a/cxgo/actions/misc.go
+++ b/cxgo/actions/misc.go
@@ -161,7 +161,7 @@ func SetCorrectArithmeticOp(expr *CXExpression) {
 }
 
 // hasDeclSpec determines if an argument has certain declaration specifier
-func hasDeclSpec (arg *CXArgument, spec int) bool {
+func hasDeclSpec(arg *CXArgument, spec int) bool {
 	found := false
 	for _, s := range arg.DeclarationSpecifiers {
 		if s == spec {

--- a/cxgo/actions/postfix.go
+++ b/cxgo/actions/postfix.go
@@ -2,9 +2,11 @@ package actions
 
 import (
 	"fmt"
-	. "github.com/skycoin/cx/cx"
-	"github.com/skycoin/skycoin/src/cipher/encoder"
 	"os"
+
+	"github.com/skycoin/skycoin/src/cipher/encoder"
+
+	. "github.com/skycoin/cx/cx"
 )
 
 // PostfixExpressionArray...
@@ -166,7 +168,7 @@ func PostfixExpressionIncDec(prevExprs []*CXExpression, isInc bool) []*CXExpress
 
 // PostfixExpressionField handles the dot notation that can follow an identifier.
 // Examples are: `foo.bar`, `foo().bar`, `pkg.foo`
-func PostfixExpressionField (prevExprs []*CXExpression, ident string) []*CXExpression {
+func PostfixExpressionField(prevExprs []*CXExpression, ident string) []*CXExpression {
 	lastExpr := prevExprs[len(prevExprs)-1]
 
 	// THEN it's a function call, e.g. foo().fld
@@ -222,7 +224,7 @@ func PostfixExpressionField (prevExprs []*CXExpression, ident string) []*CXExpre
 		expr.AddOutput(inp)
 
 		prevExprs = append(prevExprs, expr)
-		
+
 		lastExpr = prevExprs[len(prevExprs)-1]
 	}
 
@@ -297,7 +299,7 @@ func PostfixExpressionField (prevExprs []*CXExpression, ident string) []*CXExpre
 		if IsCorePackage(left.Name) {
 			println(CompilationError(left.FileName, left.FileLine),
 				fmt.Sprintf("identifier '%s' does not exist",
-					    left.Name))
+					left.Name))
 			os.Exit(CX_COMPILATION_ERROR)
 		}
 		// then it's a struct


### PR DESCRIPTION
Add automatic formatting to cxgo/actions/

Fixes # -

Changes:
- Add formatting of cxgo/actions/ to Makefile (make format)
- All the formatting changes done by executing 'make format' after the addition

Does this change need to mentioned in CHANGELOG.md?
no