### PR TITLE
fixed imports

### DIFF
--- a/goyacc/main.go
+++ b/goyacc/main.go
@@ -136,12 +136,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/skycoin/cx/yacc/parser/yacc"
-	"github.com/skycoin/cx/yacc/y"
+	"github.com/skycoin/cx/goyacc/parser/yacc"
+	"github.com/skycoin/cx/goyacc/y"
 
-	"github.com/skycoin/cx/yacc/mathutil"
-	"github.com/kycoin/cx/yacc/sortutil"
-	"github.com/kycoin/cx/yacc/strutil"
+	"github.com/skycoin/cx/goyacc/mathutil"
+	"github.com/skycoin/cx/goyacc/sortutil"
+	"github.com/skycoin/cx/goyacc/strutil"
 )
 
 var (

--- a/goyacc/y/y.go
+++ b/goyacc/y/y.go
@@ -17,9 +17,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/skycoin/cx/yacc/mathutil"
-	yparser "github.com/skycoin/cx/yacc/parser/yacc"
-	"github.com/skycoin/cx/yacc/strutil"
+	"github.com/skycoin/cx/goyacc/mathutil"
+	yparser "github.com/skycoin/cx/goyacc/parser/yacc"
+	"github.com/skycoin/cx/goyacc/strutil"
 )
 
 const (


### PR DESCRIPTION
Fixes #
Imports use goyacc instead of yacc
I opened with Goland IDE I found some mistakes with imports

Changes:
use goyacc instead of yacc
![imagen](https://user-images.githubusercontent.com/223240/109046124-29f3d000-76b3-11eb-8448-6daccfb17b0b.png)

please check imports 

Does this change need to mentioned in CHANGELOG.md?
