### PR TITLE
Update README.md for tests on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ cx-setup.bat
 Test your installation by running:
 
 ```
-cx tests\main.cx ++wdir=tests ++disable-tests=issue
+cx lib/args.cx tests/main.cx ++wdir=tests ++disable-tests=issue
 ```
 
 ## Updating CX


### PR DESCRIPTION
Corrected test install command for Windows. CONTRIBUTING.md states command for testing that works on windows. 
Windows cant find ../args when running just cx tests/main.cx, thus including lib/args.cx is necessary.

Fixes #
Fixes running cx tests on Windows. Fixes Issue- https://github.com/skycoin/cx/issues/394

Changes:
'cx lib/args.cx' needed in command with rest of 'tests/main.cx ++wdir=tests ++disable-tests=issue'

Does this change need to mentioned in CHANGELOG.md?
I think so