### PR TITLE
Fix #168: Type deduction of struct field fails.

### DIFF
--- a/cxgo/actions/functions.go
+++ b/cxgo/actions/functions.go
@@ -1100,11 +1100,11 @@ func GetGlobalSymbol(symbols *[]map[string]*CXArgument, symPkg *CXPackage, ident
 
 func PreFinalSize(finalSize *int, sym *CXArgument, arg *CXArgument) {
 	for _, op := range sym.DereferenceOperations {
+		if GetAssignmentElement(sym).IsSlice {
+			continue
+		}
 		switch op {
 		case DEREF_ARRAY:
-			if GetAssignmentElement(sym).IsSlice {
-				continue
-			}
 			var subSize int = 1
 
 			for _, len := range GetAssignmentElement(sym).Lengths[:len(GetAssignmentElement(sym).Indexes)] {

--- a/tests/main.cx
+++ b/tests/main.cx
@@ -405,7 +405,7 @@ func main ()() {
 	runTest("issue-158.cx", cx.SUCCESS, "Invalid offset calculation of non literal strings when appended to a slice")
 	runTestEx("issue-166.cx", cx.SUCCESS, "Panic when calling a function from another package where the package name alias a local variable name", TEST_ISSUE, 0)
 	runTest("issue-167.cx", cx.SUCCESS, "Garbage memory when passing the address of slice element to a function")
-	runTestEx("issue-168.cx", cx.SUCCESS, "Type deduction of struct field fails", TEST_ISSUE, 0)
+	runTest("issue-168.cx", cx.SUCCESS, "Type deduction of struct field fails")
 	runTest("issue-169.cx", cx.COMPILATION_ERROR, "No compilation error when assigning a i32 value to a []i32 variable")
 	runTest("issue-170.cx", cx.COMPILATION_ERROR, "No compilation error when comparing value of different types")
 	runTest("-stack-size 30 issue-207a.cx", cx.RUNTIME_STACK_OVERFLOW_ERROR, "No stack overflow error")

--- a/tests/testdata/tokens/main.cx.txt
+++ b/tests/testdata/tokens/main.cx.txt
@@ -3196,7 +3196,7 @@ PERIOD
 STRLIT Garbage memory when passing the address of slice element to a function
 RPAREN 
 SCOLON 
- IDENT runTestEx
+ IDENT runTest
 LPAREN 
 STRLIT issue-168.cx
  COMMA 
@@ -3205,10 +3205,6 @@ PERIOD
  IDENT SUCCESS
  COMMA 
 STRLIT Type deduction of struct field fails
- COMMA 
- IDENT TEST_ISSUE
- COMMA 
-INTLIT 0
 RPAREN 
 SCOLON 
  IDENT runTest


### PR DESCRIPTION
Fixes #168

Changes:
- Slice struct fields' sizes were not being calculated correctly. The parser was changed a bit to correctly determine these sizes.

Does this change need to mentioned in CHANGELOG.md?
Yes.