### PR TITLE
#341: Added version command to print os and arch.

### DIFF
--- a/cmd/cx/flags.go
+++ b/cmd/cx/flags.go
@@ -152,7 +152,7 @@ Notes:
 }
 
 func printVersion() {
-	fmt.Println("CX version", VERSION)
+	fmt.Printf("CX version %v %v/%v\n", VERSION, runtime.GOOS, runtime.GOARCH)
 }
 
 func checkHelp(args []string) bool {


### PR DESCRIPTION
Fixes #341

Changes:
- Added version command to print os and arch.

Does this change need to mentioned in CHANGELOG.md?
No
