### PR TITLE
Fix #311: 'CurrentFunction' and 'CurrentStruct' are causing errors in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Libraries
 * Fixed issues
   * #292: Compilation error when left hand side of an assignment expression is a struct field.
+  * #311: `CurrentFunction` and `CurrentStruct` are causing errors in programs with more than 1 package.
 * Documentation
 * IDE
   * Removed the current version of the IDE. We'll move to a textmate-based

--- a/cx/op_glfw.go
+++ b/cx/op_glfw.go
@@ -4,7 +4,7 @@ package cxcore
 
 import (
 	"os"
-	
+
 	"github.com/go-gl/glfw/v3.2/glfw"
 )
 

--- a/cx/serialize.go
+++ b/cx/serialize.go
@@ -843,6 +843,8 @@ func dsName(off int32, size int32, s *sAll) string {
 }
 
 func dsPackages(s *sAll, prgrm *CXProgram) {
+	var fnCounter int32
+	var strctCounter int32
 	for i, sPkg := range s.Packages {
 		// initializing packages with their names,
 		// empty functions, structs, imports and globals
@@ -882,13 +884,16 @@ func dsPackages(s *sAll, prgrm *CXProgram) {
 
 		// CurrentFunction
 		if sPkg.FunctionsSize > 0 {
-			prgrm.Packages[i].CurrentFunction = prgrm.Packages[i].Functions[sPkg.CurrentFunctionOffset]
+			prgrm.Packages[i].CurrentFunction = prgrm.Packages[i].Functions[sPkg.CurrentFunctionOffset-fnCounter]
 		}
 
 		// CurrentStruct
 		if sPkg.StructsSize > 0 {
-			prgrm.Packages[i].CurrentStruct = prgrm.Packages[i].Structs[sPkg.CurrentStructOffset]
+			prgrm.Packages[i].CurrentStruct = prgrm.Packages[i].Structs[sPkg.CurrentStructOffset-strctCounter]
 		}
+
+		fnCounter += sPkg.FunctionsSize
+		strctCounter += sPkg.StructsSize
 	}
 
 	// imports


### PR DESCRIPTION
… programs with more than 1 package.

Fixes #311 

Changes:
- `Deserialize` now resets the index of the CurrentPackage and CurrentFunction when a new package is entered.

Does this change need to mentioned in CHANGELOG.md?
Yes.