### PR TITLE
Added link to CX Chains wiki page to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ core language) associated to
 
 ![CX Roadmap](https://raw.githubusercontent.com/skycoin/cx/master/readme-images/cx-roadmap.jpg)
 
+# CX Chains (CX + Skycoin Blockchain)
+
+CX Chains are Skycoin's solution for the creation of blockchain-based
+programs. You can read more about them in the [CX
+wiki](https://github.com/skycoin/cx/wiki/CX-Chains-Tutorial).
+
 # Video Games in CX
 
 In order to test out the language, programmers from the Skycoin


### PR DESCRIPTION
Changes:
- Added link to CX Chains wiki page to README.md. 

Does this change need to mentioned in CHANGELOG.md?
No.