### PR TITLE
Fix test and build targets in makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ matrix:
 # Install necessaries go packages
 install:
   - go get -u modernc.org/goyacc
-  - go get golang.org/x/mobile/gl 
 
 # Build, test & run cx test
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ matrix:
       dist: xenial
     - os: osx
 
-# Install necessaries go packages
-install:
-  - go get -u modernc.org/goyacc
-
 # Build, test & run cx test
 script:
   - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,13 @@ matrix:
 
 # Install necessaries go packages
 install:
-  - make install
-  - make install-gfx-deps
-  - make install-linters
+  - go get -u modernc.org/goyacc
+  - go get golang.org/x/mobile/gl 
 
 # Build, test & run cx test
 script:
-  - make build-full
-  - make test
-  - make test-full
-  - make lint
+  - make build
+  - make install
 
 # Notifications to Telegram channel
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
 script:
   - make build
   - make install
+  - make test
 
 # Notifications to Telegram channel
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ build-parser: ## Generate lexer and parser for CX grammar
 	./bin/goyacc -o cxgo/cxgo0/cxgo0.go cxgo/cxgo0/cxgo0.y
 	./bin/goyacc -o cxgo/parser/cxgo.go cxgo/parser/cxgo.y
 
-install: build configure-workspace ## Install CX from sources. Build dependencies
+install: configure-workspace ## Install CX from sources. Build dependencies
 	@echo 'NOTE:\tWe recommend you to test your CX installation by running "cx ./tests"'
 	./bin/cx -v
 

--- a/Makefile
+++ b/Makefile
@@ -65,14 +65,14 @@ ifeq ($(UNAME_S), Linux)
 endif
 
 build:  ## Build CX from sources
-	go build $(GO_OPTS) -tags="base" -o ./bin/cx github.com/skycoin/cx/cxgo/
+	go build $(GO_OPTS) -tags="base" -o ./bin/cx github.com/skycoin/cx/cmd/cx
 	chmod +x ./bin/cx
 
 clean: ## Removes binaries.
 	rm -r ./bin/cx
 
 build-full: install-full  ## Build CX from sources with all build tags
-	go build $(GO_OPTS) -tags="base cxfx" -o ./bin/cx github.com/skycoin/cx/cxgo/
+	go build $(GO_OPTS) -tags="base cxfx" -o ./bin/cx github.com/skycoin/cx/cmd/cx
 	chmod +x ./bin/cx
 
 token-fuzzer:
@@ -94,12 +94,12 @@ ifndef CXVERSION
 	@echo "cx not found in $(PWD)/bin, please run make install first"
 else
 	# go test $(GO_OPTS) -race -tags base github.com/skycoin/cx/cxgo/
-	./bin/cx ./lib/args.cx ./tests/main.cx ++wdir=./tests ++disable-tests=gui,issue
+	./bin/cx ./lib/args.cx ./tests/main.cx ++wdir=./tests ++disable-tests=gui,issue ++cxpath=$(PWD)/bin/cx
 endif
 
 test-full: build ## Run CX test suite with all build tags
 	# go test $(GO_OPTS) -race -tags="base cxfx" github.com/skycoin/cx/cxgo/
-	./bin/cx ./lib/args.cx ./tests/main.cx ++wdir=./tests ++disable-tests=gui,issue
+	./bin/cx ./lib/args.cx ./tests/main.cx ++wdir=./tests ++disable-tests=gui,issue ++cxpath=$(PWD)/bin/cx
 
 configure-workspace: ## Configure CX workspace environment
 	mkdir -p $(CX_PATH)/src $(CX_PATH)/bin $(CX_PATH)/pkg

--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,6 @@ build:  ## Build CX from sources
 clean: ## Removes binaries.
 	rm -r ./bin/cx
 
-build-full: full  ## Build CX from sources with all build tags
-	go build $(GO_OPTS) -tags="base cxfx" -o ./bin/cx github.com/skycoin/cx/cmd/cx
-	chmod +x ./bin/cx
-
 token-fuzzer:
 	go build $(GO_OPTS) -o ./bin/cx-token-fuzzer $(PWD)/development/token-fuzzer/main.go
 	chmod +x ${GOPATH}/bin/cx-token-fuzzer

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 export GO111MODULE=on
 
 .DEFAULT_GOAL := help
-.PHONY: build-parser build build-full test test-full
-.PHONY: install-deps install install-full
+.PHONY: build-parser build test
+.PHONY: install
 .PHONY: dep
 
 PWD := $(shell pwd)
@@ -71,7 +71,7 @@ build:  ## Build CX from sources
 clean: ## Removes binaries.
 	rm -r ./bin/cx
 
-build-full: install-full  ## Build CX from sources with all build tags
+build-full: full  ## Build CX from sources with all build tags
 	go build $(GO_OPTS) -tags="base cxfx" -o ./bin/cx github.com/skycoin/cx/cmd/cx
 	chmod +x ./bin/cx
 
@@ -79,15 +79,13 @@ token-fuzzer:
 	go build $(GO_OPTS) -o ./bin/cx-token-fuzzer $(PWD)/development/token-fuzzer/main.go
 	chmod +x ${GOPATH}/bin/cx-token-fuzzer
 
-build-parser: install-deps ## Generate lexer and parser for CX grammar
+build-parser: ## Generate lexer and parser for CX grammar
 	./bin/goyacc -o cxgo/cxgo0/cxgo0.go cxgo/cxgo0/cxgo0.y
 	./bin/goyacc -o cxgo/parser/cxgo.go cxgo/parser/cxgo.y
 
-install: install-deps build configure-workspace ## Install CX from sources. Build dependencies
+install: build configure-workspace ## Install CX from sources. Build dependencies
 	@echo 'NOTE:\tWe recommend you to test your CX installation by running "cx ./tests"'
 	./bin/cx -v
-
-install-full: configure-workspace
 
 test:  ## Run CX test suite.
 ifndef CXVERSION
@@ -96,10 +94,6 @@ else
 	# go test $(GO_OPTS) -race -tags base github.com/skycoin/cx/cxgo/
 	./bin/cx ./lib/args.cx ./tests/main.cx ++wdir=./tests ++disable-tests=gui,issue ++cxpath=$(PWD)/bin/cx
 endif
-
-test-full: build ## Run CX test suite with all build tags
-	# go test $(GO_OPTS) -race -tags="base cxfx" github.com/skycoin/cx/cxgo/
-	./bin/cx ./lib/args.cx ./tests/main.cx ++wdir=./tests ++disable-tests=gui,issue ++cxpath=$(PWD)/bin/cx
 
 configure-workspace: ## Configure CX workspace environment
 	mkdir -p $(CX_PATH)/src $(CX_PATH)/bin $(CX_PATH)/pkg


### PR DESCRIPTION
Changes:
- build `cmd/cx` and test with CX path specified correctly 
- remove build targets that are redundant: `make build-full` `make test-full` `make install-deps`
- make travis run build, install and test
- fix travis builds
- remove go get commands from travis as they require network access and dynamically update the vendor