### PR TITLE
Update README.md for pacman commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ make test-full
 
 Compiling CX on Windows requires a recent version of Git to be installed. 
 
-Before compiling CX, install dependencies with `pacman`:
+Before compiling CX, install dependencies with `pacman` (download MSYS2):
 
 ```
 pacman -Sy
@@ -157,6 +157,8 @@ pacman -S mingw-w64-x86_64-openal
 if [ ! -a /mingw64/lib/libOpenAL32.a ]; then ln -s /mingw64/lib/libopenal.a /mingw64/lib/libOpenAL32.a; fi
 
 if [ ! -a /mingw64/lib/libOpenAL32.dll.a ]; then ln -s /mingw64/lib/libopenal.dll.a /mingw64/lib/libOpenAL32.dll.a; fi
+
+pacman -S --needed base-devel mingw-w64-x86_64-toolchain
 ```
 
 You can compile CX by running: 


### PR DESCRIPTION
To run pacman commands MSYS2 is required on Windows. Added additional command for download of -gcc compiler.

Fixes #
This fixes gl/glfw issue with cx-setup.bat - https://github.com/skycoin/cx/issues/329
https://github.com/skycoin/cx/issues/325
https://github.com/skycoin/cx/issues/330

Changes:
Added MSYS2 software requirment for Windows for 'pacman' commands.
Added pacman command for -gcc download.
Question: Should adding -gcc %PATH% be documented into .appveyor.yml with other Environment variables or mentioned in readme ?

Does this change need to mentioned in CHANGELOG.md?
Not sure