### PR TITLE
Linter fixes to cx/cxprogram.go

### DIFF
--- a/cx/cxprogram.go
+++ b/cx/cxprogram.go
@@ -368,7 +368,10 @@ func (cxt *CXProgram) PrintAllObjects() {
 
 		for _, ptr := range op.ListOfPointers {
 			var heapOffset int32
-			encoder.DeserializeAtomic(cxt.Memory[fp+ptr.Offset:fp+ptr.Offset+TYPE_POINTER_SIZE], &heapOffset)
+			_, err := encoder.DeserializeAtomic(cxt.Memory[fp+ptr.Offset:fp+ptr.Offset+TYPE_POINTER_SIZE], &heapOffset)
+			if err != nil {
+				panic(err)
+			}
 
 			var byts []byte
 
@@ -380,10 +383,6 @@ func (cxt *CXProgram) PrintAllObjects() {
 				// }
 
 				byts = cxt.Memory[int(heapOffset)+OBJECT_HEADER_SIZE : int(heapOffset)+OBJECT_HEADER_SIZE+ptr.CustomType.Size]
-			}
-
-			if len(ptr.Lengths) > 0 {
-
 			}
 
 			// var currLengths []int


### PR DESCRIPTION
Changes:
- Added an error check for encoder.DeserializeAtomic and removed an empty if statement in `cx/cxprogram.go`

Does this change need to mentioned in CHANGELOG.md?
No.