### PR TITLE
cxgo.y: Simplify relational expressions

### DIFF
--- a/cxgo/cxgo0/cxgo0.y
+++ b/cxgo/cxgo0/cxgo0.y
@@ -525,20 +525,16 @@ shift_expression:
 
 relational_expression:
                 shift_expression
+	|       relational_expression EQ_OP shift_expression
+	|       relational_expression NE_OP shift_expression
 	|       relational_expression LT_OP shift_expression
 	|       relational_expression GT_OP shift_expression
 	|       relational_expression LTEQ_OP shift_expression
 	|       relational_expression GTEQ_OP shift_expression
                 ;
 
-equality_expression:
-                relational_expression
-	|       equality_expression EQ_OP relational_expression
-	|       equality_expression NE_OP relational_expression
-                ;
-
-and_expression: equality_expression
-	|       and_expression REF_OP equality_expression
+and_expression: relational_expression
+	|       and_expression REF_OP relational_expression
                 ;
 
 exclusive_or_expression:

--- a/cxgo/parser/cxgo.y
+++ b/cxgo/parser/cxgo.y
@@ -117,7 +117,6 @@
 %type   <expressions>   exclusive_or_expression
 %type   <expressions>   inclusive_or_expression
 %type   <expressions>   and_expression
-%type   <expressions>   equality_expression
 %type   <expressions>   relational_expression
 %type   <expressions>   shift_expression
 %type   <expressions>   additive_expression
@@ -927,6 +926,14 @@ shift_expression:
 
 relational_expression:
                 shift_expression
+        |       relational_expression EQ_OP shift_expression
+                {
+			$$ = ShorthandExpression($1, $3, OP_EQUAL)
+                }
+        |       relational_expression NE_OP shift_expression
+                {
+			$$ = ShorthandExpression($1, $3, OP_UNEQUAL)
+                }
         |       relational_expression LT_OP shift_expression
                 {
 			$$ = ShorthandExpression($1, $3, OP_LT)
@@ -945,20 +952,8 @@ relational_expression:
                 }
                 ;
 
-equality_expression:
-                relational_expression
-        |       equality_expression EQ_OP relational_expression
-                {
-			$$ = ShorthandExpression($1, $3, OP_EQUAL)
-                }
-        |       equality_expression NE_OP relational_expression
-                {
-			$$ = ShorthandExpression($1, $3, OP_UNEQUAL)
-                }
-                ;
-
-and_expression: equality_expression
-        |       and_expression REF_OP equality_expression
+and_expression: relational_expression
+        |       and_expression REF_OP relational_expression
                 {
 			$$ = ShorthandExpression($1, $3, OP_BITAND)
                 }


### PR DESCRIPTION
This patch simplifies the parsing of some expressions.  I have been working on issue #283 (for loops with boolean variable as expression), but have not found the root cause yet.  In the mean time, I have simplified the parsing.  The tests pass.

NOTE: This also makes the '==' and '!=' have the same precedence as in Golang.

Changes:
- Remove the equality_expression state in the parser

Does this change need to mentioned in CHANGELOG.md?
No