### PR TITLE
Fix #153: Panic in when assigning an empty initializer list to a []i3…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * #82: Empty code blocks (even if they contain commented-out lines) crash like this.
   * #99: Short variable declarations are not working with calls to methods or functions.
   * #102: String concatenation using the + operator doesn't work.
+  * #153: Panic in when assigning an empty initializer list to a []i32 variable.
   * #247: No compilation error when variables are inline initialized.
   * #244: Crash when using a constant expression in a slice literal expression.
 	* The problem actually involved the incapability of using expressions as

--- a/cxgo/cxgo.y
+++ b/cxgo/cxgo.y
@@ -1018,30 +1018,35 @@ assignment_expression:
                 struct_literal_expression
 	|       unary_expression assignment_operator assignment_expression
                 {
-			if $3[0].IsArrayLiteral {
-				if $2 != "=" && $2 != ":=" {
-					panic("")
-				}
-				if $2 == ":=" {
-					for _, from := range $3 {
-						from.Outputs[0].IsShortDeclaration = true
-						from.Outputs[0].PreviouslyDeclared = true
+			if $3 == nil {
+				$$ = nil
+			}
+			if $3 != nil {
+				if $3[0].IsArrayLiteral {
+					if $2 != "=" && $2 != ":=" {
+						panic("")
 					}
-				}
-				$$ = ArrayLiteralAssignment($1, $3)
-			} else if $3[len($3) - 1].IsStructLiteral {
-				if $2 != "=" && $2 != ":=" {
-					panic("")
-				}
-				if $2 == ":=" {
-					for _, from := range $3 {
-						from.Outputs[0].IsShortDeclaration = true
-						from.Outputs[0].PreviouslyDeclared = true
+					if $2 == ":=" {
+						for _, from := range $3 {
+							from.Outputs[0].IsShortDeclaration = true
+							from.Outputs[0].PreviouslyDeclared = true
+						}
 					}
+					$$ = ArrayLiteralAssignment($1, $3)
+				} else if $3[len($3) - 1].IsStructLiteral {
+					if $2 != "=" && $2 != ":=" {
+						panic("")
+					}
+					if $2 == ":=" {
+						for _, from := range $3 {
+							from.Outputs[0].IsShortDeclaration = true
+							from.Outputs[0].PreviouslyDeclared = true
+						}
+					}
+					$$ = StructLiteralAssignment($1, $3)
+				} else {
+					$$ = Assignment($1, $2, $3)
 				}
-				$$ = StructLiteralAssignment($1, $3)
-			} else {
-				$$ = Assignment($1, $2, $3)
 			}
                 }
                 ;

--- a/tests/issue-153.cx
+++ b/tests/issue-153.cx
@@ -2,5 +2,5 @@ package main
 func main()(){
 	var si []i32
 	si = []i32{}
-    test(len(si), 0, "")
+	test(len(si), 0, "")
 }

--- a/tests/main.cx
+++ b/tests/main.cx
@@ -397,7 +397,7 @@ func main ()() {
 	runTest("issue-134.cx", cx.COMPILATION_ERROR, "Panic when declaring a variable of an unknown type")
 	runTestEx("issue-135.cx", cx.COMPILATION_ERROR, "No compilation error when using arithmetic operators on struct instances", TEST_ISSUE, 0)
 	runTestEx("issue-141.cx", cx.SUCCESS, "Parser gets confused with `2 -2`", TEST_STABLE, 0)
-	runTestEx("issue-153.cx", cx.SUCCESS, "Panic in when assigning an empty initializer list to a []i32 variable", TEST_ISSUE, 0)
+	runTest("issue-153.cx", cx.SUCCESS, "Panic in when assigning an empty initializer list to a []i32 variable")
 	runTest("issue-154.cx", cx.SUCCESS, "Cx stack overflow when appending to a slice passed by address")
 	runTestEx("issue-155.cx", cx.COMPILATION_ERROR, "Panic when trying to assign return value of a function returning void", TEST_ISSUE, 0)
 	runTest("issue-156.cx", cx.COMPILATION_ERROR, "Panic when using a function declared in another package without importing the package")

--- a/tests/testdata/tokens/main.cx.txt
+++ b/tests/testdata/tokens/main.cx.txt
@@ -3104,7 +3104,7 @@ STRLIT Parser gets confused with `2 -2`
 INTLIT 0
 RPAREN 
 SCOLON 
- IDENT runTestEx
+ IDENT runTest
 LPAREN 
 STRLIT issue-153.cx
  COMMA 
@@ -3113,10 +3113,6 @@ PERIOD
  IDENT SUCCESS
  COMMA 
 STRLIT Panic in when assigning an empty initializer list to a []i32 variable
- COMMA 
- IDENT TEST_ISSUE
- COMMA 
-INTLIT 0
 RPAREN 
 SCOLON 
  IDENT runTest


### PR DESCRIPTION
…2 variable.

Fixes #153

Changes:
- Empty slice literals are now handled correctly.

Does this change need to mentioned in CHANGELOG.md?
Yes.