### PR TITLE
Added Space Invaders dapp that uses CX chains to the list of video games

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,35 +160,36 @@ repository](https://github.com/skycoin/cx-book).
 
 ## CX Chains:
 
-https://github.com/amherag/skycoin
+* https://github.com/amherag/skycoin
 
 ## CX Examples:
 
-https://github.com/skycoin/cx/tree/develop/examples
+* https://github.com/skycoin/cx/tree/develop/examples
 
 ## CX Libraries:
 
-https://github.com/skycoin/cxfx [video game library]
-https://github.com/ReewassSquared/cxm [math library]
-https://github.com/ReewassSquared/CXSL [general utilities library]
-https://github.com/ReewassSquared/CXCIPHER [crypto library]
-https://github.com/asahi3g/pumpcx [user interface library]
-https://github.com/ReewassSquared/CXML [machine learning library]
+* https://github.com/skycoin/cxfx [video game library]
+* https://github.com/ReewassSquared/cxm [math library]
+* https://github.com/ReewassSquared/CXSL [general utilities library]
+* https://github.com/ReewassSquared/CXCIPHER [crypto library]
+* https://github.com/asahi3g/pumpcx [user interface library]
+* https://github.com/ReewassSquared/CXML [machine learning library]
 
 ## CX Video Games:
 
-https://github.com/galah4d/casino-cx [slot machine]
-https://github.com/atang152/crappyBall-cx [flappy bird clone]
-https://github.com/galah4d/pacman-3d [pacman 3D clone]
-https://github.com/skycoin/cx-games/tree/master/Snake-by-Lunier [snake clone]
-https://github.com/skycoin/cx-games/tree/master/SynthCat-Brick-Breaker-by-RedCurse [brick breaker clone]
-https://github.com/skycoin/cx-games/tree/master/Pac-Man-CX-by-Galah4d [pacman 2D clone]
-https://github.com/skycoin/cx-games/tree/master/Whacky-Stack [tetris clone]
-https://github.com/skycoin/cx-games/tree/master/ridge-blaster [dig-n-rig clone]
+* https://github.com/galah4d/casino-cx [slot machine]
+* https://github.com/atang152/crappyBall-cx [flappy bird clone]
+* https://github.com/galah4d/pacman-3d [pacman 3D clone]
+* https://github.com/skycoin/cx-games/tree/master/Snake-by-Lunier [snake clone]
+* https://github.com/skycoin/cx-games/tree/master/SynthCat-Brick-Breaker-by-RedCurse [brick breaker clone]
+* https://github.com/skycoin/cx-games/tree/master/Pac-Man-CX-by-Galah4d [pacman 2D clone]
+* https://github.com/skycoin/cx-games/tree/master/Whacky-Stack [tetris clone]
+* https://github.com/skycoin/cx-games/tree/master/ridge-blaster [dig-n-rig clone]
+* https://github.com/taekwondouglas/space-invaders [space invaders clone dapp using CX chains]
 
 ## Miscellaneous:
 
-https://github.com/skycoin/cx-website [cx.skycoin.net]
+* https://github.com/skycoin/cx-website [cx.skycoin.net]
 
 # CX Roadmap
 


### PR DESCRIPTION
Changes:
- Added the game at https://github.com/taekwondouglas/space-invaders to the list of video games in the README.
- I also formatted the list. The list of projects were all clumped.

Does this change need to mentioned in CHANGELOG.md?
Should we? It's not a change to CX itself, but I don't know if it's good to let people know about new projects being developed using CX.