### PR TITLE
Added an CX chain example that uses slices.

### DIFF
--- a/examples/blockchain/slices-bc.cx
+++ b/examples/blockchain/slices-bc.cx
@@ -1,0 +1,32 @@
+package bc
+
+var numbers []i32
+var texts []str
+
+package main
+import "bc"
+
+func main () {
+	// Initializing our CX chain numbers.
+	bc.numbers = append(bc.numbers, 1)
+	bc.numbers = append(bc.numbers, 2)
+	bc.numbers = append(bc.numbers, 3)
+	bc.numbers = append(bc.numbers, 4)
+
+	// Initializing our CX chain texts.
+	bc.texts = append(bc.texts, "Once")
+	bc.texts = append(bc.texts, "upon")
+	bc.texts = append(bc.texts, "a")
+	bc.texts = append(bc.texts, "time")
+
+	// Just checking that our values are there
+	i32.print(bc.numbers[0])
+	i32.print(bc.numbers[1])
+	i32.print(bc.numbers[2])
+	i32.print(bc.numbers[3])
+
+	str.print(bc.texts[0])
+	str.print(bc.texts[1])
+	str.print(bc.texts[2])
+	str.print(bc.texts[3])
+}

--- a/examples/blockchain/slices-txn.cx
+++ b/examples/blockchain/slices-txn.cx
@@ -1,0 +1,20 @@
+package main
+import "bc"
+
+func main () {
+	bc.numbers = append(bc.numbers, 5)
+	bc.numbers = append(bc.numbers, 6)
+
+	// Print all the numbers that have been added in transactions.
+	for c := 0; c < len(bc.numbers); c++ {
+		i32.print(bc.numbers[c])
+	}
+
+	bc.texts = append(bc.texts, "in")
+	bc.texts = append(bc.texts, "Wonderland")
+
+	// Print all the texts that have been added in transactions.
+	for d := 0; d < len(bc.texts); d++ {
+		str.print(bc.texts[d])
+	}
+}


### PR DESCRIPTION
Changes:
- Added `examples/blockchain/slices-bc.cx` and `examples/blockchain/slices-txn.cx`. These files can be used to demonstrate the new capability of CX chains to store heap objects in their program state.

Does this change need to mentioned in CHANGELOG.md?
No.