### PR TITLE
Changing required golang version for Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: go
 
 # Version of go to use
 go:
-  - "1.14.x"
+  - "1.15.x"
 
 # Define global variables
 env:


### PR DESCRIPTION
Changes:
- Changed golang version from 1.14.x to 1.15.x for travis.

Does this change need to mentioned in CHANGELOG.md?
No.