### PR TITLE
Fix #312: Deserialization is not setting correctly the sizes for the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Libraries
 * Fixed issues
   * #292: Compilation error when left hand side of an assignment expression is a struct field.
+  * #312: Deserialization is not setting correctly the sizes for the CallStack, HeapStartsAt and StackSize fields of the CXProgram structure.
 * Documentation
 * IDE
   * Removed the current version of the IDE. We'll move to a textmate-based

--- a/cx/op_glfw.go
+++ b/cx/op_glfw.go
@@ -4,7 +4,7 @@ package cxcore
 
 import (
 	"os"
-	
+
 	"github.com/go-gl/glfw/v3.2/glfw"
 )
 

--- a/cx/serialize.go
+++ b/cx/serialize.go
@@ -1143,6 +1143,8 @@ func dsIntegers(off int32, size int32, s *sAll) []int {
 func initDeserialization(prgrm *CXProgram, s *sAll) {
 	prgrm.Memory = s.Memory
 	prgrm.Packages = make([]*CXPackage, len(s.Packages))
+	prgrm.CallStack = make([]CXCall, CALLSTACK_SIZE)
+	prgrm.HeapStartsAt = int(s.Program.HeapStartsAt)
 
 	dsPackages(s, prgrm)
 }

--- a/cx/serialize.go
+++ b/cx/serialize.go
@@ -1146,7 +1146,7 @@ func initDeserialization(prgrm *CXProgram, s *sAll) {
 	prgrm.Memory = s.Memory
 	prgrm.Packages = make([]*CXPackage, len(s.Packages))
 	prgrm.StackSize = int(s.Program.StackSize)
-  prgrm.CallStack = make([]CXCall, CALLSTACK_SIZE)
+	prgrm.CallStack = make([]CXCall, CALLSTACK_SIZE)
 	prgrm.HeapStartsAt = int(s.Program.HeapStartsAt)
 
 	dsPackages(s, prgrm)


### PR DESCRIPTION
…CallStack, HeapStartsAt and StackSize fields of the CXProgram structure.

Fixes #

Changes:
- Deserialization is now setting the sizes for CallStack, HeapStartsAt and StackSize.

Does this change need to mentioned in CHANGELOG.md?
Yes.