### PR TITLE
Fixed linter problems for cx/op_testing.go and cx/op_und.go

### DIFF
--- a/cx/op_os.go
+++ b/cx/op_os.go
@@ -1,3 +1,5 @@
+// +build base extra full
+
 package cxcore
 
 import (
@@ -15,12 +17,12 @@ import (
 )
 
 const (
-	OS_RUN_SUCCESS = iota
-	OS_RUN_EMPTY_CMD
-	OS_RUN_PANIC // 2
-	OS_RUN_START_FAILED
-	OS_RUN_WAIT_FAILED
-	OS_RUN_TIMEOUT
+	osRunSuccess = iota
+	osRunEmptyCmd
+	osRunPanic
+	osRunStartFailed
+	osRunWaitFailed
+	osRunTimeout
 )
 
 var openFiles map[string]*os.File = make(map[string]*os.File, 0)
@@ -75,13 +77,13 @@ func op_os_Exit(expr *CXExpression, fp int) {
 
 func op_os_Run(expr *CXExpression, fp int) {
 	inp0, inp1, inp2, inp3, out0, out1, out2 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Inputs[3], expr.Outputs[0], expr.Outputs[1], expr.Outputs[2]
-	var runError int32 = OS_RUN_SUCCESS
+	var runError int32 = osRunSuccess
 
 	command := ReadStr(fp, inp0)
 	dir := ReadStr(fp, inp3)
 	args := strings.Split(command, " ")
 	if len(args) <= 0 {
-		runError = OS_RUN_EMPTY_CMD
+		runError = osRunEmptyCmd
 	}
 
 	name := args[0]
@@ -107,7 +109,7 @@ func op_os_Run(expr *CXExpression, fp int) {
 	}
 
 	if err := cmd.Start(); err != nil {
-		runError = OS_RUN_START_FAILED
+		runError = osRunStartFailed
 	} else {
 		done := make(chan error)
 		go func() { done <- cmd.Wait() }()
@@ -115,7 +117,7 @@ func op_os_Run(expr *CXExpression, fp int) {
 		select {
 		case <-time.After(timeout):
 			cmd.Process.Kill()
-			runError = OS_RUN_TIMEOUT
+			runError = osRunTimeout
 		case err := <-done:
 			if err != nil {
 				if exiterr, ok := err.(*exec.ExitError); ok {
@@ -129,7 +131,7 @@ func op_os_Run(expr *CXExpression, fp int) {
 						cmdError = int32(status.ExitStatus())
 					}
 				} else {
-					runError = OS_RUN_WAIT_FAILED
+					runError = osRunWaitFailed
 				}
 			}
 		}

--- a/cx/op_os.go
+++ b/cx/op_os.go
@@ -17,12 +17,12 @@ import (
 )
 
 const (
-	osRunSuccess = iota
-	osRunEmptyCmd
-	osRunPanic
-	osRunStartFailed
-	osRunWaitFailed
-	osRunTimeout
+	OS_RUN_SUCCESS = iota
+	OS_RUN_EMPTY_CMD
+	OS_RUN_PANIC // 2
+	OS_RUN_START_FAILED
+	OS_RUN_WAIT_FAILED
+	OS_RUN_TIMEOUT
 )
 
 var openFiles map[string]*os.File = make(map[string]*os.File, 0)
@@ -77,13 +77,13 @@ func op_os_Exit(expr *CXExpression, fp int) {
 
 func op_os_Run(expr *CXExpression, fp int) {
 	inp0, inp1, inp2, inp3, out0, out1, out2 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Inputs[3], expr.Outputs[0], expr.Outputs[1], expr.Outputs[2]
-	var runError int32 = osRunSuccess
+	var runError int32 = OS_RUN_SUCCESS
 
 	command := ReadStr(fp, inp0)
 	dir := ReadStr(fp, inp3)
 	args := strings.Split(command, " ")
 	if len(args) <= 0 {
-		runError = osRunEmptyCmd
+		runError = OS_RUN_EMPTY_CMD
 	}
 
 	name := args[0]
@@ -109,7 +109,7 @@ func op_os_Run(expr *CXExpression, fp int) {
 	}
 
 	if err := cmd.Start(); err != nil {
-		runError = osRunStartFailed
+		runError = OS_RUN_START_FAILED
 	} else {
 		done := make(chan error)
 		go func() { done <- cmd.Wait() }()
@@ -117,7 +117,7 @@ func op_os_Run(expr *CXExpression, fp int) {
 		select {
 		case <-time.After(timeout):
 			cmd.Process.Kill()
-			runError = osRunTimeout
+			runError = OS_RUN_TIMEOUT
 		case err := <-done:
 			if err != nil {
 				if exiterr, ok := err.(*exec.ExitError); ok {
@@ -131,7 +131,7 @@ func op_os_Run(expr *CXExpression, fp int) {
 						cmdError = int32(status.ExitStatus())
 					}
 				} else {
-					runError = osRunWaitFailed
+					runError = OS_RUN_WAIT_FAILED
 				}
 			}
 		}

--- a/cx/op_testing.go
+++ b/cx/op_testing.go
@@ -10,7 +10,7 @@ var assertSuccess = true
 
 // AssertFailed ...
 func AssertFailed() bool {
-	return assertSuccess == false
+	return !assertSuccess
 }
 
 func assert(expr *CXExpression, fp int) (same bool) {
@@ -69,7 +69,7 @@ func opTest(expr *CXExpression, fp int) {
 }
 
 func opPanic(expr *CXExpression, fp int) {
-	if assert(expr, fp) == false {
+	if !assert(expr, fp) {
 		os.Exit(CX_ASSERT)
 	}
 }

--- a/cx/op_und.go
+++ b/cx/op_und.go
@@ -351,7 +351,7 @@ func opLen(expr *CXExpression, fp int) {
 func opAppend(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 
-	if inp1.Type != inp2.Type || inp1.Type != out1.Type || GetAssignmentElement(inp1).IsSlice == false || GetAssignmentElement(out1).IsSlice == false {
+	if inp1.Type != inp2.Type || inp1.Type != out1.Type || !GetAssignmentElement(inp1).IsSlice || !GetAssignmentElement(out1).IsSlice {
 		panic(CX_RUNTIME_INVALID_ARGUMENT)
 	}
 
@@ -373,7 +373,7 @@ func opAppend(expr *CXExpression, fp int) {
 func opResize(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 
-	if inp1.Type != out1.Type || GetAssignmentElement(inp1).IsSlice == false || GetAssignmentElement(out1).IsSlice == false {
+	if inp1.Type != out1.Type || !GetAssignmentElement(inp1).IsSlice || !GetAssignmentElement(out1).IsSlice {
 		panic(CX_RUNTIME_INVALID_ARGUMENT)
 	}
 
@@ -389,7 +389,7 @@ func opResize(expr *CXExpression, fp int) {
 func opInsert(expr *CXExpression, fp int) {
 	inp1, inp2, inp3, out1 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Outputs[0]
 
-	if inp1.Type != inp3.Type || inp1.Type != out1.Type || GetAssignmentElement(inp1).IsSlice == false || GetAssignmentElement(out1).IsSlice == false {
+	if inp1.Type != inp3.Type || inp1.Type != out1.Type || GetAssignmentElement(inp1).IsSlice || GetAssignmentElement(out1).IsSlice {
 		panic(CX_RUNTIME_INVALID_ARGUMENT)
 	}
 
@@ -412,7 +412,7 @@ func opInsert(expr *CXExpression, fp int) {
 func opRemove(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 
-	if inp1.Type != out1.Type || GetAssignmentElement(inp1).IsSlice == false || GetAssignmentElement(out1).IsSlice == false {
+	if inp1.Type != out1.Type || !GetAssignmentElement(inp1).IsSlice || !GetAssignmentElement(out1).IsSlice {
 		panic(CX_RUNTIME_INVALID_ARGUMENT)
 	}
 
@@ -434,7 +434,7 @@ func opCopy(expr *CXExpression, fp int) {
 	dstElem := GetAssignmentElement(dstInput)
 	srcElem := GetAssignmentElement(srcInput)
 
-	if dstInput.Type != srcInput.Type || dstElem.IsSlice == false || srcElem.IsSlice == false || dstElem.TotalSize != srcElem.TotalSize {
+	if dstInput.Type != srcInput.Type || !dstElem.IsSlice || !srcElem.IsSlice || dstElem.TotalSize != srcElem.TotalSize {
 		panic(CX_RUNTIME_INVALID_ARGUMENT)
 	}
 

--- a/cx/op_und.go
+++ b/cx/op_und.go
@@ -389,7 +389,7 @@ func opResize(expr *CXExpression, fp int) {
 func opInsert(expr *CXExpression, fp int) {
 	inp1, inp2, inp3, out1 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Outputs[0]
 
-	if inp1.Type != inp3.Type || inp1.Type != out1.Type || GetAssignmentElement(inp1).IsSlice || GetAssignmentElement(out1).IsSlice {
+	if inp1.Type != inp3.Type || inp1.Type != out1.Type || !GetAssignmentElement(inp1).IsSlice || !GetAssignmentElement(out1).IsSlice {
 		panic(CX_RUNTIME_INVALID_ARGUMENT)
 	}
 


### PR DESCRIPTION
Changes:
- Simplified some Boolean comparisons

Does this change need to mentioned in CHANGELOG.md?
No.