### PR TITLE
Removed UUID field from CX structures.

### DIFF
--- a/cx/cxargument.go
+++ b/cx/cxargument.go
@@ -1,9 +1,5 @@
 package cxcore
 
-import (
-	. "github.com/satori/go.uuid" //nolint golint
-)
-
 // The CXArgument struct contains a variable, i.e. a combination of a name and a type.
 //
 // It is used when declaring variables and in function parameters.
@@ -16,7 +12,6 @@ type CXArgument struct {
 	Fields                []*CXArgument // strct.fld1.fld2().fld3
 	Name                  string
 	FileName              string
-	ElementID             UUID
 	Type                  int
 	Size                  int // size of underlaying basic type
 	TotalSize             int // total size of an array, performance reasons
@@ -45,20 +40,18 @@ type CXArgument struct {
 // MakeArgument ...
 func MakeArgument(name string, fileName string, fileLine int) *CXArgument {
 	return &CXArgument{
-		ElementID: MakeElementID(),
-		Name:      name,
-		FileName:  fileName,
-		FileLine:  fileLine}
+		Name:     name,
+		FileName: fileName,
+		FileLine: fileLine}
 }
 
 // MakeField ...
 func MakeField(name string, typ int, fileName string, fileLine int) *CXArgument {
 	return &CXArgument{
-		ElementID: MakeElementID(),
-		Name:      name,
-		Type:      typ,
-		FileName:  fileName,
-		FileLine:  fileLine,
+		Name:     name,
+		Type:     typ,
+		FileName: fileName,
+		FileLine: fileLine,
 	}
 }
 
@@ -66,13 +59,12 @@ func MakeField(name string, typ int, fileName string, fileLine int) *CXArgument 
 func MakeGlobal(name string, typ int, fileName string, fileLine int) *CXArgument {
 	size := GetArgSize(typ)
 	global := &CXArgument{
-		ElementID: MakeElementID(),
-		Name:      name,
-		Type:      typ,
-		Size:      size,
-		Offset:    HeapOffset,
-		FileName:  fileName,
-		FileLine:  fileLine,
+		Name:     name,
+		Type:     typ,
+		Size:     size,
+		Offset:   HeapOffset,
+		FileName: fileName,
+		FileLine: fileLine,
 	}
 	HeapOffset += size
 	return global

--- a/cx/cxexpression.go
+++ b/cx/cxexpression.go
@@ -2,8 +2,6 @@ package cxcore
 
 import (
 	"errors"
-	// "fmt"
-	. "github.com/satori/go.uuid" //nolint golint
 )
 
 // CXExpression is used represent a CX expression.
@@ -12,9 +10,6 @@ import (
 // flow.
 //
 type CXExpression struct {
-	// Metadata
-	ElementID UUID
-
 	// Contents
 	Inputs   []*CXArgument
 	Outputs  []*CXArgument
@@ -45,10 +40,9 @@ type CXExpression struct {
 // MakeExpression ...
 func MakeExpression(op *CXFunction, fileName string, fileLine int) *CXExpression {
 	return &CXExpression{
-		ElementID: MakeElementID(),
-		Operator:  op,
-		FileLine:  fileLine,
-		FileName:  fileName}
+		Operator: op,
+		FileLine: fileLine,
+		FileName: fileName}
 }
 
 // ----------------------------------------------------------------

--- a/cx/cxfunction.go
+++ b/cx/cxfunction.go
@@ -3,19 +3,16 @@ package cxcore
 import (
 	"errors"
 	"fmt"
-
-	. "github.com/satori/go.uuid" //nolint golint
 )
 
 // CXFunction is used to represent a CX function.
 //
 type CXFunction struct {
 	// Metadata
-	Name      string     // Name of the function
-	Package   *CXPackage // The package it's a member of
-	ElementID UUID
-	IsNative  bool // True if the function is native to CX, e.g. int32.add()
-	OpCode    int  // opcode if IsNative = true
+	Name     string     // Name of the function
+	Package  *CXPackage // The package it's a member of
+	IsNative bool       // True if the function is native to CX, e.g. int32.add()
+	OpCode   int        // opcode if IsNative = true
 
 	// Contents
 	Inputs      []*CXArgument   // Input parameters to the function
@@ -41,10 +38,9 @@ type CXFunction struct {
 //
 func MakeFunction(name string, fileName string, fileLine int) *CXFunction {
 	return &CXFunction{
-		ElementID: MakeElementID(),
-		Name:      name,
-		FileName:  fileName,
-		FileLine:  fileLine,
+		Name:     name,
+		FileName: fileName,
+		FileLine: fileLine,
 	}
 }
 
@@ -52,9 +48,8 @@ func MakeFunction(name string, fileName string, fileLine int) *CXFunction {
 //
 func MakeNativeFunction(opCode int, inputs []*CXArgument, outputs []*CXArgument) *CXFunction {
 	fn := &CXFunction{
-		ElementID: MakeElementID(),
-		IsNative:  true,
-		OpCode:    opCode,
+		IsNative: true,
+		OpCode:   opCode,
 	}
 
 	offset := 0

--- a/cx/cxpackage.go
+++ b/cx/cxpackage.go
@@ -3,16 +3,13 @@ package cxcore
 import (
 	"errors"
 	"fmt"
-
-	. "github.com/satori/go.uuid" //nolint golint
 )
 
 // CXPackage is used to represent a CX package.
 //
 type CXPackage struct {
 	// Metadata
-	Name      string // Name of the package
-	ElementID UUID
+	Name string // Name of the package
 
 	// Contents
 	Imports   []*CXPackage  // imported packages
@@ -31,7 +28,6 @@ type CXPackage struct {
 //
 func MakePackage(name string) *CXPackage {
 	return &CXPackage{
-		ElementID: MakeElementID(),
 		Name:      name,
 		Globals:   make([]*CXArgument, 0, 10),
 		Imports:   make([]*CXPackage, 0),

--- a/cx/cxprogram.go
+++ b/cx/cxprogram.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/amherag/skycoin/src/cipher/encoder"
-	. "github.com/satori/go.uuid" // nolint golint
 )
 
 /*
@@ -23,8 +22,7 @@ import (
 //
 type CXProgram struct {
 	// Metadata
-	Path      string // Path to the CX project in the filesystem
-	ElementID UUID   // Was supposed to be used for blockchain integration. Needs to be removed.
+	Path string // Path to the CX project in the filesystem
 
 	// Contents
 	Packages []*CXPackage // Packages in a CX program
@@ -58,7 +56,6 @@ type CXCall struct {
 func MakeProgram() *CXProgram {
 	minHeapSize := minHeapSize()
 	newPrgrm := &CXProgram{
-		ElementID:   MakeElementID(),
 		Packages:    make([]*CXPackage, 0),
 		CallStack:   make([]CXCall, CALLSTACK_SIZE),
 		Memory:      make([]byte, STACK_SIZE+minHeapSize),

--- a/cx/cxstruct.go
+++ b/cx/cxstruct.go
@@ -1,20 +1,16 @@
 package cxcore
 
 import (
-	// "errors"
 	"fmt"
-
-	. "github.com/satori/go.uuid" //nolint golint
 )
 
 // CXStruct is used to represent a CX struct.
 //
 type CXStruct struct {
 	// Metadata
-	Name      string     // Name of the struct
-	Package   *CXPackage // The package this struct belongs to
-	Size      int        // The size in memory that this struct takes.
-	ElementID UUID
+	Name    string     // Name of the struct
+	Package *CXPackage // The package this struct belongs to
+	Size    int        // The size in memory that this struct takes.
 
 	// Contents
 	Fields []*CXArgument // The fields of the struct
@@ -23,8 +19,7 @@ type CXStruct struct {
 // MakeStruct ...
 func MakeStruct(name string) *CXStruct {
 	return &CXStruct{
-		ElementID: MakeElementID(),
-		Name:      name,
+		Name: name,
 	}
 }
 


### PR DESCRIPTION
Changes:
- The CX structures (CXPackage, CXStruct, CXProgram, etc.) had a UUID field that wasn't being used. I removed them.

Does this change need to mentioned in CHANGELOG.md?
No.