### PR TITLE
Fix #70: Inline field and index dereferences to function calls' outputs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 	examples: 1.0 1. .1 1e+2 .1e-3
 * Libraries
 * Fixed issues
+  * #70: Inline field and index "dereferences" to function calls' outputs.
   * #76: Using int literal 0 where 0.0 was needed gave no error.
   * #166: Panic when calling a function from another package where the package name alias a local variable name
   * #271: CX floats cannot handle exponents

--- a/cxgo/actions/functions.go
+++ b/cxgo/actions/functions.go
@@ -318,9 +318,12 @@ func ProcessPointerStructs(expr *CXExpression) {
 func processTestExpression (expr *CXExpression) {
 	if expr.Operator != nil {
 		opCode := expr.Operator.OpCode
-		if (opCode == OP_ASSERT || opCode == OP_TEST || opCode == OP_PANIC) &&
-			expr.Inputs[0].Type != expr.Inputs[1].Type {
-			println(CompilationError(CurrentFile, LineNo), fmt.Sprintf("first and second input arguments' types are not equal in '%s' call", OpNames[expr.Operator.OpCode]))
+		if (opCode == OP_ASSERT || opCode == OP_TEST || opCode == OP_PANIC) {
+			inp1Type := GetFormattedType(expr.Inputs[0])
+			inp2Type := GetFormattedType(expr.Inputs[1])
+			if inp1Type != inp2Type {
+				println(CompilationError(CurrentFile, LineNo), fmt.Sprintf("first and second input arguments' types are not equal in '%s' call ('%s' != '%s')", OpNames[expr.Operator.OpCode], inp1Type, inp2Type))
+			}
 		}
 	}
 }

--- a/cxgo/actions/postfix.go
+++ b/cxgo/actions/postfix.go
@@ -13,10 +13,46 @@ import (
 //
 func PostfixExpressionArray(prevExprs []*CXExpression, postExprs []*CXExpression) []*CXExpression {
 	var elt *CXArgument
-	if len(prevExprs[len(prevExprs)-1].Outputs[0].Fields) > 0 {
-		elt = prevExprs[len(prevExprs)-1].Outputs[0].Fields[len(prevExprs[len(prevExprs)-1].Outputs[0].Fields)-1]
+	prevExpr := prevExprs[len(prevExprs)-1]
+	
+	if prevExpr.Operator != nil && len(prevExpr.Outputs) == 0 {
+		genName := MakeGenSym(LOCAL_PREFIX)
+		
+		out := MakeArgument(genName, prevExpr.FileName, prevExpr.FileLine-1).AddType(TypeNames[prevExpr.Operator.Outputs[0].Type])
+
+		out.DeclarationSpecifiers = prevExpr.Operator.Outputs[0].DeclarationSpecifiers
+		out.CustomType = prevExpr.Operator.Outputs[0].CustomType
+		out.Size = prevExpr.Operator.Outputs[0].Size
+		out.TotalSize = prevExpr.Operator.Outputs[0].TotalSize
+		out.Lengths = prevExpr.Operator.Outputs[0].Lengths
+		out.IsSlice = prevExpr.Operator.Outputs[0].IsSlice
+		out.PreviouslyDeclared = true
+
+		prevExpr.AddOutput(out)
+
+		inp := MakeArgument(genName, prevExpr.FileName, prevExpr.FileLine).AddType(TypeNames[prevExpr.Operator.Outputs[0].Type])
+
+		inp.DeclarationSpecifiers = prevExpr.Operator.Outputs[0].DeclarationSpecifiers
+		inp.CustomType = prevExpr.Operator.Outputs[0].CustomType
+		inp.Size = prevExpr.Operator.Outputs[0].Size
+		inp.TotalSize = prevExpr.Operator.Outputs[0].TotalSize
+		inp.Lengths = prevExpr.Operator.Outputs[0].Lengths
+		inp.IsSlice = prevExpr.Operator.Outputs[0].IsSlice
+		inp.PreviouslyDeclared = true
+
+		useExpr := MakeExpression(nil, prevExpr.FileName, prevExpr.FileLine)
+		useExpr.Package = prevExpr.Package
+		useExpr.AddOutput(inp)
+
+		prevExprs = append(prevExprs, useExpr)
+	}
+
+	prevExpr = prevExprs[len(prevExprs)-1]
+	
+	if len(prevExpr.Outputs[0].Fields) > 0 {
+		elt = prevExpr.Outputs[0].Fields[len(prevExpr.Outputs[0].Fields)-1]
 	} else {
-		elt = prevExprs[len(prevExprs)-1].Outputs[0]
+		elt = prevExpr.Outputs[0]
 	}
 
 	elt.IsArray = false
@@ -171,28 +207,12 @@ func PostfixExpressionIncDec(prevExprs []*CXExpression, isInc bool) []*CXExpress
 func PostfixExpressionField(prevExprs []*CXExpression, ident string) []*CXExpression {
 	lastExpr := prevExprs[len(prevExprs)-1]
 
-	// THEN it's a function call, e.g. foo().fld
+	// Then it's a function call, e.g. foo().fld
 	// and we need to create some auxiliary variables to hold the result from
 	// the function call
 	if lastExpr.Operator != nil {
 		opOut := lastExpr.Operator.Outputs[0]
 		symName := MakeGenSym(LOCAL_PREFIX)
-
-		// we need to declare an aux variable, e.g. `var *lcl_10 i32`
-		// that will hold the result of the function call
-		aux := MakeArgument(symName, lastExpr.FileName, lastExpr.FileLine).AddType(TypeNames[opOut.Type])
-		aux.DeclarationSpecifiers = opOut.DeclarationSpecifiers
-		aux.CustomType = opOut.CustomType
-		aux.Size = opOut.Size
-		aux.TotalSize = opOut.TotalSize
-		aux.PreviouslyDeclared = true
-		aux.Package = lastExpr.Package
-
-		declExpr := MakeExpression(nil, lastExpr.FileName, lastExpr.FileLine)
-		declExpr.Package = lastExpr.Package
-		declExpr.AddOutput(aux)
-
-		prevExprs = append([]*CXExpression{declExpr}, prevExprs...)
 
 		// we associate the result of the function call to the aux variable
 		out := MakeArgument(symName, lastExpr.FileName, lastExpr.FileLine).AddType(TypeNames[opOut.Type])

--- a/tests/main.cx
+++ b/tests/main.cx
@@ -362,7 +362,7 @@ func main ()() {
 	runTest("issue-67.cx", cx.COMPILATION_ERROR, "No compilation error when var is accessed outside of its declaring scope")
 	runTest("issue-68.cx", cx.COMPILATION_ERROR, "Panic when a str var is shadowed by a struct var in another scope")
 	runTestEx("issue-69.cx", cx.SUCCESS, "glfw.GetCursorPos() throws error", TEST_GUI | TEST_STABLE, 0)
-	runTestEx("issue-70.cx", cx.SUCCESS, "Inline field and index 'dereferences' to function calls' outputs", TEST_ISSUE, 0)
+	runTest("issue-70.cx", cx.SUCCESS, "Inline field and index 'dereferences' to function calls' outputs")
 	runTest("issue-71.cx", cx.COMPILATION_ERROR, "No compilation error when redeclaring a variable")
 	runTestEx("issue-72.cx", cx.SUCCESS, "Multi-dimensional slices don't work", TEST_ISSUE, 0)
 	runTestEx("issue-75.cx", cx.SUCCESS, "can't prefix a (f32) variable with minus to flip it's signedness", TEST_STABLE, 0)

--- a/tests/testdata/tokens/main.cx.txt
+++ b/tests/testdata/tokens/main.cx.txt
@@ -2681,7 +2681,7 @@ STRLIT glfw.GetCursorPos() throws error
 INTLIT 0
 RPAREN 
 SCOLON 
- IDENT runTestEx
+ IDENT runTest
 LPAREN 
 STRLIT issue-70.cx
  COMMA 
@@ -2690,10 +2690,6 @@ PERIOD
  IDENT SUCCESS
  COMMA 
 STRLIT Inline field and index 'dereferences' to function calls' outputs
- COMMA 
- IDENT TEST_ISSUE
- COMMA 
-INTLIT 0
 RPAREN 
 SCOLON 
  IDENT runTest


### PR DESCRIPTION
Fixes #70

Changes:
- Inline accessing an array or a struct instance returned by a function is now possible.

Does this change need to mentioned in CHANGELOG.md?
Yes.