### PR TITLE
Removed cx-games as a module.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "cx-games"]
-	path = cx-games
-	url = https://github.com/skycoin/cx-games.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 * Additions
   * ...
 * Changes
-  * ...
+  * Removed cx-games as a module. It was just confusing as users would be
+    redirected to an outdated version of the repo and the games are already
+    mentioned in the README.
 * Libraries
   * ...
 * Fixed issues


### PR DESCRIPTION
Changes:
- Removed cx-games as a module. It was just confusing as users would be redirected to an outdated version of the repo and the games are already mentioned in the README.

Does this change need to mentioned in CHANGELOG.md?
Yes.