### PR TITLE
README.md update for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ make test-full
 
 ### Compiling CX on Windows
 
+Requires installation of GIT from https://git-scm.com/downloads prior to compile.
 An installation script is also provided for Windows named `cx-setup.bat`. You can compile CX on Windows by running:
 
 ```


### PR DESCRIPTION
GIT installation link added in README for Windows users

Fixes #
Should allow Windows users to compile 'cx-setup' without additional error about missing GIT

Changes:
-Added GIT installation requirment for Windows users in install section

Does this change need to mentioned in CHANGELOG.md?
