### PR TITLE
Fixes to how the data segment is allocated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Changes
   * Redesign of CX's garbage collector.
   * Changes to several functions that relied on allocating objects on the heap.
+  * In previous versions of CX the data segment was living inside the heap segment. Now the data segment is properly separated from the heap segment.
 * Libraries
   * ...
 * Fixed issues

--- a/cx/op_misc.go
+++ b/cx/op_misc.go
@@ -12,7 +12,7 @@ func EscapeAnalysis(fp int, inpOffset, outOffset int, arg *CXArgument) {
 	byts := ReadMemory(inpOffset, arg)
 
 	// creating a header for this object
-	size := encoder.SerializeAtomic(int32(len(byts)))
+	size := encoder.SerializeAtomic(int32(len(byts)) + OBJECT_HEADER_SIZE)
 
 	var header = make([]byte, OBJECT_HEADER_SIZE)
 	for c := 5; c < OBJECT_HEADER_SIZE; c++ {

--- a/cxgo/actions/config.go
+++ b/cxgo/actions/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 var PRGRM *CXProgram
-var DataOffset int = STACK_SIZE + TYPE_POINTER_SIZE // to be able to handle nil pointers
+var DataOffset int = STACK_SIZE
 
 var CurrentFile string
 var LineNo int

--- a/cxgo/actions/misc.go
+++ b/cxgo/actions/misc.go
@@ -206,8 +206,25 @@ func WritePrimary(typ int, byts []byte, isGlobal bool) []*CXExpression {
 			arg.TotalSize = TYPE_POINTER_SIZE
 		}
 
-		for i, byt := range byts {
-			PRGRM.Memory[DataOffset+i] = byt
+		// A CX program allocates min(INIT_HEAP_SIZE, MAX_HEAP_SIZE) bytes
+		// after the stack segment. These bytes are used to allocate the data segment
+		// at compile time. If the data segment is bigger than min(INIT_HEAP_SIZE, MAX_HEAP_SIZE),
+		// we'll start appending the bytes to PRGRM.Memory.
+		// After compilation, we calculate how many bytes we need to add to have a heap segment
+		// equal to `minHeapSize()` that is allocated after the data segment.
+		if size + DataOffset > len(PRGRM.Memory) {
+			var i int
+			// First we need to fill the remaining free bytes in
+			// the current `PRGRM.Memory` slice.
+			for i = 0; i < len(PRGRM.Memory) - DataOffset; i++ {
+				PRGRM.Memory[DataOffset+i] = byts[i]
+			}
+			// Then we append the bytes that didn't fit.
+			PRGRM.Memory = append(PRGRM.Memory, byts[i:]...)
+		} else {
+			for i, byt := range byts {
+				PRGRM.Memory[DataOffset+i] = byt
+			}
 		}
 		DataOffset += size
 


### PR DESCRIPTION
Changes:
- In previous versions of CX the data segment was living inside the heap segment. For example, if the CX compiler was set to allocate 1 Mb of heap space and the data segment required 500 Kb, then the CX runtime would have only 500 Kb to store objects on the heap.

Does this change need to mentioned in CHANGELOG.md?
Yes.