### PR TITLE
Rename skycoin.net to skycoin.com

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
  - OS: [e.g. Linux, Windows]
- - Browser (if related to cx.skycoin.net) [e.g. Chrome, Safari]
+ - Browser (if related to cx.skycoin.com) [e.g. Chrome, Safari]
  - CX Version [e.g. 0.5.18]
 
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Table of Contents
       * [Updating CX](#updating-cx)
    * [Running CX](#running-cx)
       * [Hello World](#hello-world)
-      * [Basic Options](#other-options) 
+      * [Basic Options](#other-options)
          * [Running CX Programs](#running-cx-programs)
-      * [REPL tutorial](#cx-repl)               
+      * [REPL tutorial](#cx-repl)
    * [Syntax](#syntax)
       * [Comments](#comments)
       * [Declarations](#declarations)
@@ -189,7 +189,7 @@ repository](https://github.com/Skycoin/cx-book).
 
 ## Miscellaneous:
 
-* https://github.com/skycoin/cx-website [cx.skycoin.net]
+* https://github.com/skycoin/cx-website [cx.skycoin.com]
 
 <!--# CX Roadmap
 
@@ -387,7 +387,7 @@ this in your terminal:
 
 ```
 CX 0.5.13
-More information about CX is available at http://cx.skycoin.net/ and https://github.com/skycoin/cx/
+More information about CX is available at http://cx.skycoin.com/ and https://github.com/skycoin/cx/
 :func main {...
 	*
 ```

--- a/releases/RELEASE-0.6.1.md
+++ b/releases/RELEASE-0.6.1.md
@@ -29,16 +29,16 @@ There are a number of major improvement over 0.6.0:
    clause. From CX 0.6.1 the CX language will enforce strict lexical scoping.
 
  * `if/elseif` and `if/elseif/else` constructs now work correctly.
- 
+
  * The `+` operator can now be used to concatenate strings:
- 
+
     ```
     var conc str
     conc = "Hello " + "world!"
     ```
- 
+
  * Expressions can now be used when initializing slice/array literals:
- 
+
    ```
    var slc []i32
    slc = []i32{i32.add(1, 2), foo()}
@@ -77,12 +77,12 @@ There are a number of major improvement over 0.6.0:
    The CX book is being updated, but this is not part of this release.  The
    book version 0.6 will have its own release at a later time.  If you want to
    look at the work in progress, you can find a snapshot of it in the `book/`
-   subdirectory. 
+   subdirectory.
 
 ## About CX
 
 CX is the programming language for smart contracts on the
-[Skycoin](https://www.skycoin.net/) blockchain. CX is a general purpose,
+[Skycoin](https://www.skycoin.com/) blockchain. CX is a general purpose,
 interpreted and compiled programming language, with a very strict type system
 and a syntax similar to Golang's. CX provides a new programming paradigm based
 on the concept of affordances.

--- a/releases/RELEASE-0.6.2.md
+++ b/releases/RELEASE-0.6.2.md
@@ -64,12 +64,12 @@ There are a few language improvement over 0.6.1:
    The CX book is being updated, but this is not part of this release.  The
    book version 0.6 will have its own release at a later time.  If you want to
    look at the work in progress, you can find a snapshot of it in the `book/`
-   subdirectory. 
+   subdirectory.
 
 ## About CX
 
 CX is the blockchain programming language on the
-[Skycoin](https://www.skycoin.net/) blockchain. CX is a general purpose,
+[Skycoin](https://www.skycoin.com/) blockchain. CX is a general purpose,
 interpreted and compiled programming language, with a very strict type system
 and a syntax similar to Golang's. CX provides a new programming paradigm based
 on the concept of affordances.

--- a/releases/RELEASE-0.6.md
+++ b/releases/RELEASE-0.6.md
@@ -105,6 +105,6 @@ of CX 0.5, but are now officially supported.  These are:
 
 ## About CX
 
-CX is the programming language for smart contracts on the [Skycoin](https://www.skycoin.net/) blockchain. CX is a general purpose, interpreted and compiled programming language, with a very strict type system and a syntax similar to Golang's. CX provides a new programming paradigm based on the concept of affordances.
+CX is the programming language for smart contracts on the [Skycoin](https://www.skycoin.com/) blockchain. CX is a general purpose, interpreted and compiled programming language, with a very strict type system and a syntax similar to Golang's. CX provides a new programming paradigm based on the concept of affordances.
 
 

--- a/releases/RELEASE-0.7.0.md
+++ b/releases/RELEASE-0.7.0.md
@@ -71,7 +71,7 @@ There are no library improvements in CX 0.7.0
 ## About CX
 
 CX is the blockchain programming language for use on the
-[Skycoin](https://www.skycoin.net/) blockchain and associated Fiber
+[Skycoin](https://www.skycoin.com/) blockchain and associated Fiber
 blockchains. CX is a general purpose, interpreted and compiled programming
 language, with a very strict type system and a syntax similar to Golang's. CX
 provides a new programming paradigm based on the concept of affordances.

--- a/releases/RELEASE-0.7.1.md
+++ b/releases/RELEASE-0.7.1.md
@@ -69,7 +69,7 @@ There are no library improvements in CX 0.7.1.
 ## About CX
 
 CX is the blockchain programming language for use on the
-[Skycoin](https://www.skycoin.net/) blockchain and associated Fiber
+[Skycoin](https://www.skycoin.com/) blockchain and associated Fiber
 blockchains. CX is a general purpose, interpreted and compiled programming
 language, with a very strict type system and a syntax similar to Golang's. CX
 provides a new programming paradigm based on the concept of affordances.

--- a/releases/RELEASE-0.7beta.md
+++ b/releases/RELEASE-0.7beta.md
@@ -57,7 +57,7 @@ There are no language-specific improvements in CX 0.7beta.
 ## About CX
 
 CX is the blockchain programming language on the
-[Skycoin](https://www.skycoin.net/) blockchain. CX is a general purpose,
+[Skycoin](https://www.skycoin.com/) blockchain. CX is a general purpose,
 interpreted and compiled programming language, with a very strict type system
 and a syntax similar to Golang's. CX provides a new programming paradigm based
 on the concept of affordances.


### PR DESCRIPTION
Changes:
- Rename skycoin.net to skycoin.com in the project.

Does this change need to mentioned in CHANGELOG.md?
No.