### PR TITLE
CX chains now only store the data segment.

### DIFF
--- a/cx/serialize.go
+++ b/cx/serialize.go
@@ -1459,3 +1459,23 @@ func MergePrograms(prgrm1, prgrm2 *CXProgram) *CXProgram {
 
 	return prgrm2
 }
+
+// GetSerializedMemoryOffset returns the offset at which the memory of a serialized CX program starts.
+func GetSerializedMemoryOffset(sPrgrm []byte) int {
+	idxSize := mustSerializeSize(sIndex{})
+	var index sIndex
+	mustDeserializeRaw(sPrgrm[:idxSize], &index)
+	return int(index.MemoryOffset)
+}
+
+// GetSerializedStackSize returns the stack size of a serialized CX program starts.
+func GetSerializedStackSize(sPrgrm []byte) int {
+	idxSize := mustSerializeSize(sIndex{})
+	var index sIndex
+	mustDeserializeRaw(sPrgrm[:idxSize], &index)
+
+	var prgrmInfo sProgram
+	mustDeserializeRaw(sPrgrm[index.ProgramOffset:index.CallsOffset], &prgrmInfo)
+
+	return int(prgrmInfo.StackSize)
+}

--- a/cxgo/main.go
+++ b/cxgo/main.go
@@ -449,11 +449,25 @@ func main () {
 			panic(err)
 		}
 
+		memOff := GetSerializedMemoryOffset(sPrgrm)
+		stackSize := GetSerializedStackSize(sPrgrm)
+		// sPrgrm with Stack and Heap
+		sPrgrmSH := sPrgrm[:memOff]
+		// Appending new stack
+		sPrgrmSH = append(sPrgrmSH, make([]byte, stackSize)...)
+		// Appending data segment
+		sPrgrmSH = append(sPrgrmSH, sPrgrm[memOff:]...)
+		// Appending new heap
+		sPrgrmSH = append(sPrgrmSH, make([]byte, INIT_HEAP_SIZE)...)
+		
 		// Deserialize(sPrgrm).RunCompiled(0, cxArgs)
 		// bcPrgrm = Deserialize(sPrgrm)
-		prevMemSize := len(PRGRM.Memory)
-		PRGRM = Deserialize(sPrgrm)
-		PRGRM.Memory = append(PRGRM.Memory, make([]byte, prevMemSize - len(PRGRM.Memory))...)
+		// prevMemSize := len(PRGRM.Memory)
+		PRGRM = Deserialize(sPrgrmSH)
+		// // Adding 
+		// PRGRM.Memory = append(make([]byte, STACK_SIZE), PRGRM.Memory...)
+		// PRGRM.Memory
+		// PRGRM.Memory = append(PRGRM.Memory, make([]byte, prevMemSize - len(PRGRM.Memory))...)
 		DataOffset = PRGRM.HeapStartsAt
 	}
 
@@ -814,6 +828,11 @@ func main () {
 			cmd.Start()
 			cmd.Wait()
 		} else if options.broadcastMode {
+			// Resetting memory
+			dsPrgrm := Deserialize(sPrgrm)
+			PRGRM.StackPointer = 0
+			PRGRM.HeapPointer = dsPrgrm.HeapPointer
+			
 			s := Serialize(PRGRM, 1)
 			txnCode := ExtractTransactionProgram(sPrgrm, s)
 


### PR DESCRIPTION
Changes:
- For now, CX chains will preserve its state using only the data memory segment. The heap and stack segments will be added later on, as they were creating many conflicts.

Does this change need to mentioned in CHANGELOG.md?
No.