### PR TITLE
Fix makefile $GOBIN and test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ PKG_NAMES_WINDOWS := mingw-w64-x86_64-openal
 
 UNAME_S := $(shell uname -s)
 
+CXVERSION := $(shell $(PWD)/bin/cx --version 2> /dev/null)
+
 ifneq (,$(findstring Linux, $(UNAME_S)))
 PLATFORM := LINUX
 SUBSYSTEM := LINUX
@@ -142,11 +144,12 @@ token-fuzzer:
 	chmod +x ${GOPATH}/bin/cx-token-fuzzer
 
 test: #build ## Run CX test suite.
-    ifndef $(shell ./bin/cx --version 2> /dev/null)
-      $(error "No cx installed in $(PWD)/bin, consider running make install first")
-    endif
+ifndef CXVERSION
+	@echo "cx not found in $(PWD)/bin, please run make install first"
+else	
 	$(GO_OPTS) go test -race -tags base github.com/skycoin/cx/cxgo/
 	$(GOBIN)/cx ./lib/args.cx ./tests/main.cx ++wdir=./tests ++disable-tests=gui,issue
+endif
 
 test-full: build ## Run CX test suite with all build tags
 	$(GO_OPTS) go test -race -tags="base cxfx" github.com/skycoin/cx/cxgo/

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,10 @@ token-fuzzer:
 	$(GO_OPTS) go build -i -o $(GOBIN)/cx-token-fuzzer $(PWD)/development/token-fuzzer/main.go
 	chmod +x ${GOPATH}/bin/cx-token-fuzzer
 
-test: build ## Run CX test suite.
+test: #build ## Run CX test suite.
+    ifndef $(shell ./bin/cx --version 2> /dev/null)
+      $(error "No cx installed in $(PWD)/bin, consider running make install first")
+    endif
 	$(GO_OPTS) go test -race -tags base github.com/skycoin/cx/cxgo/
 	$(GOBIN)/cx ./lib/args.cx ./tests/main.cx ++wdir=./tests ++disable-tests=gui,issue
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ endif
 
 ## Ensure $GOBIN is set.
 GOLANGCI_LINT_VERSION ?= latest
-GOBIN ?= $(PWD)/bin
+GOBIN = $(PWD)/bin
 GO_OPTS ?= GOBIN=$(GOBIN)
 
 ifdef CXPATH


### PR DESCRIPTION
Fixes #316 and #317 

Changes:
- `make test` should check whether `./bin/cx` exists or not before running the test
- `$GOBIN` variable now default to `./bin/cx`

Does this change need to mentioned in CHANGELOG.md?
No
