### PR TITLE
Fixes for affordances.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 	- Added basic Regexp library.
 	- Added basic Cipher library.
 * Changes
+  * Updated affordances to play well with newer language features.
   * Removed cx-games as a module. It was just confusing as users would be
     redirected to an outdated version of the repo and the games are already
     mentioned in the README.

--- a/cx/op_aff.go
+++ b/cx/op_aff.go
@@ -3,7 +3,6 @@ package cxcore
 import (
 	"fmt"
 	"strconv"
-
 	// "github.com/SkycoinProject/skycoin/src/cipher/encoder"
 )
 
@@ -157,7 +156,6 @@ func queryParam(fn *CXFunction, args []*CXArgument, exprLbl string, argOffsetB [
 		// argNameB := encoder.Serialize(arg.Name)
 		// argNameOffset := int32(WriteObjectRetOff(argNameB))
 		argNameOffset := WriteStringObj(arg.Name)
-		
 
 		argOffset := AllocateSeq(OBJECT_HEADER_SIZE + STR_SIZE + I32_SIZE + STR_SIZE)
 		WriteI32(argOffset+OBJECT_HEADER_SIZE, int32(argNameOffset))

--- a/cx/opcodes.go
+++ b/cx/opcodes.go
@@ -1054,12 +1054,12 @@ func init() {
 	Op(OP_PANIC_IF_NOT, "panicIfNot", opPanicIfNot, In(ABOOL, ASTR), nil)
 	Op(OP_STRERROR, "strerror", opStrError, In(AI32), Out(ASTR))
 
-	Op(OP_AFF_PRINT, "aff.print", opAffPrint, In(AAFF), nil)
-	Op(OP_AFF_QUERY, "aff.query", opAffQuery, In(AAFF), Out(AAFF))
-	Op(OP_AFF_ON, "aff.on", opAffOn, In(AAFF, AAFF), nil)
-	Op(OP_AFF_OF, "aff.of", opAffOf, In(AAFF, AAFF), nil)
-	Op(OP_AFF_INFORM, "aff.inform", opAffInform, In(AAFF, AI32, AAFF), nil)
-	Op(OP_AFF_REQUEST, "aff.request", opAffRequest, In(AAFF, AI32, AAFF), nil)
+	Op(OP_AFF_PRINT, "aff.print", opAffPrint, In(Slice(TYPE_AFF)), nil)
+	Op(OP_AFF_QUERY, "aff.query", opAffQuery, In(Slice(TYPE_AFF)), Out(Slice(TYPE_AFF)))
+	Op(OP_AFF_ON, "aff.on", opAffOn, In(Slice(TYPE_AFF), Slice(TYPE_AFF)), nil)
+	Op(OP_AFF_OF, "aff.of", opAffOf, In(Slice(TYPE_AFF), Slice(TYPE_AFF)), nil)
+	Op(OP_AFF_INFORM, "aff.inform", opAffInform, In(Slice(TYPE_AFF), AI32, Slice(TYPE_AFF)), nil)
+	Op(OP_AFF_REQUEST, "aff.request", opAffRequest, In(Slice(TYPE_AFF), AI32, Slice(TYPE_AFF)), nil)
 
 	Op(OP_HTTP_SERVE, "http.Serve", opHTTPServe, In(ASTR), Out(ASTR))
 	Op(OP_HTTP_LISTEN_AND_SERVE, "http.ListenAndServe", opHTTPListenAndServe, In(ASTR), Out(ASTR))

--- a/cx/utilities.go
+++ b/cx/utilities.go
@@ -1377,7 +1377,7 @@ func WriteStringObj(str string) int {
 	return NewWriteObj(strB)
 }
 
-// ReadStringFromOffset reads the string located at offset `off`.
+// ReadStringFromObject reads the string located at offset `off`.
 func ReadStringFromObject(off int32) string {
 	var plusOff int32
 	if int(off) > PROGRAM.HeapStartsAt {
@@ -1385,8 +1385,7 @@ func ReadStringFromObject(off int32) string {
 		plusOff += OBJECT_HEADER_SIZE
 	}
 
-	var size int32
-	size = mustDeserializeI32(PROGRAM.Memory[off+plusOff:off+plusOff+STR_HEADER_SIZE])
+	size := mustDeserializeI32(PROGRAM.Memory[off+plusOff : off+plusOff+STR_HEADER_SIZE])
 
 	str := ""
 	_, err := encoder.DeserializeRaw(PROGRAM.Memory[off+plusOff:off+plusOff+STR_HEADER_SIZE+size], &str)

--- a/cx/utilities.go
+++ b/cx/utilities.go
@@ -1370,3 +1370,28 @@ func IsPointer(sym *CXArgument) bool {
 	// }
 	return false
 }
+
+// WriteStringObj writes `str` to the heap as an object and returns its absolute offset.
+func WriteStringObj(str string) int {
+	strB := encoder.Serialize(str)
+	return NewWriteObj(strB)
+}
+
+// ReadStringFromOffset reads the string located at offset `off`.
+func ReadStringFromObject(off int32) string {
+	var plusOff int32
+	if int(off) > PROGRAM.HeapStartsAt {
+		// Found in heap segment.
+		plusOff += OBJECT_HEADER_SIZE
+	}
+
+	var size int32
+	size = mustDeserializeI32(PROGRAM.Memory[off+plusOff:off+plusOff+STR_HEADER_SIZE])
+
+	str := ""
+	_, err := encoder.DeserializeRaw(PROGRAM.Memory[off+plusOff:off+plusOff+STR_HEADER_SIZE+size], &str)
+	if err != nil {
+		panic(err)
+	}
+	return str
+}

--- a/cxgo/actions/assignment.go
+++ b/cxgo/actions/assignment.go
@@ -150,6 +150,7 @@ func Assignment(to []*CXExpression, assignOp string, from []*CXExpression) []*CX
 			if outTypeArg.IsSlice {
 				// if from[idx].Operator.Outputs[0].IsSlice {
 				sym.Lengths = append([]int{0}, sym.Lengths...)
+				sym.DeclarationSpecifiers = append(sym.DeclarationSpecifiers, DECL_SLICE)
 			}
 
 			sym.IsSlice = outTypeArg.IsSlice

--- a/examples/affordances/affordances-of/argument-struct.cx
+++ b/examples/affordances/affordances-of/argument-struct.cx
@@ -21,7 +21,7 @@ type Person struct {
 }
 
 func predStrct (strct aff.Structure) (res bool) {
-	if strct.Name == "Point" || strct.Name == "Line" {
+	if strct.Name == "Line" {
 		res = true
 	}
 }
@@ -43,10 +43,9 @@ targetExpr:
 
 	elts := aff.query(fltrs)
 
-	aff.of(elts, tgt)
-	
-	aff.request(elts, 0, tgt)
+	aff.print(elts)
 
-	// Use the new field through affordances
-	// Ah, let's just print an instance of Point, duh
+	aff.of(elts, tgt)
+
+	aff.request(elts, 0, tgt)
 }


### PR DESCRIPTION
Changes:
- Affordances were outdated. They were not complying to CX's type checking system and many other newer language features.

Does this change need to mentioned in CHANGELOG.md?
Yes.