### PR TITLE
Update for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,13 @@ make test-full
 
 ### Compiling CX on Windows
 
-Requires installation of GIT from https://git-scm.com/downloads prior to compile.
+Requires installation of GIT from https://git-scm.com/downloads prior to compile. 
+Setup GOPATH for cx:
+
+```
+set GOPATH=%userprofile%/cx
+```
+
 An installation script is also provided for Windows named `cx-setup.bat`. You can compile CX on Windows by running:
 
 ```


### PR DESCRIPTION
GOPATH matching cx environment

Fixes #
GOPATH needs to match cx environment for dependencies to be installed.

Changes:
Added command for setting GOPATH. I will add command for CXPATH command as well so user can chose where to setup environment.

Does this change need to mentioned in CHANGELOG.md?
