### PR TITLE
Linter fixes cx/execute.go

### DIFF
--- a/cx/execute.go
+++ b/cx/execute.go
@@ -3,7 +3,6 @@ package cxcore
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"time"
 
 	"github.com/skycoin/skycoin/src/cipher/encoder"
@@ -220,37 +219,6 @@ func (cxt *CXProgram) RunCompiled(nCalls int, args []string) error {
 	}
 	return err
 
-}
-
-func (cxt *CXProgram) ccallback(expr *CXExpression, functionName string, packageName string, inputs [][]byte) {
-	if fn, err := cxt.GetFunction(functionName, packageName); err == nil {
-		line := cxt.CallStack[cxt.CallCounter].Line
-		previousCall := cxt.CallCounter
-		cxt.CallCounter++
-		newCall := &cxt.CallStack[cxt.CallCounter]
-		newCall.Operator = fn
-		newCall.Line = 0
-		newCall.FramePointer = cxt.StackPointer
-		cxt.StackPointer += newCall.Operator.Size
-		newFP := newCall.FramePointer
-
-		// wiping next mem frame (removing garbage)
-		for c := 0; c < expr.Operator.Size; c++ {
-			cxt.Memory[newFP+c] = 0
-		}
-
-		for i, inp := range inputs {
-			WriteMemory(GetFinalOffset(newFP, newCall.Operator.Inputs[i]), inp)
-		}
-
-		var nCalls = 0
-		if err := cxt.Run(true, &nCalls, previousCall); err != nil {
-			os.Exit(CX_INTERNAL_ERROR)
-		}
-
-		cxt.CallCounter = previousCall
-		cxt.CallStack[cxt.CallCounter].Line = line
-	}
 }
 
 func (call *CXCall) ccall(prgrm *CXProgram) error {

--- a/cx/op_glfw.go
+++ b/cx/op_glfw.go
@@ -3,8 +3,41 @@
 package cxcore
 
 import (
+	"os"
+	
 	"github.com/go-gl/glfw/v3.2/glfw"
 )
+
+func (cxt *CXProgram) ccallback(expr *CXExpression, functionName string, packageName string, inputs [][]byte) {
+	if fn, err := cxt.GetFunction(functionName, packageName); err == nil {
+		line := cxt.CallStack[cxt.CallCounter].Line
+		previousCall := cxt.CallCounter
+		cxt.CallCounter++
+		newCall := &cxt.CallStack[cxt.CallCounter]
+		newCall.Operator = fn
+		newCall.Line = 0
+		newCall.FramePointer = cxt.StackPointer
+		cxt.StackPointer += newCall.Operator.Size
+		newFP := newCall.FramePointer
+
+		// wiping next mem frame (removing garbage)
+		for c := 0; c < expr.Operator.Size; c++ {
+			cxt.Memory[newFP+c] = 0
+		}
+
+		for i, inp := range inputs {
+			WriteMemory(GetFinalOffset(newFP, newCall.Operator.Inputs[i]), inp)
+		}
+
+		var nCalls = 0
+		if err := cxt.Run(true, &nCalls, previousCall); err != nil {
+			os.Exit(CX_INTERNAL_ERROR)
+		}
+
+		cxt.CallCounter = previousCall
+		cxt.CallStack[cxt.CallCounter].Line = line
+	}
+}
 
 // declared in func_glfw.go
 var windows map[string]*glfw.Window = make(map[string]*glfw.Window, 0)


### PR DESCRIPTION
Changes:
- Fixed linter problem where ccallback is considered dead code because of a build tag in cx/op_glfw.go.

Does this change need to mentioned in CHANGELOG.md?
No.