### PR TITLE
Updated README installation instructions.

### DIFF
--- a/GO-INSTALLATION.md
+++ b/GO-INSTALLATION.md
@@ -1,0 +1,102 @@
+# Installing go
+
+CX supports go1.15+.
+
+## For OSX
+First you need to have `homebrew` installed, if you don't have it yet.
+
+```sh
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
+
+Then, let's install go's latest version.
+
+```sh
+brew install go
+```
+
+Lastly, let's install Mercurial and Bazaar
+
+```sh
+brew install mercurial bzr
+```
+
+## For linux
+We need to install linux dependencies on the correct distribution.
+
+#### Ubuntu and Debian
+```sh
+sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get install -y curl git mercurial make binutils gcc bzr bison libgmp3-dev screen gcc build-essential
+```
+
+#### Centos and Fedora
+```sh
+sudo yum update -y && sudo yum upgrade -y
+sudo yum install -y git curl make gcc mercurial binutils bzr bison screen
+if [[ "$(cat /etc/redhat-release | grep -o CentOS)" == "CentOS" ]]; then sudo yum install -y build-essential libgmp3-dev; else sudo yum groupinstall -y "Development Tools" "Development Libraries" && sudo yum install -y gmp; fi;
+```
+#### Archlinux
+First update the system and ensure the dependancies are met
+```sh
+sudo pacman -Syy && sudo pacman -Syu
+sudo pacman -S base-devel
+```
+
+Install the latest version of go on Archlinux with:
+```sh
+sudo pacman -S go
+```
+
+## Install Go manually
+### Install Go
+
+Let's go to home directory and declare `go`'s version that you want to download.
+
+```sh
+cd ~
+export GOV=1.15 # golang version
+```
+
+After that, let's download and uncompress golang source.
+
+```sh
+curl -sS https://storage.googleapis.com/golang/go$GOV.linux-amd64.tar.gz > go$GOV.linux-amd64.tar.gz
+tar xvf go$GOV.linux-amd64.tar.gz
+rm go$GOV.linux-amd64.tar.gz
+```
+
+lastly, let's install `go`.
+
+```sh
+sudo mv go /usr/local/go
+sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
+sudo ln -s /usr/local/go/bin/godoc /usr/local/bin/godoc
+sudo ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+```
+
+Note: Find any golang source version at [Go Website](https://golang.org/dl/)
+
+### Setup your GOPATH
+The $GOPATH environment variable specifies the location of your workspace. It defaults to a directory named `go` inside your home directory, so $HOME/go on Unix.
+
+Create your workspace directory with it's respective inner folders:
+
+```sh
+mkdir -p $HOME/go
+mkdir -p $HOME/go/bin
+mkdir -p $HOME/go/src
+mkdir -p $HOME/go/pkg
+```
+
+Setup $GOPATH variable, add it to ~/.bashrc. After editing, run `source ~/.bashrc` or open a new tab.
+
+```sh
+export GOROOT=/usr/local/go
+export GOPATH=$HOME/go
+export GOBIN=$GOPATH/bin
+export PATH=$PATH:$GOBIN
+```
+
+## Test your Go installation
+Create and run the hello.go application described here: https://golang.org/doc/install#testing to check if your Go installation is working.

--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ https://github.com/skycoin/cx/issues, and we'll fix it for the next release.
 
 ### Installing Go
 
-CX supports go1.10+.
+CX supports go1.15+.
 
-[Go 1.10+ installation/setup](https://github.com/skycoin/skycoin/blob/develop/INSTALLATION.md)
+[Go 1.15+ installation/setup](https://github.com/skycoin/cx/blob/develop/GO-INSTALLATION.md)
 
 ### Compiling CX on \*nix
 
@@ -221,6 +221,12 @@ Build CX's binary and install by running:
 
 ```
 make install
+```
+
+Add the CX binary path to your operating system's `$PATH`. For example, in Linux:
+
+```
+export PATH=$PATH:$HOME/cx/bin
 ```
 
 You should test your installation by running:

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Build CX's binary and install by running:
 make install
 ```
 
-Add the CX binary path to your operating system's `$PATH`. For example, in Linux:
+`make install` builds a CX binary and installs it into `$HOME/cx/bin`. Add the CX binary path to your operating system's `$PATH`. For example, in Linux:
 
 ```
 export PATH=$PATH:$HOME/cx/bin
@@ -276,6 +276,8 @@ cx-setup.bat
 Do you want to know how CX looks? This is how you print "Hello, World!"
 in a terminal:
 
+Create a `hello-world.cx` file, put these contents in the file:
+
 ```
 package main
 
@@ -284,49 +286,19 @@ func main () {
 }
 ```
 
-Every CX program must have at least a *main* package, and a *main*
-function. As mentioned before, CX has a strict type system,
-where functions can only be associated with a single type
-signature. As a consequence,
-if we want to print a string, as in the example above, we have to call
-*str*'s print function, where *str* is a package containing string
-related functions.
-
-However, there are some exceptions, mainly to functions where it makes
-sense to have a generalized type signature. For example, the `len`
-function accepts arrays of any type as its argument, instead of having
-`[]i32.len()` or `[][]str.len()`. Another example is `sprintf`, which
-is used to construct a string using a format string and a series of
-arguments of any type.
+Then run `cx hello-world.cx`. You can also run the examples found in the `examples` directory.
 
 ## Basic Options
 
-If you write `cx --help` or `cx -h`, you should see a text describing
+If you type `cx --help` or `cx -h`, you should see a text describing
 CX's usage, options and more. `cx --version` provides the detail about the current cx version installed on the machine.
 
 Some interesting options are:
 
-* `--base` which generates a CX program's assembly code (in Go)
-* `--compile` which generates an executable file
 * `--repl` which loads the program and makes CX run in REPL mode
 (useful for debugging a program)
 * `--web` which starts CX as a RESTful web service (you can send code
   to be evaluated to this endpoint: http://127.0.0.1:5336/eval)
-
-
-### Running CX Programs
-
-To run a CX program, you have to type, for example, `cx
-the-program.cx`. Let's try to run some examples from the `examples`
-directory in this repository. In a terminal, type this:
-
-```
-cd $GOPATH/src/github.com/skycoin/cx/
-cx examples/hello-world.cx
-```
-
-This should print `Hello World!` in the terminal. Now try running `cx
-examples/opengl/game.cx`.
 
 
 ## REPL tutorial


### PR DESCRIPTION
Fixes #359 

Changes:
- Added instructions on how to install golang 1.15.
- Added instructions on how to add CX to your $PATH.

Does this change need to mentioned in CHANGELOG.md?
No.