### PR TITLE
Build from vendor into ./bin/dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ install-mobile:
 	go get golang.org/x/mobile/gl # TODO @evanlinjin: This is a library. needed?
 
 clean: ## Removes binaries. 
-	rm -r ./bin/*
+	rm -rf ./bin
 
 token-fuzzer:
 	go build $(GO_OPTS) -i -o ./bin/cx-token-fuzzer $(PWD)/development/token-fuzzer/main.go

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ install-mobile:
 	go get golang.org/x/mobile/gl # TODO @evanlinjin: This is a library. needed?
 
 clean: ## Removes binaries. 
-	rm -r ./bin/cx
+	rm -r ./bin/*
 
 token-fuzzer:
 	go build $(GO_OPTS) -i -o ./bin/cx-token-fuzzer $(PWD)/development/token-fuzzer/main.go

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,9 @@ else
   GOPATH := $(LOCAL_GOPATH)
 endif
 
-
-## Ensure $GOBIN is set.
 GOLANGCI_LINT_VERSION ?= latest
 
-GO_OPTS ?= GOBIN=$(GOBIN)
+GO_OPTS ?= -mod=vendor
 
 ifdef CXPATH
 	CX_PATH := $(CXPATH)
@@ -81,20 +79,20 @@ configure-workspace: ## Configure CX workspace environment
 	@echo "NOTE:\tCX workspace at $(CX_PATH)"
 
 build-parser: install-deps ## Generate lexer and parser for CX grammar
-	$(GOBIN)/goyacc -o cxgo/cxgo0/cxgo0.go cxgo/cxgo0/cxgo0.y
-	$(GOBIN)/goyacc -o cxgo/parser/cxgo.go cxgo/parser/cxgo.y
+	./bin/goyacc -o cxgo/cxgo0/cxgo0.go cxgo/cxgo0/cxgo0.y
+	./bin/goyacc -o cxgo/parser/cxgo.go cxgo/parser/cxgo.y
 
 build:  ## Build CX from sources
-	$(GO_OPTS) go build -tags="base" -i -o $(GOBIN)/cx github.com/skycoin/cx/cxgo/
-	chmod +x $(GOBIN)/cx
+	go build $(GO_OPTS) -tags="base" -i -o ./bin/cx github.com/skycoin/cx/cxgo/
+	chmod +x ./bin/cx
 
 build-full: install-full  ## Build CX from sources with all build tags
-	$(GO_OPTS) go build -tags="base cxfx" -i -o $(GOBIN)/cx github.com/skycoin/cx/cxgo/
-	chmod +x $(GOBIN)/cx
+	go build $(GO_OPTS) -tags="base cxfx" -i -o ./bin/cx github.com/skycoin/cx/cxgo/
+	chmod +x ./bin/cx
 
 build-android: install-full install-mobile 
 	# TODO @evanlinjin: We should switch this to use 'github.com/SkycoinProject/gomobile' once it can build.
-	$(GO_OPTS) go get -u golang.org/x/mobile/cmd/gomobile
+	go get -u golang.org/x/mobile/cmd/gomobile
 
 install-gfx-deps-LINUX:
 	@echo 'Installing dependencies for $(UNAME_S)'
@@ -116,35 +114,35 @@ install-gfx-deps-MACOS:
 
 install-deps:
 	@echo "Installing go package dependencies"
-	$(GO_OPTS) go get -u modernc.org/goyacc
+	go get -u modernc.org/goyacc
 
 install: install-deps build configure-workspace ## Install CX from sources. Build dependencies
 	@echo 'NOTE:\tWe recommend you to test your CX installation by running "cx ./tests"'
-	$(GOBIN)/cx -v
+	./bin/cx -v
 
 install-full: install-deps configure-workspace
 
 install-mobile:
-	$(GO_OPTS) go get golang.org/x/mobile/gl # TODO @evanlinjin: This is a library. needed?
+	go get golang.org/x/mobile/gl # TODO @evanlinjin: This is a library. needed?
 
 clean: ## Removes binaries. 
-	rm -r $(GOBIN)/cx
+	rm -r ./bin/cx
 
 token-fuzzer:
-	$(GO_OPTS) go build -i -o $(GOBIN)/cx-token-fuzzer $(PWD)/development/token-fuzzer/main.go
+	go build $(GO_OPTS) -i -o ./bin/cx-token-fuzzer $(PWD)/development/token-fuzzer/main.go
 	chmod +x ${GOPATH}/bin/cx-token-fuzzer
 
 test: #build ## Run CX test suite.
 ifndef CXVERSION
 	@echo "cx not found in $(PWD)/bin, please run make install first"
 else	
-	$(GO_OPTS) go test -race -tags base github.com/skycoin/cx/cxgo/
-	$(GOBIN)/cx ./lib/args.cx ./tests/main.cx ++wdir=./tests ++disable-tests=gui,issue
+	go test $(GO_OPTS) -race -tags base github.com/skycoin/cx/cxgo/
+	./bin/cx ./lib/args.cx ./tests/main.cx ++wdir=./tests ++disable-tests=gui,issue
 endif
 
 test-full: build ## Run CX test suite with all build tags
-	$(GO_OPTS) go test -race -tags="base cxfx" github.com/skycoin/cx/cxgo/
-	$(GOBIN)/cx ./lib/args.cx ./tests/main.cx ++wdir=./tests ++disable-tests=gui,issue
+	go test $(GO_OPTS) -race -tags="base cxfx" github.com/skycoin/cx/cxgo/
+	./bin/cx ./lib/args.cx ./tests/main.cx ++wdir=./tests ++disable-tests=gui,issue
 
 check: test ## Perform self-tests
 
@@ -154,9 +152,9 @@ format: ## Formats the code. Must have goimports installed (use make install-lin
 	goimports -w -local github.com/skycoin/cx ./cxgo
 
 update-vendor: ## Update go vendor
-	$(GO_OPTS) go mod vendor
-	$(GO_OPTS) go mod verify
-	$(GO_OPTS) go mod tidy
+	go mod $(GO_OPTS) vendor
+	go mod $(GO_OPTS) verify
+	go mod $(GO_OPTS) tidy
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
Fixes #361

Note: Technically the `-mod=vendor` flag should not be necessary if devs use Go version of 1.14 or higher. But to be sure they build from vendor even with older Go versions, we set it explicitly in the Makefile. 

Changes:
- build from vendor folder unless explicitly set by developer to use online modules
- build into `./bin` directory
- remove the whole `./bin` directory when `make clean` is invoked

Does this change need to mentioned in CHANGELOG.md?
I dont think so. 

How to test this PR?

Run:

```
make build
```

This should work and put binaries into the `./bin` directory. 

Clean your modcache with

```
go clean -modcache
```

Replace Makefile line 66 with:

```
GO_OPTS ?= -mod=mod
```

Disconnect from all networks with Internet access.

Run:

```
make build
```

This should fail as it tries to access the network for fetching the packages. 