### PR TITLE
Changed version in cxgo/main.go from 0.6.2 to 0.7beta

### DIFF
--- a/cxgo/main.go
+++ b/cxgo/main.go
@@ -46,7 +46,7 @@ import (
 	"errors"
 )
 
-const VERSION = "0.6.2"
+const VERSION = "0.7beta"
 
 var (
 	log             = logging.MustGetLogger("newcoin")


### PR DESCRIPTION
Changes:
- Changed to v0.7beta

Does this change need to mentioned in CHANGELOG.md?
Yes.