### PR TITLE
CPU Profiling

### DIFF
--- a/cx/op_profile.go
+++ b/cx/op_profile.go
@@ -1,0 +1,49 @@
+// +build base
+
+package cxcore
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/pprof"
+)
+
+var openProfiles map[string]*os.File = make(map[string]*os.File, 0)
+
+func startCPUProfile(name string, rate int) *os.File {
+	f, err := os.Create(fmt.Sprintf("%s_%s_cpu.pprof", os.Args[0], name))
+	if err != nil {
+		fmt.Println("Failed to create CPU profile: ", err)
+	}
+	if rate != 100 { // test against default value to avoid warning
+		runtime.SetCPUProfileRate(rate)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		fmt.Println("Failed to start CPU profile: ", err)
+	}
+	return f
+}
+
+func stopCPUProfile(f *os.File) {
+	if f != nil {
+		defer f.Close()
+	}
+	defer pprof.StopCPUProfile()
+}
+
+func opStartProfile(prgrm *CXProgram) {
+	expr := prgrm.GetExpr()
+	fp := prgrm.GetFramePointer()
+
+	profilePath := ReadStr(fp, expr.Inputs[0])
+	openProfiles[profilePath] = startCPUProfile(profilePath, int(ReadI32(fp, expr.Inputs[1])))
+}
+
+func opStopProfile(prgrm *CXProgram) {
+	expr := prgrm.GetExpr()
+	fp := prgrm.GetFramePointer()
+
+	profilePath := ReadStr(fp, expr.Inputs[0])
+	stopCPUProfile(openProfiles[profilePath])
+}

--- a/cx/opcodes_base.go
+++ b/cx/opcodes_base.go
@@ -37,6 +37,10 @@ const (
 	OP_JSON_TOKEN_I64
 	OP_JSON_TOKEN_STR
 
+	// profile
+	OP_START_CPU_PROFILE
+	OP_STOP_CPU_PROFILE
+
 	// http
 	// OP_HTTP_GET
 
@@ -126,6 +130,14 @@ func init() {
 	AddOpCode(OP_JSON_TOKEN_STR, "json.Str",
 		[]*CXArgument{newOpPar(TYPE_I32, false)},
 		[]*CXArgument{newOpPar(TYPE_STR, false), newOpPar(TYPE_BOOL, false)})
+
+	// profile
+	AddOpCode(OP_START_CPU_PROFILE, "StartCPUProfile",
+		[]*CXArgument{newOpPar(TYPE_STR, false), newOpPar(TYPE_I32, false)},
+		[]*CXArgument{})
+	AddOpCode(OP_STOP_CPU_PROFILE, "StopCPUProfile",
+		[]*CXArgument{newOpPar(TYPE_STR, false)},
+		[]*CXArgument{})
 
 	// exec
 	handleOpcode := func(opCode int) opcodeHandler {

--- a/cx/opcodes_base.go
+++ b/cx/opcodes_base.go
@@ -198,6 +198,12 @@ func init() {
 			return opJSONTokenI64
 		case OP_JSON_TOKEN_STR:
 			return opJSONTokenStr
+
+		// profile
+		case OP_START_CPU_PROFILE:
+			return opStartProfile
+		case OP_STOP_CPU_PROFILE:
+			return opStopProfile
 		}
 
 		return nil

--- a/cxgo/main.go
+++ b/cxgo/main.go
@@ -53,6 +53,7 @@ var (
 	log             = logging.MustGetLogger("newcoin")
 	apiClient       = &http.Client{Timeout: 10 * time.Second}
 	genesisBlockURL = "http://127.0.0.1:%d/api/v1/block?seq=0"
+	profile         *os.File
 )
 
 var (
@@ -709,6 +710,11 @@ func lexerStep0(sourceCodeCopy, fileNames []string) int {
 	return parseErrors
 }
 
+func cleanupAndExit(exitCode int) {
+	StopCPUProfile(profile)
+	os.Exit(exitCode)
+}
+
 // ParseSourceCode takes a group of files representing CX `sourceCode` and
 // parses it into CX program structures for `PRGRM`.
 func ParseSourceCode(sourceCode []*os.File, fileNames []string) {
@@ -734,7 +740,7 @@ func ParseSourceCode(sourceCode []*os.File, fileNames []string) {
 
 	PRGRM = cxgo0.PRGRM0
 	if FoundCompileErrors || parseErrors > 0 {
-		os.Exit(CX_COMPILATION_ERROR)
+		cleanupAndExit(CX_COMPILATION_ERROR)
 	}
 
 	// Adding global variables `OS_ARGS` to the `os` (operating system)
@@ -771,7 +777,7 @@ func ParseSourceCode(sourceCode []*os.File, fileNames []string) {
 	StopProfile("4. parse")
 
 	if FoundCompileErrors || parseErrors > 0 {
-		os.Exit(CX_COMPILATION_ERROR)
+		cleanupAndExit(CX_COMPILATION_ERROR)
 	}
 }
 
@@ -836,16 +842,13 @@ func parseProgram(options cxCmdFlags, fileNames []string, sourceCode []*os.File)
 	LineNo = 0
 
 	if FoundCompileErrors {
-		os.Exit(CX_COMPILATION_ERROR)
+		cleanupAndExit(CX_COMPILATION_ERROR)
 	}
 
 	return true, bcHeap, sPrgrm
 }
 
 func runProgram(options cxCmdFlags, cxArgs []string, sourceCode []*os.File, bcHeap []byte, sPrgrm []byte) {
-	profile := StartCPUProfile("run")
-	defer StopCPUProfile(profile)
-	defer DumpMEMProfile("run")
 	StartProfile("run")
 	defer StopProfile("run")
 


### PR DESCRIPTION
Changes:
- Add opcodes to start/stop cpu profiling from cx code : StartCPUProfile/StopCPUProfile.
- Remove runtime profiling from cxgo/main.go as it can be triggered for cx now.

Does this change need to mentioned in CHANGELOG.md?
Yes