### PR TITLE
Fix cxfx callbacks.

### DIFF
--- a/cxfx/event.go
+++ b/cxfx/event.go
@@ -79,7 +79,9 @@ func (cb *CXCallback) InitEx(prgrm *CXProgram) {
 }
 
 func (cb *CXCallback) Call(inputs [][]byte) {
-	cb.prgrm.Callback(cb.expr.Operator, inputs)
+	if fn, err := cb.prgrm.GetFunction(cb.functionName, cb.packageName); err == nil {
+		cb.prgrm.Callback(fn, inputs)
+	}
 }
 
 var appKeyboardCallback CXCallback

--- a/cxfx/utils.go
+++ b/cxfx/utils.go
@@ -16,19 +16,19 @@ func opGlfwFuncI32I32(prgrm *CXProgram) {
 	expr := prgrm.GetExpr()
 	fp := prgrm.GetFramePointer()
 
-	// inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
-	out1 := expr.Outputs[0]
-	// packageName := ReadStr(fp, inp1)
-	// functionName := ReadStr(fp, inp2)
+	packageName := ReadStr(fp, expr.Inputs[0])
+	functionName := ReadStr(fp, expr.Inputs[1])
 	callback := func(a int32, b int32) {
 		var inps [][]byte = make([][]byte, 2)
 		inps[0] = FromI32(a)
 		inps[1] = FromI32(b)
-		PROGRAM.Callback(expr.Operator, inps)
+		if fn, err := prgrm.GetFunction(functionName, packageName); err == nil {
+			PROGRAM.Callback(fn, inps)
+		}
 	}
 
 	Functions_i32_i32 = append(Functions_i32_i32, callback)
-	WriteI32(GetFinalOffset(fp, out1), int32(len(Functions_i32_i32)-1))
+	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(len(Functions_i32_i32)-1))
 }
 
 func opGlfwCallI32I32(prgrm *CXProgram) {


### PR DESCRIPTION
Fixes cxfx callbacks used in opengl games and tutorials.

Changes:
- CXFunction argument of the callback function is now retreived correctly.

- Regression started at this commit https://github.com/skycoin/cx/commit/f8d4510c68f2c26721b9bb234fb121c10087b814.