### PR TITLE
Fixes to how temporary variables are created in the array literal creation process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@
   * Removed cx-games as a module. It was just confusing as users would be
     redirected to an outdated version of the repo and the games are already
     mentioned in the README.
+  * Multidimensional array literals are now working properly.
 * Libraries
   * ...
 * Fixed issues
-  * ...
+  * #481: Array literals: Problem with temporary variables in multi-dimensional arrays.
 * Documentation
   * ...
 * Miscellaneous

--- a/cxgo/actions/assignment.go
+++ b/cxgo/actions/assignment.go
@@ -105,7 +105,7 @@ func getOutputType(expr *CXExpression) *CXArgument {
 }
 
 // Assignment handles assignment statements with different operators, like =, :=, +=, *=.
-func Assignment(to []*CXExpression, assignOp string, from []*CXExpression) []*CXExpression {	
+func Assignment(to []*CXExpression, assignOp string, from []*CXExpression) []*CXExpression {
 	idx := len(from) - 1
 
 	// Checking if we're trying to assign stuff from a function call
@@ -223,14 +223,6 @@ func Assignment(to []*CXExpression, assignOp string, from []*CXExpression) []*CX
 				to[0].Outputs[0].Type = from[idx].Operator.Outputs[0].Type
 				to[0].Outputs[0].Lengths = from[idx].Operator.Outputs[0].Lengths
 			}
-
-			// to[0].Outputs[0].Type = from[idx].Operator.Outputs[0].Type
-			// FIXME: Duct-tape solution. I'm pretty sure this needs to be handled by another
-			// function like CopyArgFields
-			if len(from[idx].Outputs) > 0 {
-				to[0].Outputs[0].Lengths = from[idx].Outputs[0].Lengths
-			}
-			// to[0].Outputs[0].Size = Natives[from[idx].Operator.OpCode].Outputs[0].Size
 
 			to[0].Outputs[0].DoesEscape = from[idx].Operator.Outputs[0].DoesEscape
 			to[0].Outputs[0].PassBy = from[idx].Operator.Outputs[0].PassBy

--- a/cxgo/actions/declarations.go
+++ b/cxgo/actions/declarations.go
@@ -348,13 +348,13 @@ func DeclareLocal(declarator *CXArgument, declaration_specifiers *CXArgument,
 //
 // It is called repeatedly while the type is parsed.
 //
-//   declSpec:  The incoming type
-//   arraySize: The size of the array if `opTyp` = DECL_ARRAY
-//   opTyp:     The type of modification to `declSpec` (array of, pointer to, ...)
+//   declSpec:     The incoming type
+//   arrayLengths: The lengths of the array if `opTyp` = DECL_ARRAY
+//   opTyp:        The type of modification to `declSpec` (array of, pointer to, ...)
 //
 // Returns the new type build from `declSpec` and `opTyp`.
 //
-func DeclarationSpecifiers(declSpec *CXArgument, arraySize int, opTyp int) *CXArgument {
+func DeclarationSpecifiers(declSpec *CXArgument, arrayLengths []int, opTyp int) *CXArgument {
 	switch opTyp {
 	case DECL_POINTER:
 		declSpec.DeclarationSpecifiers = append(declSpec.DeclarationSpecifiers, DECL_POINTER)
@@ -379,15 +379,19 @@ func DeclarationSpecifiers(declSpec *CXArgument, arraySize int, opTyp int) *CXAr
 
 		return declSpec
 	case DECL_ARRAY:
-		declSpec.DeclarationSpecifiers = append(declSpec.DeclarationSpecifiers, DECL_ARRAY)
+		for range arrayLengths {
+			declSpec.DeclarationSpecifiers = append(declSpec.DeclarationSpecifiers, DECL_ARRAY)
+		}
 		arg := declSpec
 		arg.IsArray = true
-		arg.Lengths = append([]int{arraySize}, arg.Lengths...)
+		arg.Lengths = arrayLengths
 		arg.TotalSize = arg.Size * TotalLength(arg.Lengths)
 
 		return arg
 	case DECL_SLICE:
-		declSpec.DeclarationSpecifiers = append(declSpec.DeclarationSpecifiers, DECL_SLICE)
+		for range arrayLengths {
+			declSpec.DeclarationSpecifiers = append(declSpec.DeclarationSpecifiers, DECL_SLICE)
+		}
 
 		arg := declSpec
 		arg.IsSlice = true
@@ -395,7 +399,8 @@ func DeclarationSpecifiers(declSpec *CXArgument, arraySize int, opTyp int) *CXAr
 		arg.IsArray = true
 		arg.PassBy = PASSBY_REFERENCE
 
-		arg.Lengths = append([]int{0}, arg.Lengths...)
+		// arg.Lengths = append([]int{0}, arg.Lengths...)
+		arg.Lengths = arrayLengths
 		arg.TotalSize = arg.Size
 		arg.Size = TYPE_POINTER_SIZE
 
@@ -421,10 +426,10 @@ func DeclarationSpecifiersBasic(typ int) *CXArgument {
 
 	if typ == TYPE_AFF {
 		// equivalent to slice of strings
-		return DeclarationSpecifiers(arg, 0, DECL_SLICE)
+		return DeclarationSpecifiers(arg, []int{0}, DECL_SLICE)
 	}
 
-	return DeclarationSpecifiers(arg, 0, DECL_BASIC)
+	return DeclarationSpecifiers(arg, []int{0}, DECL_BASIC)
 }
 
 // DeclarationSpecifiersStruct() declares a struct

--- a/cxgo/actions/literals.go
+++ b/cxgo/actions/literals.go
@@ -21,7 +21,7 @@ func SliceLiteralExpression(typSpec int, exprs []*CXExpression) []*CXExpression 
 	slcVarExpr := MakeExpression(nil, CurrentFile, LineNo)
 	slcVarExpr.Package = pkg
 	slcVar := MakeArgument(symName, CurrentFile, LineNo)
-	slcVar = DeclarationSpecifiers(slcVar, 0, DECL_SLICE)
+	slcVar = DeclarationSpecifiers(slcVar, []int{0}, DECL_SLICE)
 	slcVar.AddType(TypeNames[typSpec])
 
 	// slcVar.IsSlice = true
@@ -200,7 +200,7 @@ func PrimaryStructLiteralExternal(impName string, ident string, strctFlds []*CXE
 	return result
 }
 
-func ArrayLiteralExpression(arrSize int, typSpec int, exprs []*CXExpression) []*CXExpression {
+func ArrayLiteralExpression(arrSizes []int, typSpec int, exprs []*CXExpression) []*CXExpression {
 	var result []*CXExpression
 
 	pkg, err := PRGRM.GetCurrentPackage()
@@ -213,7 +213,7 @@ func ArrayLiteralExpression(arrSize int, typSpec int, exprs []*CXExpression) []*
 	arrVarExpr := MakeExpression(nil, CurrentFile, LineNo)
 	arrVarExpr.Package = pkg
 	arrVar := MakeArgument(symName, CurrentFile, LineNo)
-	arrVar = DeclarationSpecifiers(arrVar, arrSize, DECL_ARRAY)
+	arrVar = DeclarationSpecifiers(arrVar, arrSizes, DECL_ARRAY)
 	arrVar.AddType(TypeNames[typSpec])
 	arrVar.TotalSize = arrVar.Size * TotalLength(arrVar.Lengths)
 
@@ -259,7 +259,8 @@ func ArrayLiteralExpression(arrSize int, typSpec int, exprs []*CXExpression) []*
 
 			result = append(result, symExpr)
 
-			sym.Lengths = append(expr.Outputs[0].Lengths, arrSize)
+			// sym.Lengths = append(expr.Outputs[0].Lengths, arrSizes[len(arrSizes)-1])
+			sym.Lengths = arrSizes
 			sym.TotalSize = sym.Size * TotalLength(sym.Lengths)
 		} else {
 			result = append(result, expr)
@@ -269,13 +270,15 @@ func ArrayLiteralExpression(arrSize int, typSpec int, exprs []*CXExpression) []*
 	symNameOutput := MakeGenSym(LOCAL_PREFIX)
 
 	symOutput := MakeArgument(symNameOutput, CurrentFile, LineNo).AddType(TypeNames[typSpec])
-	symOutput.Lengths = append(symOutput.Lengths, arrSize)
+	// symOutput.Lengths = append(symOutput.Lengths, arrSizes[len(arrSizes)-1])
+	symOutput.Lengths = arrSizes
 	symOutput.Package = pkg
 	symOutput.PreviouslyDeclared = true
 	symOutput.TotalSize = symOutput.Size * TotalLength(symOutput.Lengths)
 
 	symInput := MakeArgument(symName, CurrentFile, LineNo).AddType(TypeNames[typSpec])
-	symInput.Lengths = append(symInput.Lengths, arrSize)
+	// symInput.Lengths = append(symInput.Lengths, arrSizes[len(arrSizes)-1])
+	symInput.Lengths = arrSizes
 	symInput.Package = pkg
 	symInput.PreviouslyDeclared = true
 	symInput.TotalSize = symInput.Size * TotalLength(symInput.Lengths)

--- a/cxgo/actions/literals.go
+++ b/cxgo/actions/literals.go
@@ -7,7 +7,7 @@ import (
 )
 
 // SliceLiteralExpression handles literal expressions by converting it to a series of `append` expressions.
-func SliceLiteralExpression(typSpec int, exprs []*CXExpression) []*CXExpression {
+func SliceLiteralExpression(sliceDim []int, typSpec int, exprs []*CXExpression) []*CXExpression {
 	var result []*CXExpression
 
 	pkg, err := PRGRM.GetCurrentPackage()
@@ -21,7 +21,7 @@ func SliceLiteralExpression(typSpec int, exprs []*CXExpression) []*CXExpression 
 	slcVarExpr := MakeExpression(nil, CurrentFile, LineNo)
 	slcVarExpr.Package = pkg
 	slcVar := MakeArgument(symName, CurrentFile, LineNo)
-	slcVar = DeclarationSpecifiers(slcVar, []int{0}, DECL_SLICE)
+	slcVar = DeclarationSpecifiers(slcVar, sliceDim, DECL_SLICE)
 	slcVar.AddType(TypeNames[typSpec])
 
 	// slcVar.IsSlice = true
@@ -39,14 +39,15 @@ func SliceLiteralExpression(typSpec int, exprs []*CXExpression) []*CXExpression 
 		if expr.IsArrayLiteral {
 			symInp := MakeArgument(symName, CurrentFile, LineNo).AddType(TypeNames[typSpec])
 			symInp.Package = pkg
+			symInp.Lengths = sliceDim
 			symOut := MakeArgument(symName, CurrentFile, LineNo).AddType(TypeNames[typSpec])
 			symOut.Package = pkg
+			symOut.Lengths = sliceDim
 
 			endPointsCounter++
 
 			symExpr := MakeExpression(nil, CurrentFile, LineNo)
 			symExpr.Package = pkg
-			// symExpr.Outputs = append(symExpr.Outputs, symOut)
 			symExpr.AddOutput(symOut)
 
 			if expr.Operator == nil {
@@ -60,12 +61,21 @@ func SliceLiteralExpression(typSpec int, exprs []*CXExpression) []*CXExpression 
 				// We need to create a temporary variable to hold the result of the
 				// nested expressions. Then use that variable as part of the slice literal.
 				out := MakeArgument(MakeGenSym(LOCAL_PREFIX), expr.FileName, expr.FileLine)
+				out = DeclarationSpecifiers(out, sliceDim[:len(sliceDim)-1], DECL_SLICE)
+				expr.IsArrayLiteral = false
 				outArg := getOutputType(expr)
 				out.AddType(TypeNames[outArg.Type])
 				out.CustomType = outArg.CustomType
 				out.Size = outArg.Size
 				out.TotalSize = outArg.Size
+				out.Lengths = sliceDim
 				out.PreviouslyDeclared = true
+
+				// Declaring `out`
+				declExpr := MakeExpression(nil, CurrentFile, LineNo)
+				declExpr.Package = pkg
+				declExpr.AddOutput(out)
+				result = append(result, declExpr)
 
 				expr.Outputs = nil
 				expr.AddOutput(out)
@@ -110,7 +120,9 @@ func SliceLiteralExpression(typSpec int, exprs []*CXExpression) []*CXExpression 
 	// symInput.PassBy = PASSBY_REFERENCE
 
 	symInput.TotalSize = TYPE_POINTER_SIZE
+	symInput.Lengths = sliceDim
 	symOutput.TotalSize = TYPE_POINTER_SIZE
+	symOutput.Lengths = sliceDim
 
 	symExpr := MakeExpression(Natives[OP_IDENTITY], CurrentFile, LineNo)
 	symExpr.Package = pkg

--- a/cxgo/actions/misc.go
+++ b/cxgo/actions/misc.go
@@ -299,11 +299,11 @@ func AffordanceStructs(pkg *CXPackage, currentFile string, lineNo int) {
 
 	fnFldInpSig := MakeField("InputSignature", TYPE_STR, "", 0)
 	fnFldInpSig.Size = GetArgSize(TYPE_STR)
-	fnFldInpSig = DeclarationSpecifiers(fnFldInpSig, 0, DECL_SLICE)
+	fnFldInpSig = DeclarationSpecifiers(fnFldInpSig, []int{0}, DECL_SLICE)
 
 	fnFldOutSig := MakeField("OutputSignature", TYPE_STR, "", 0)
 	fnFldOutSig.Size = GetArgSize(TYPE_STR)
-	fnFldOutSig = DeclarationSpecifiers(fnFldOutSig, 0, DECL_SLICE)
+	fnFldOutSig = DeclarationSpecifiers(fnFldOutSig, []int{0}, DECL_SLICE)
 
 	fnStrct.AddField(fnFldName)
 	fnStrct.AddField(fnFldInpSig)

--- a/cxgo/cxgo0/cxgo0.y
+++ b/cxgo/cxgo0/cxgo0.y
@@ -422,12 +422,16 @@ array_literal_expression:
         |       indexing_literal type_specifier LBRACE RBRACE
         ;
 
+indexing_slices:
+		LBRACK RBRACK
+        |       indexing_slices LBRACK RBRACK
+		;
+
 slice_literal_expression:
-                LBRACK RBRACK IDENTIFIER LBRACE argument_expression_list RBRACE
-        |       LBRACK RBRACK IDENTIFIER LBRACE RBRACE
-        |       LBRACK RBRACK type_specifier LBRACE argument_expression_list RBRACE
-        |       LBRACK RBRACK type_specifier LBRACE RBRACE
-        |       LBRACK RBRACK slice_literal_expression
+                indexing_slices IDENTIFIER LBRACE argument_expression_list RBRACE
+        |       indexing_slices IDENTIFIER LBRACE RBRACE
+        |       indexing_slices type_specifier LBRACE argument_expression_list RBRACE
+        |       indexing_slices type_specifier LBRACE RBRACE
                 ;
 
 

--- a/cxgo/main.go
+++ b/cxgo/main.go
@@ -734,8 +734,8 @@ func ParseSourceCode(sourceCode []*os.File, fileNames []string) {
 			arg0.Package = osPkg
 
 			arg1 := MakeArgument(OS_ARGS, "", -1).AddType(TypeNames[TYPE_STR])
-			arg1 = DeclarationSpecifiers(arg1, 0, DECL_BASIC)
-			arg1 = DeclarationSpecifiers(arg1, 0, DECL_SLICE)
+			arg1 = DeclarationSpecifiers(arg1, []int{0}, DECL_BASIC)
+			arg1 = DeclarationSpecifiers(arg1, []int{0}, DECL_SLICE)
 
 			DeclareGlobalInPackage(osPkg, arg0, arg1, nil, false)
 		}
@@ -886,6 +886,7 @@ func main() {
 	}
 
 	if options.replMode || len(sourceCode) == 0 {
+		PRGRM.SelectProgram()
 		repl()
 		return
 	}


### PR DESCRIPTION
Fixes #482 

Changes:
- The parser had to be changed a bit to read all the slice dimensions in another grammar rule. Instead of building up the dimensions of the CXArgument step by step, all the dimensions are read at once and used to create the slice literal in a single step.

Does this change need to mentioned in CHANGELOG.md?
Yes.