### PR TITLE
Removed interpret flag.

### DIFF
--- a/cxgo/actions/config.go
+++ b/cxgo/actions/config.go
@@ -15,7 +15,6 @@ var WebPersistantMode bool
 var BaseOutput bool
 var ReplMode bool
 var HelpMode bool
-var InterpretMode bool
 var CompileMode bool
 var ReplTargetFn string = ""
 var ReplTargetStrct string = ""

--- a/cxgo/cxgo.nex
+++ b/cxgo/cxgo.nex
@@ -207,15 +207,10 @@ import (
 	"net/http"
 	
 	"runtime"
-	//"runtime/debug"
 
-	//"github.com/skycoin/viscript/signal"
-	
-	// "github.com/skycoin/skycoin/src/cipher/encoder"
 	. "github.com/skycoin/cx/cx"
 	. "github.com/skycoin/cx/cxgo/actions"
 	"github.com/skycoin/cx/cxgo/cxgo0"
-	// "github.com/skycoin/cx/src/interpreted"
 )
 
 const VERSION = "0.6.0"
@@ -570,7 +565,7 @@ func addInitFunction (PRGRM *CXProgram) {
 		PRGRM.SelectFunction(MAIN_FUNC)
 	} else {
 		panic(err)
-}
+	}
 }
 
 func isJSON(str string) bool {
@@ -1029,19 +1024,11 @@ func main () {
 	if options.replMode || len(sourceCode) == 0 {
 		repl()
 	} else if !CompileMode && !BaseOutput && len(sourceCode) > 0 {
-		if InterpretMode {
-			if err := PRGRM.RunCompiled(0, cxArgs); err != nil {
-				fmt.Println(err)
-				repl()
-			}
-		} else {
-			if err := PRGRM.RunCompiled(0, cxArgs); err != nil {
-				panic(err)
-				// repl()
-			}
-			if AssertFailed() {
-				os.Exit(CX_ASSERT)
-			}
+		if err := PRGRM.RunCompiled(0, cxArgs); err != nil {
+			panic(err)
+		}
+		if AssertFailed() {
+			os.Exit(CX_ASSERT)
 		}
 	}
 	

--- a/cxgo/flags.go
+++ b/cxgo/flags.go
@@ -13,9 +13,6 @@ type cxCmdFlags struct {
 	compileOutput       string
 	newProject          bool
 	replMode            bool
-	signalClientMode    bool
-	signalClientID      int
-	signalServerAddress string
 	webMode             bool
 	ideMode             bool
 	webPersistentMode   bool
@@ -34,9 +31,6 @@ func defaultCmdFlags() cxCmdFlags {
 		compileOutput:       "",
 		newProject:          false,
 		replMode:            false,
-		signalClientMode:    false,
-		signalClientID:      1,
-		signalServerAddress: "localhost:7999",
 		webMode:             false,
 		ideMode:             false,
 		webPersistentMode:   false,
@@ -76,10 +70,6 @@ func registerFlags(options *cxCmdFlags) {
 	flag.StringVar(&options.maxHeap, "hm", options.maxHeap, "alias for -max-heap")
 	flag.StringVar(&options.stackSize, "stack-size", options.stackSize, "Set the stack size for the CX virtual machine")
 	flag.StringVar(&options.stackSize, "ss", options.stackSize, "alias for -stack-size")
-	// viscript options
-	// flag.BoolVar(&options.signalClientMode, "signal-client", options.signalClientMode, "Run signal client")
-	// flag.IntVar(&options.signalClientID, "signal-client-id", options.signalClientID, "Id of signal client (default 1)")
-	// flag.StringVar(&options.signalServerAddress, "signal-client-address", options.signalServerAddress, "Address of signal server (default 'localhost:7999')")
 }
 
 func printHelp() {
@@ -94,11 +84,6 @@ CX options:
 -r, --repl                        Loads source files into memory and starts a read-eval-print loop.
 -w, --web                         Start CX as a web service.
 -ide, --ide						            Start CX as a web service, and Leaps service start also.
-
-Signal options:
--signal-client                   Run signal client
--signal-client-id UINT           Id of signal client (default 1)
--signal-server-address STRING    Address of signal server (default "localhost:7999")
 
 Notes:
 * Options --compile and --repl are mutually exclusive.


### PR DESCRIPTION
Changes:
- CX hasn't been using the `-i` flag for a while. This flag was used to run CX in interpreted mode. CX now always parses the program, transcompiles it to Golang and then runs it.

Does this change need to mentioned in CHANGELOG.md?
No.