### PR TITLE
op_os.go declares some constants that are used in other files. Its bu…

### DIFF
--- a/cx/op_os.go
+++ b/cx/op_os.go
@@ -1,5 +1,3 @@
-// +build base extra full
-
 package cxcore
 
 import (


### PR DESCRIPTION
…ild tag needs to be removed so it is considered for any build.

Changes:
- Removed `cx/op_os.go` build tag, as it declares constants that are used in the "bare" build. Tags need to be changed to consider only `base` and `full`. If all the OpenGL dependencies are moved to CXFX in the future, we'll end with a single CX build and all of them will need to go.

Does this change need to mentioned in CHANGELOG.md?
