### PR TITLE
Changed GC functions to accept a CXProgram argument instead of always…

### DIFF
--- a/cx/serialize.go
+++ b/cx/serialize.go
@@ -451,7 +451,7 @@ func serializeProgram(prgrm *CXProgram, s *sAll) {
 
 	sPrgrm.MemoryOffset = int32(0)
 	// we need to call GC to compress memory usage
-	MarkAndCompact()
+	MarkAndCompact(prgrm)
 	// sPrgrm.MemorySize = int32(PROGRAM.HeapStartsAt + PROGRAM.HeapPointer)
 	sPrgrm.MemorySize = int32(len(PROGRAM.Memory))
 


### PR DESCRIPTION
… using the global reference to the program being used by the runtime

Changes:
- The garbage collector was always running against the `CXProgram` stored in the global variable `PROGRAM` which is used by the CX runtime in several places. I changed this behavior to start accepting an input argument of a reference to an arbitrary `CXProgram`. The purpose of this change is to have the ability to call the garbage collector on any program reference, which is useful when handling CX chains.

Does this change need to mentioned in CHANGELOG.md?
No.