### PR TITLE
Fix #284: Concatenation of str variables with + operator doesn't work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * #156: Panic when using a function declared in another package without importing the package.
   * #166: Panic when calling a function from another package where the package name alias a local variable name
   * #271: CX floats cannot handle exponents
+  * #284: Concatenation of str variables with + operator doesn't work.
 * Documentation
 * IDE (WiP)
 * Miscellaneous

--- a/cxgo/actions/functions.go
+++ b/cxgo/actions/functions.go
@@ -89,6 +89,15 @@ func CheckUndValidTypes(expr *CXExpression) {
 	}
 }
 
+// CheckConcatStr checks if `expr`'s operator is OP_UND_ADD and if its operands are of type str.
+// If this is the case, the operator is changed to OP_STR_CONCAT to concatenate the strings.
+func CheckConcatStr (expr *CXExpression) {
+	if expr.Operator != nil && expr.Operator.OpCode == OP_UND_ADD &&
+		expr.Inputs[0].Type == TYPE_STR && expr.Inputs[1].Type == TYPE_STR {
+		expr.Operator = Natives[OP_STR_CONCAT]
+	}
+}
+
 func FunctionDeclaration(fn *CXFunction, inputs, outputs []*CXArgument, exprs []*CXExpression) {
 	if FoundCompileErrors {
 		return
@@ -149,6 +158,7 @@ func FunctionDeclaration(fn *CXFunction, inputs, outputs []*CXArgument, exprs []
 
 		CheckTypes(expr)
 		CheckUndValidTypes(expr)
+		CheckConcatStr(expr)
 
 		if expr.ScopeOperation == SCOPE_REM {
 			*symbols = (*symbols)[:len(*symbols)-1]

--- a/tests/main.cx
+++ b/tests/main.cx
@@ -423,7 +423,7 @@ func main ()() {
 	runTestEx("issue-281.cx", cx.SUCCESS, "Wrong sprintf behaviour when printing boolean values with %v", TEST_ISSUE, 0)
 	runTestEx("issue-282.cx", cx.SUCCESS, "for true {} loop scope is not executed", TEST_ISSUE, 0)
 	runTestEx("issue-283.cx", cx.SUCCESS, "for loop using boolean value is not compiling", TEST_ISSUE, 0)
-	runTestEx("issue-284.cx", cx.SUCCESS, "Concatenation of str variables with + operator doesn't work", TEST_ISSUE, 0)
+	runTest("issue-284.cx", cx.SUCCESS, "Concatenation of str variables with + operator doesn't work")
 	runTestEx("issue-285.cx", cx.SUCCESS, "Short declaration doesn't compile with opcode return value", TEST_ISSUE, 0)
 	runTestEx("issue-286.cx", cx.SUCCESS, "Compilation error when struct field is named 'input' or 'output'", TEST_ISSUE, 0)
 	runTestEx("issue-287.cx", cx.COMPILATION_ERROR, "No compilation error when using empty argument list after function call", TEST_ISSUE, 0)

--- a/tests/testdata/tokens/main.cx.txt
+++ b/tests/testdata/tokens/main.cx.txt
@@ -3390,7 +3390,7 @@ STRLIT for loop using boolean value is not compiling
 INTLIT 0
 RPAREN 
 SCOLON 
- IDENT runTestEx
+ IDENT runTest
 LPAREN 
 STRLIT issue-284.cx
  COMMA 
@@ -3399,10 +3399,6 @@ PERIOD
  IDENT SUCCESS
  COMMA 
 STRLIT Concatenation of str variables with + operator doesn't work
- COMMA 
- IDENT TEST_ISSUE
- COMMA 
-INTLIT 0
 RPAREN 
 SCOLON 
  IDENT runTestEx


### PR DESCRIPTION
Fixes #284

Changes:
- Concatenation of str variables with + operator now works.

Does this change need to mentioned in CHANGELOG.md?
Yes.