### PR TITLE
Fix #166: Panic when calling a function from another package where th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-### v0.6.1 (NOT YET RELEASED)
+### v0.6.2 (NOT YET RELEASED)
+* Fixed issues
+  * #166: Panic when calling a function from another package where the package name alias a local variable name
+
+### v0.6.1
 * Additions
   * Support for lexical scoping
   * `if/elseif` and `if/elseif/else` statements now work properly.

--- a/cxgo/actions/functions.go
+++ b/cxgo/actions/functions.go
@@ -750,7 +750,8 @@ func ProcessMethodCall(expr *CXExpression, symbols *[]map[string]*CXArgument, of
 				}
 				argOut, err := lookupSymbol(out.Package.Name, out.Name, symbols)
 				if err != nil {
-					panic("")
+					println(CompilationError(out.FileName, out.FileLine), fmt.Sprintf("identifier '%s' does not exist", out.Name))
+					os.Exit(CX_COMPILATION_ERROR)
 				}
 				// then we found an output
 				if len(out.Fields) > 0 {
@@ -796,6 +797,11 @@ func ProcessMethodCall(expr *CXExpression, symbols *[]map[string]*CXArgument, of
 
 					strct := argOut.CustomType
 
+					if strct == nil {
+						println(CompilationError(argOut.FileName, argOut.FileLine), fmt.Sprintf("illegal method call or field access on identifier '%s' of primitive type '%s'", argOut.Name, TypeNames[argOut.Type]))
+						os.Exit(CX_COMPILATION_ERROR)
+					}
+
 					expr.Inputs = append(expr.Outputs[:1], expr.Inputs...)
 
 					expr.Outputs = expr.Outputs[:len(expr.Outputs)-1]
@@ -816,13 +822,18 @@ func ProcessMethodCall(expr *CXExpression, symbols *[]map[string]*CXArgument, of
 
 			argOut, err := lookupSymbol(out.Package.Name, out.Name, symbols)
 			if err != nil {
-				println(CompilationError(out.FileName, out.FileLine), fmt.Sprintf("'%s.%s' not found", out.Package.Name, out.Name))
+				println(CompilationError(out.FileName, out.FileLine), fmt.Sprintf("identifier '%s' does not exist", out.Name))
 				os.Exit(CX_COMPILATION_ERROR)
 			}
 
 			// then we found an output
 			if len(out.Fields) > 0 {
 				strct := argOut.CustomType
+
+				if strct == nil {
+					println(CompilationError(argOut.FileName, argOut.FileLine), fmt.Sprintf("illegal method call or field access on identifier '%s' of primitive type '%s'", argOut.Name, TypeNames[argOut.Type]))
+					os.Exit(CX_COMPILATION_ERROR)
+				}
 
 				if fn, err := strct.Package.GetMethod(strct.Name+"."+out.Fields[len(out.Fields)-1].Name, strct.Name); err == nil {
 					expr.Operator = fn

--- a/tests/main.cx
+++ b/tests/main.cx
@@ -403,7 +403,7 @@ func main ()() {
 	runTest("issue-156.cx", cx.COMPILATION_ERROR, "Panic when using a function declared in another package without importing the package")
 	runTest("issue-157.cx", cx.SUCCESS, "Cx memory stomped")
 	runTest("issue-158.cx", cx.SUCCESS, "Invalid offset calculation of non literal strings when appended to a slice")
-	runTestEx("issue-166.cx", cx.SUCCESS, "Panic when calling a function from another package where the package name alias a local variable name", TEST_ISSUE, 0)
+	runTest("issue-166.cx", cx.COMPILATION_ERROR, "Panic when calling a function from another package where the package name alias a local variable name")
 	runTest("issue-167.cx", cx.SUCCESS, "Garbage memory when passing the address of slice element to a function")
 	runTest("issue-168.cx", cx.SUCCESS, "Type deduction of struct field fails")
 	runTest("issue-169.cx", cx.COMPILATION_ERROR, "No compilation error when assigning a i32 value to a []i32 variable")

--- a/tests/testdata/tokens/main.cx.txt
+++ b/tests/testdata/tokens/main.cx.txt
@@ -3170,19 +3170,15 @@ PERIOD
 STRLIT Invalid offset calculation of non literal strings when appended to a slice
 RPAREN 
 SCOLON 
- IDENT runTestEx
+ IDENT runTest
 LPAREN 
 STRLIT issue-166.cx
  COMMA 
  IDENT cx
 PERIOD 
- IDENT SUCCESS
+ IDENT COMPILATION_ERROR
  COMMA 
 STRLIT Panic when calling a function from another package where the package name alias a local variable name
- COMMA 
- IDENT TEST_ISSUE
- COMMA 
-INTLIT 0
 RPAREN 
 SCOLON 
  IDENT runTest


### PR DESCRIPTION
…e package name alias a local variable name

Fixes #166

Changes:
- Error is thrown when trying to call a method or accessing a field of a variable that's not a struct instance.

Does this change need to mentioned in CHANGELOG.md?
Yes.