### PR TITLE
Fix #292: Compilation error when left hand side of an assignment expr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   * ...
 * Libraries
 * Fixed issues
-  * #xx: ...
+  * #292: Compilation error when left hand side of an assignment expression is a struct field.
 * Documentation
 * IDE (WiP)
 * Miscellaneous

--- a/cxgo/actions/functions.go
+++ b/cxgo/actions/functions.go
@@ -1021,7 +1021,7 @@ func CopyArgFields(sym *CXArgument, arg *CXArgument) {
 
 	if len(sym.Fields) > 0 {
 		sym.Type = sym.Fields[len(sym.Fields)-1].Type
-		// sym.IsSlice = sym.Fields[len(sym.Fields) - 1].IsSlice
+		sym.IsSlice = sym.Fields[len(sym.Fields) - 1].IsSlice
 	} else {
 		sym.Type = arg.Type
 	}

--- a/cxgo/cxgo.nex
+++ b/cxgo/cxgo.nex
@@ -213,7 +213,7 @@ import (
 	"github.com/skycoin/cx/cxgo/cxgo0"
 )
 
-const VERSION = "0.6.1"
+const VERSION = "0.6.2"
 
 var insert bool
 // var PRGRM *CXProgram

--- a/tests/main.cx
+++ b/tests/main.cx
@@ -432,7 +432,7 @@ func main ()() {
 	runTestEx("issue-290.cx", cx.COMPILATION_ERROR, "Left hand side of , is not compiled", TEST_ISSUE, 0)
 	runTestEx("issue-291-a.cx", cx.SUCCESS, "Compilation error when using return value of a member method in a expression", TEST_ISSUE, 0)
 	runTestEx("issue-291-b.cx", cx.SUCCESS, "Compilation error when using return value of a member method in a expression", TEST_ISSUE, 0)
-	runTestEx("issue-292.cx", cx.SUCCESS, "Compilation error when left hand side of an assignment expression is a struct field", TEST_ISSUE, 0)
+	runTest("issue-292.cx", cx.SUCCESS, "Compilation error when left hand side of an assignment expression is a struct field")
 	runTestEx("issue-293.cx", cx.SUCCESS, "Crash when INIT_HEAP_SIZE limit is reached ", TEST_ISSUE, 0)
 	runTestEx("issue-294-a.cx", cx.SUCCESS, "Crash in garbage collector when heap is resized", TEST_ISSUE, 0)
 	runTestEx("issue-294-b.cx", cx.SUCCESS, "Crash in garbage collector when heap is resized", TEST_ISSUE, 0)

--- a/tests/testdata/tokens/main.cx.txt
+++ b/tests/testdata/tokens/main.cx.txt
@@ -3505,7 +3505,7 @@ STRLIT Compilation error when using return value of a member method in a express
 INTLIT 0
 RPAREN 
 SCOLON 
- IDENT runTestEx
+ IDENT runTest
 LPAREN 
 STRLIT issue-292.cx
  COMMA 
@@ -3514,10 +3514,6 @@ PERIOD
  IDENT SUCCESS
  COMMA 
 STRLIT Compilation error when left hand side of an assignment expression is a struct field
- COMMA 
- IDENT TEST_ISSUE
- COMMA 
-INTLIT 0
 RPAREN 
 SCOLON 
  IDENT runTestEx


### PR DESCRIPTION
…ession is a struct field.

Fixes #292

Changes:
- The problem was related to assigning **slices** to struct fields, specifically. Fixed.

Does this change need to mentioned in CHANGELOG.md?
Yes.