### PR TITLE
Fix issue #360: Panic when package keyword is misspelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@
 * Libraries
   * ...
 * Fixed issues
+  * #360: Panic when package keyword is misspelled
   * #373: Error in address used to generate a CSRF token. Port was 6001 instead of 6421.
 * Documentation
-  * Added file `documentation/BLOCKCHAIN-OVERVIEW.md` which describes the processes and modules involved in CX chains.
+  * New file `documentation/BLOCKCHAIN-OVERVIEW.md` which describes the processes and modules involved in CX chains.
   * The blockchain tutorial
 	[documentation/BLOCKCHAIN.md](https://github.com/skycoin/cx/blob/develop/documentation/BLOCKCHAIN.md)
 	will be used to reflect the state in the CX source code (`develop` branch)

--- a/cxgo/flags.go
+++ b/cxgo/flags.go
@@ -146,6 +146,10 @@ Notes:
 `)
 }
 
+// parseArgsForCX parses the arguments and returns:
+//  - []arguments
+//  - []file pointers	open files
+//  - []sting		filenames
 func parseArgsForCX(args []string) (cxArgs []string, sourceCode []*os.File, fileNames []string) {
 	for _, arg := range args {
 		if len(arg) > 2 && arg[:2] == "++" {


### PR DESCRIPTION
Fixes #360 Panic when package keyword is misspelled

Changes:
- Adds a check whether any package is defined when collecting types (structs)
- Reports a compile error if not.

Does this change need to mentioned in CHANGELOG.md?
yes