### PR TITLE
Copied over and modified windows setup instructions from #425

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,18 +128,22 @@ make test
 
 Compiling CX on Windows requires a recent version of Git to be installed. 
 
-Before compiling CX, install dependencies with `pacman` (download MSYS2):
+Pacman is a utility which manages software packages.   
+
+To install pacman, download [Mysys2](https://www.msys2.org) and run the installer.
+
+When the installation is complete, click ` Run MSYS2 now `.     
+
+If MSYS2 has already been installed, run it through the start menu.
+
+You can run a full system upgrade and install required dependencies with: 
 
 ```
-pacman -Sy
-
-pacman -S mingw-w64-x86_64-openal
+pacman -Syu git mingw-w64-x86_64-openal base-devel mingw-w64-x86_64-toolchain
 
 if [ ! -a /mingw64/lib/libOpenAL32.a ]; then ln -s /mingw64/lib/libopenal.a /mingw64/lib/libOpenAL32.a; fi
 
 if [ ! -a /mingw64/lib/libOpenAL32.dll.a ]; then ln -s /mingw64/lib/libopenal.dll.a /mingw64/lib/libOpenAL32.dll.a; fi
-
-pacman -S --needed base-devel mingw-w64-x86_64-toolchain
 ```
 
 You can compile CX by running: 


### PR DESCRIPTION
Fixes #329 

Changes:
- copied over changes from #425 and cleaned them up a bit.
- moved all install steps into one `pacman` command
