### PR TITLE
Added version field to CXProgram

### DIFF
--- a/cx/cxprogram.go
+++ b/cx/cxprogram.go
@@ -41,6 +41,7 @@ type CXProgram struct {
 	CallCounter  int           // What function call is the currently being executed in the CallStack
 	HeapPointer  int           // At what offset a CX program can insert a new object to the heap
 	Terminated   bool          // Utility field for the runtime. Indicates if a CX program has already finished or not.
+	Version      string        // CX version used to build this CX program.
 
 	// Used by the REPL and parser
 	CurrentPackage *CXPackage // Represents the currently active package in the REPL or when parsing a CX file.

--- a/cx/serialize.go
+++ b/cx/serialize.go
@@ -43,6 +43,9 @@ type sProgram struct {
 	HeapStartsAt int32
 
 	Terminated int32
+
+	VersionOffset int32
+	VersionSize   int32
 }
 
 type sCall struct {
@@ -459,6 +462,7 @@ func serializeProgram(prgrm *CXProgram, s *sAll) {
 	sPrgrm.HeapStartsAt = int32(prgrm.HeapStartsAt)
 
 	sPrgrm.Terminated = serializeBoolean(prgrm.Terminated)
+	sPrgrm.VersionOffset, sPrgrm.VersionSize = serializeName(prgrm.Version, s)
 }
 
 func sStructArguments(strct *CXStruct, s *sAll) {
@@ -1166,6 +1170,7 @@ func initDeserialization(prgrm *CXProgram, s *sAll) {
 	prgrm.HeapPointer = int(s.Program.HeapPointer)
 	prgrm.StackSize = int(s.Program.StackSize)
 	prgrm.HeapSize = int(s.Program.HeapSize)
+	prgrm.Version = dsName(s.Program.VersionOffset, s.Program.VersionSize, s)
 
 	dsPackages(s, prgrm)
 }


### PR DESCRIPTION
Changes:
- Added Version field to CXProgram. Updated serialize.go to consider this field.

Does this change need to mentioned in CHANGELOG.md?
No.