### PR TITLE
Changed max transaction size to 128 Mb.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 	broadcasts the transaction code and it is run in the peer node to update the program state. If the user
 	wants to test transaction code, the --transaction flag must be used.
   * Updated the style of the CX roadmap.
+  * Changed max transaction size to 128 Mb. CX chains are storing their program state in two different unspent outputs in their skycoin fork. This means that if a CX program to be stored on a CX chain needs 64 Mb, then the CX chain will need at least a max transaction size of 128 Mb. This behavior needs to be corrected immediately in the next version of CX and the user needs a way to set these parameters via flags (they're hardcoded at the moment).
 * Libraries
   * ...
 * Fixed issues

--- a/cxgo/main.go
+++ b/cxgo/main.go
@@ -279,7 +279,7 @@ func runNode(mode string, options cxCmdFlags) *exec.Cmd {
 			"-max-txn-size-unconfirmed=134217728",
 		 	"-max-txn-size-create-block=134217728",
 			"-max-block-size=134217728",
-			"-max-in-msg-len=134217728",
+			"-max-in-msg-len=134217929",
 			"-max-out-msg-len=134217929", // I don't know why this value, but the logger stated a value >= than this is needed
 		)
 	case "peer":
@@ -299,7 +299,7 @@ func runNode(mode string, options cxCmdFlags) *exec.Cmd {
 		"-max-txn-size-unconfirmed=134217728",
 		"-max-txn-size-create-block=134217728",
 		"-max-block-size=134217728",
-		"-max-in-msg-len=134217728",
+		"-max-in-msg-len=134217929",
 		"-max-out-msg-len=134217929", // I don't know why this value, but the logger stated a value >= than this is needed
 	)
 	default:

--- a/cxgo/main.go
+++ b/cxgo/main.go
@@ -123,7 +123,7 @@ func initCXBlockchain (initPrgrm []byte, coinname, seckey string) error {
 	params, err := fiber.NewConfig(configFile, configDir)
 
 	cmd := exec.Command("go", "run", filepath.Join(projectRoot, fmt.Sprintf("cmd/%[1]s/%[1]s.go", coinname)), "-block-publisher=true", fmt.Sprintf("-blockchain-secret-key=%s", seckey),
-		"-disable-incoming", "-max-out-msg-len=5243081")
+		"-disable-incoming", "-max-out-msg-len=134217929")
 
 	var genesisSig string
 	var genesisBlock readable.Block
@@ -276,10 +276,11 @@ func runNode(mode string, options cxCmdFlags) *exec.Cmd {
 			fmt.Sprintf("-genesis-address=%s", options.genesisAddress),
 			fmt.Sprintf("-genesis-signature=%s", options.genesisSignature),
 			fmt.Sprintf("-blockchain-public-key=%s", options.pubKey),
-			"-max-txn-size-unconfirmed=5242880",
-		 	"-max-txn-size-create-block=5242880",
-			"-max-block-size=5242880",
-			"-max-out-msg-len=5243081", // I don't know why this value, but the logger stated a value >= than this is needed
+			"-max-txn-size-unconfirmed=134217728",
+		 	"-max-txn-size-create-block=134217728",
+			"-max-block-size=134217728",
+			"-max-in-msg-len=134217728",
+			"-max-out-msg-len=134217929", // I don't know why this value, but the logger stated a value >= than this is needed
 		)
 	case "peer":
 	return exec.Command("cxcoin", "-enable-all-api-sets",
@@ -295,10 +296,11 @@ func runNode(mode string, options cxCmdFlags) *exec.Cmd {
 		fmt.Sprintf("-web-interface-port=%d", options.port + 420),
 		fmt.Sprintf("-port=%d", options.port),
 		fmt.Sprintf("-data-dir=/tmp/%d", options.port),
-		"-max-txn-size-unconfirmed=5242880",
-		"-max-txn-size-create-block=5242880",
-		"-max-block-size=5242880",
-		"-max-out-msg-len=5243081", // I don't know why this value, but the logger stated a value >= than this is needed
+		"-max-txn-size-unconfirmed=134217728",
+		"-max-txn-size-create-block=134217728",
+		"-max-block-size=134217728",
+		"-max-in-msg-len=134217728",
+		"-max-out-msg-len=134217929", // I don't know why this value, but the logger stated a value >= than this is needed
 	)
 	default:
 		return nil

--- a/fiber.toml
+++ b/fiber.toml
@@ -3,17 +3,18 @@
   blockchain_pubkey_str = "02583e5ebbf85522474e0f17e681e62ca37910db6b8792763af4e97663c31a7984"
   blockchain_seckey_str = ""
   create_block_burn_factor = 100
-  create_block_max_transaction_size = 5242880
+  create_block_max_transaction_size = 134217728
   default_connections = []
   genesis_address_str = "23v7mT1uLpViNKZHh9aww4VChxizqKsNq4E"
   genesis_coin_volume = 10000000000.0
-  genesis_signature_str = "2b9a398b6c57ecb92ca94ee9b7b8756b1567be4515090df2c38b850be0e80e801d4809114f6b5d042f6bcb5753570362126a33aed39d56fd1771322dbfa5140200"
+  genesis_signature_str = ""
   genesis_timestamp = 1426562704
-  max_block_size = 5242880
+  max_block_size = 134217728
+  max_block_transactions_size = 134217728
   peer_list_url = "https://127.0.0.1/peers.txt"
   port = 6000
   unconfirmed_burn_factor = 100
-  unconfirmed_max_transaction_size = 5242880
+  unconfirmed_max_transaction_size = 134217728
   web_interface_port = 6420
 
 [params]
@@ -22,3 +23,4 @@
   initial_unlocked_count = 2
   max_coin_supply = 100000000.0
   user_burn_factor = 100
+  user_max_transaction_size = 134217728

--- a/src/params/params.go
+++ b/src/params/params.go
@@ -23,7 +23,7 @@ var (
 		// BurnFactor can be overriden with `USER_BURN_FACTOR` env var
 		BurnFactor: 100,
 		// MaxTransactionSize can be overriden with `USER_MAX_TXN_SIZE` env var
-		MaxTransactionSize: 5242880, // in bytes
+		MaxTransactionSize: 134217728, // in bytes
 		// MaxDropletPrecision can be overriden with `USER_MAX_DECIMALS` env var
 		MaxDropletPrecision: 3,
 	}


### PR DESCRIPTION
Changes:
- Changed max transaction size to 128 Mb. CX chains are storing their program state in two different unspent outputs in their skycoin fork. This means that if a CX program to be stored on a CX chain needs 64 Mb, then the CX chain will need at least a max transaction size of 128 Mb. This behavior needs to be corrected immediately in the next version of CX and the user needs a way to set these parameters via flags (they're hardcoded at the moment).

Does this change need to mentioned in CHANGELOG.md?
Yes.