### PR TITLE
Debug: add debug feature for the lexer (cxgo.nex)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,23 @@
 ### v0.7.0 (NOT YET RELEASED)
 * Additions
   * CX can now generate addresses to be used by CX chains.
+  * New debug option --debug-lexer or -Dl to see which tokens that are
+	returned by the lexer.
 * Changes
   * Removed `cmd/cli`. The CX executable should now be used to generate CX chain addresses.
-  * The tutorial in [documentation/BLOCKCHAIN.md](https://github.com/skycoin/cx/blob/develop/documentation/BLOCKCHAIN.md) is now updated and will be used to reflect the latest changes in the CX source code (`develop` branch), while the tutorial in the [wiki](https://github.com/skycoin/cx/wiki/CX-Chains-Tutorial) will be used as a tutorial for the latest CX release.
 * Libraries
+  * ...
 * Fixed issues
   * #373: Error in address used to generate a CSRF token. Port was 6001 instead of 6421.
 * Documentation
+  * The blockchain tutorial
+	[documentation/BLOCKCHAIN.md](https://github.com/skycoin/cx/blob/develop/documentation/BLOCKCHAIN.md)
+	will be used to reflect the state in the CX source code (`develop` branch)
+  * The blockchain tutorial in the
+	[wiki](https://github.com/skycoin/cx/wiki/CX-Chains-Tutorial) will
+	be used as a tutorial for the latest CX release. 
 * Miscellaneous
+  * ...
 
 ### v0.7beta released 2019-05-19
 * Additions

--- a/cxgo/flags.go
+++ b/cxgo/flags.go
@@ -37,6 +37,9 @@ type cxCmdFlags struct {
 	pubKey              string
 	genesisAddress      string
 	genesisSignature    string
+
+	// Debug flags for the CX developers
+	debugLexer          bool
 }
 
 func defaultCmdFlags() cxCmdFlags {
@@ -61,6 +64,8 @@ func defaultCmdFlags() cxCmdFlags {
 		pubKey:              "",
 		genesisAddress:      "",
 		genesisSignature:    "",
+
+		debugLexer:          false,
 	}
 }
 
@@ -116,6 +121,10 @@ func registerFlags(options *cxCmdFlags) {
 	flag.StringVar(&options.pubKey, "public-key", options.pubKey, "CX program blockchain public key")
 	flag.StringVar(&options.genesisAddress, "genesis-address", options.genesisAddress, "CX blockchain program genesis address")
 	flag.StringVar(&options.genesisSignature, "genesis-signature", options.genesisSignature, "CX blockchain program genesis address")
+
+	// Debug flags
+	flag.BoolVar(&options.debugLexer, "debug-lexer", options.debugLexer, "Debug the lexer by printing all scanner tokens")
+	flag.BoolVar(&options.debugLexer, "Dl",          options.debugLexer, "alias for -debug-lexer")
 }
 
 func printHelp() {
@@ -129,7 +138,7 @@ CX options:
 -n, --new                         Creates a new project located at $CXPATH/src
 -r, --repl                        Loads source files into memory and starts a read-eval-print loop.
 -w, --web                         Start CX as a web service.
--ide, --ide						            Start CX as a web service, and Leaps service start also.
+-ide, --ide                       Start CX as a web service, and Leaps service start also.
 
 Notes:
 * Options --compile and --repl are mutually exclusive.

--- a/cxgo/main.go
+++ b/cxgo/main.go
@@ -315,6 +315,9 @@ func main() {
 	registerFlags(&options)
 	flag.Parse()
 
+	// Propagate some options out to other packages
+	DebugLexer = options.debugLexer   // in package parser
+
 	if options.publisherMode || options.peerMode {
 		var cmd *exec.Cmd
 		if options.publisherMode {

--- a/cxgo/parser/cxgo.nex
+++ b/cxgo/parser/cxgo.nex
@@ -188,15 +188,29 @@
 package parser
 
 import (
+       "fmt"
        "strconv"
 	"github.com/skycoin/cx/cx"
 	. "github.com/skycoin/cx/cxgo/actions"
-	"github.com/skycoin/cx/cxgo/cxgo0")    // Only for CurrentFilename
+	"github.com/skycoin/cx/cxgo/cxgo0"    // Only for CurrentFilename
+)
 
 
-var insert bool
+var insert      bool
+var DebugLexer  bool = false
+
 
 func f (token int) int {
+	// Debug
+	if DebugLexer {
+		tokenName := tokenNames[token]
+		if tokenName == "" {
+			fmt.Println("Token: ", token)
+		} else {
+			fmt.Println("Token: ", tokenName)
+		}
+	}
+
 	if insert && token == NEWLINE {
 		insert = false
 		return SEMICOLON
@@ -248,3 +262,160 @@ func (yylex Lexer) Error (e string) {
 	yylex.Stop()
 }
 
+
+var tokenNames = map[int]string {
+	BYTE_LITERAL: "BYTE_LITERAL",
+	BOOLEAN_LITERAL: "BOOLEAN_LITERAL",
+	INT_LITERAL: "INT_LITERAL",
+	LONG_LITERAL: "LONG_LITERAL",
+	FLOAT_LITERAL: "FLOAT_LITERAL",
+	DOUBLE_LITERAL: "DOUBLE_LITERAL",
+	FUNC: "FUNC",
+	OP: "OP",
+	LPAREN: "LPAREN",
+	RPAREN: "RPAREN",
+	LBRACE: "LBRACE",
+	RBRACE: "RBRACE",
+	LBRACK: "LBRACK",
+	RBRACK: "RBRACK",
+	IDENTIFIER: "IDENTIFIER",
+	VAR: "VAR",
+	COMMA: "COMMA",
+	PERIOD: "PERIOD",
+	COMMENT: "COMMENT",
+	STRING_LITERAL: "STRING_LITERAL",
+	PACKAGE: "PACKAGE",
+	IF: "IF",
+	ELSE: "ELSE",
+	FOR: "FOR",
+	TYPSTRUCT: "TYPSTRUCT",
+	STRUCT: "STRUCT",
+	SEMICOLON: "SEMICOLON",
+	NEWLINE: "NEWLINE",
+	ASSIGN: "ASSIGN",
+	CASSIGN: "CASSIGN",
+	IMPORT: "IMPORT",
+	RETURN: "RETURN",
+	GOTO: "GOTO",
+	GT_OP: "GT_OP",
+	LT_OP: "LT_OP",
+	GTEQ_OP: "GTEQ_OP",
+	LTEQ_OP: "LTEQ_OP",
+	EQUAL: "EQUAL",
+	COLON: "COLON",
+	NEW: "NEW",
+	EQUALWORD: "EQUALWORD",
+	GTHANWORD: "GTHANWORD",
+	LTHANWORD: "LTHANWORD",
+	GTHANEQ: "GTHANEQ",
+	LTHANEQ: "LTHANEQ",
+	UNEQUAL: "UNEQUAL",
+	AND: "AND",
+	OR: "OR",
+	ADD_OP: "ADD_OP",
+	SUB_OP: "SUB_OP",
+	MUL_OP: "MUL_OP",
+	DIV_OP: "DIV_OP",
+	MOD_OP: "MOD_OP",
+	REF_OP: "REF_OP",
+	NEG_OP: "NEG_OP",
+	AFFVAR: "AFFVAR",
+	PLUSPLUS: "PLUSPLUS",
+	MINUSMINUS: "MINUSMINUS",
+	REMAINDER: "REMAINDER",
+	LEFTSHIFT: "LEFTSHIFT",
+	RIGHTSHIFT: "RIGHTSHIFT",
+	EXP: "EXP",
+	NOT: "NOT",
+	BITXOR_OP: "BITXOR_OP",
+	BITOR_OP: "BITOR_OP",
+	BITCLEAR_OP: "BITCLEAR_OP",
+	PLUSEQ: "PLUSEQ",
+	MINUSEQ: "MINUSEQ",
+	MULTEQ: "MULTEQ",
+	DIVEQ: "DIVEQ",
+	REMAINDEREQ: "REMAINDEREQ",
+	EXPEQ: "EXPEQ",
+	LEFTSHIFTEQ: "LEFTSHIFTEQ",
+	RIGHTSHIFTEQ: "RIGHTSHIFTEQ",
+	BITANDEQ: "BITANDEQ",
+	BITXOREQ: "BITXOREQ",
+	BITOREQ: "BITOREQ",
+
+	DEC_OP: "DEC_OP",
+	INC_OP: "INC_OP",
+	PTR_OP: "PTR_OP",
+	LEFT_OP: "LEFT_OP",
+	RIGHT_OP: "RIGHT_OP",
+	GE_OP: "GE_OP",
+	LE_OP: "LE_OP",
+	EQ_OP: "EQ_OP",
+	NE_OP: "NE_OP",
+	AND_OP: "AND_OP",
+	OR_OP: "OR_OP",
+	ADD_ASSIGN: "ADD_ASSIGN",
+	AND_ASSIGN: "AND_ASSIGN",
+	LEFT_ASSIGN: "LEFT_ASSIGN",
+	MOD_ASSIGN: "MOD_ASSIGN",
+	MUL_ASSIGN: "MUL_ASSIGN",
+	DIV_ASSIGN: "DIV_ASSIGN",
+	OR_ASSIGN: "OR_ASSIGN",
+	RIGHT_ASSIGN: "RIGHT_ASSIGN",
+	SUB_ASSIGN: "SUB_ASSIGN",
+	XOR_ASSIGN: "XOR_ASSIGN",
+	BOOL: "BOOL",
+	BYTE: "BYTE",
+	F32: "F32",
+	F64: "F64",
+	I8: "I8",
+	I16: "I16",
+	I32: "I32",
+	I64: "I64",
+	STR: "STR",
+	UI8: "UI8",
+	UI16: "UI16",
+	UI32: "UI32",
+	UI64: "UI64",
+	UNION: "UNION",
+	ENUM: "ENUM",
+	CONST: "CONST",
+	CASE: "CASE",
+	DEFAULT: "DEFAULT",
+	SWITCH: "SWITCH",
+	BREAK: "BREAK",
+	CONTINUE: "CONTINUE",
+	TYPE: "TYPE",
+
+	/* Types */
+	BASICTYPE: "BASICTYPE",
+	/* Selectors */
+	SPACKAGE: "SPACKAGE",
+	SSTRUCT: "SSTRUCT",
+	SFUNC: "SFUNC",
+	/* Removers */
+	REM: "REM",
+	DEF: "DEF",
+	EXPR: "EXPR",
+	FIELD: "FIELD",
+	INPUT: "INPUT",
+	OUTPUT: "OUTPUT",
+	CLAUSES: "CLAUSES",
+	OBJECT: "OBJECT",
+	OBJECTS: "OBJECTS",
+	/* Stepping */
+	STEP: "STEP",
+	PSTEP: "PSTEP",
+	TSTEP: "TSTEP",
+	/* Debugging */
+	DSTACK: "DSTACK",
+	DPROGRAM: "DPROGRAM",
+	DSTATE: "DSTATE",
+	/* Affordances */
+	AFF: "AFF",
+	CAFF: "CAFF",
+	TAG: "TAG",
+	INFER: "INFER",
+	VALUE: "VALUE",
+	/* Pointers */
+	ADDR: "ADDR",
+}


### PR DESCRIPTION
If you give the option --debug-lexer or -Dl, the lexer will print out all the
tokens that it returns to the parser.

Fixes #

Changes:
- Add a debug option to debug the parser by printing all tokens from the lexer
- New structure for more debug options later

Does this change need to mentioned in CHANGELOG.md?
Yes