### PR TITLE
Fix #110: `read()` is not working.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Libraries
   * ...
 * Fixed issues
+  * #110: `read()` is not working.
   * #306: Can't print double quotes.
   * #321: Can't do math inside 2nd square brackets (indexer) of an expression.
   * #419: Initializing array or slice with values equivalent to nil.

--- a/cx/op_und.go
+++ b/cx/op_und.go
@@ -659,31 +659,14 @@ func opRead(prgrm *CXProgram) {
 	fp := prgrm.GetFramePointer()
 
 	out1 := expr.Outputs[0]
-	out1Offset := GetFinalOffset(fp, out1)
 
 	reader := bufio.NewReader(os.Stdin)
 	text, err := reader.ReadString('\n')
-	// text = strings.Trim(text, " \n")
-	text = strings.Replace(text, "\n", "", -1)
-	text = strings.Replace(text, "\r", "", -1)
-
 	if err != nil {
 		panic("")
 	}
-	byts := encoder.Serialize(text)
-	size := encoder.Serialize(int32(len(byts)) + OBJECT_HEADER_SIZE)
-	heapOffset := AllocateSeq(len(byts) + OBJECT_HEADER_SIZE)
+	text = strings.Replace(text, "\n", "", -1)
+	text = strings.Replace(text, "\r", "", -1)
 
-	var header = make([]byte, OBJECT_HEADER_SIZE)
-	for c := 5; c < OBJECT_HEADER_SIZE; c++ {
-		header[c] = size[c-5]
-	}
-
-	obj := append(header, byts...)
-
-	WriteMemory(heapOffset, obj)
-
-	off := encoder.SerializeAtomic(int32(heapOffset + OBJECT_HEADER_SIZE))
-
-	WriteMemory(out1Offset, off)
+	writeString(fp, text, out1)
 }

--- a/cx/op_und.go
+++ b/cx/op_und.go
@@ -663,7 +663,7 @@ func opRead(prgrm *CXProgram) {
 	reader := bufio.NewReader(os.Stdin)
 	text, err := reader.ReadString('\n')
 	if err != nil {
-		panic("")
+		panic(err)
 	}
 	text = strings.Replace(text, "\n", "", -1)
 	text = strings.Replace(text, "\r", "", -1)


### PR DESCRIPTION
Fixes #110 

Changes:
- `read()` was not properly storing the string it was reading from user input. Fixed.

Does this change need to mentioned in CHANGELOG.md?
Yes.