### PR TITLE
Added --wallet-id flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Additions
   * Prototype for CX chains (CX programs stored on the Skycoin blockchain)
   * Added/forked the newcoin and skycoin-cli commands to the CX repository.
+  * Added --wallet-id flag. This parameter replaces having to set the WALLET environment variable for CX chains.
 * Changes
   * Transaction and block default sizes for CX chains changed from 32 Kb to 5 Mb.
 * Libraries

--- a/cxgo/flags.go
+++ b/cxgo/flags.go
@@ -29,6 +29,7 @@ type cxCmdFlags struct {
 	broadcastMode       bool
 	walletMode          bool
 	port                int
+	walletId            string
 	walletSeed          string
 	programName         string
 	secKey              string
@@ -54,6 +55,7 @@ func defaultCmdFlags() cxCmdFlags {
 		broadcastMode:       false,
 		port:                6001,
 		programName:         "cxcoin",
+		walletId:            "cxcoin_cli.wlt",
 		secKey:              "",
 		pubKey:              "",
 		genesisAddress:      "",
@@ -106,6 +108,7 @@ func registerFlags(options *cxCmdFlags) {
 	flag.BoolVar(&options.peerMode, "peer", options.peerMode, "Run a CX chain peer node")
 	flag.IntVar(&options.port, "port", options.port, "Port used when running a CX chain peer node")
 	flag.StringVar(&options.walletSeed, "wallet-seed", options.walletSeed, "Seed to use for a new wallet")
+	flag.StringVar(&options.walletId, "wallet-id", options.walletId, "Wallet ID to use for signing transactions")
 	flag.StringVar(&options.programName, "program-name", options.programName, "Name of the initial CX program on the blockchain")
 	flag.StringVar(&options.secKey, "secret-key", options.secKey, "CX program blockchain security key")
 	flag.StringVar(&options.pubKey, "public-key", options.pubKey, "CX program blockchain public key")

--- a/cxgo/main.go
+++ b/cxgo/main.go
@@ -273,9 +273,9 @@ func runNode (mode string, options cxCmdFlags) *exec.Cmd {
 			fmt.Sprintf("-genesis-address=%s", options.genesisAddress),
 			fmt.Sprintf("-genesis-signature=%s", options.genesisSignature),
 			fmt.Sprintf("-blockchain-public-key=%s", options.pubKey),
-			"-max-txn-size-unconfirmed=5000000",
-		 	"-max-txn-size-create-block=5000000",
-			"-max-block-size=5000000",
+			"-max-txn-size-unconfirmed=5242880",
+		 	"-max-txn-size-create-block=5242880",
+			"-max-block-size=5242880",
 		)
 	case "peer":
 	return exec.Command("cxcoin", "-enable-all-api-sets",
@@ -291,9 +291,9 @@ func runNode (mode string, options cxCmdFlags) *exec.Cmd {
 		fmt.Sprintf("-web-interface-port=%d", options.port + 420),
 		fmt.Sprintf("-port=%d", options.port),
 		fmt.Sprintf("-data-dir=/tmp/%d", options.port),
-		"-max-txn-size-unconfirmed=5000000",
-		"-max-txn-size-create-block=5000000",
-		"-max-block-size=5000000",
+		"-max-txn-size-unconfirmed=5242880",
+		"-max-txn-size-create-block=5242880",
+		"-max-block-size=5242880",
 	)
 	default:
 		return nil
@@ -855,8 +855,7 @@ func main () {
 			dataMap = make(map[string]interface{}, 0)
 			dataMap["mainExprs"] = txnCode
 			dataMap["hours_selection"] = map[string]string{"type": "manual"}
-			dataMap["wallet"] = map[string]string{"id": os.Getenv("WALLET")}
-			dataMap["change_address"] = os.Getenv("ADDRESS")
+			dataMap["wallet"] = map[string]string{"id": options.walletId}
 			dataMap["to"] = []interface{}{map[string]string{"address": "2PBcLADETphmqWV7sujRZdh3UcabssgKAEB", "coins": "1", "hours": "0"}}
 			
 			jsonStr, err := json.Marshal(dataMap)


### PR DESCRIPTION
Changes:
- Added flag for --wallet-id; the id of the wallet to be used to sign transactions. This parameter had to be set as an environment variable.

Does this change need to mentioned in CHANGELOG.md?
Yes.