### PR TITLE
Updated cx-setup.bat for OpenGL support

### DIFF
--- a/cx-setup.bat
+++ b/cx-setup.bat
@@ -108,7 +108,7 @@ if %ERRORLEVEL% neq 0 (
 
 
 rem run CX tests
-%BIN_PATH%\cx.exe cx %SKYCOIN_PATH%\cx\lib\args.cx %SKYCOIN_PATH%\cx\tests\main.cx ++wdir=tests\ ++disable-tests=gui,issue
+%BIN_PATH%\cx.exe %SKYCOIN_PATH%\cx\lib\args.cx %SKYCOIN_PATH%\cx\tests\main.cx ++wdir=tests\ ++disable-tests=gui,issue
 call :showResults cx\tests "Tested" "ERROR while testing"
 
 call :echoWithColor yellow "You can re-run CX tests with:"
@@ -235,7 +235,7 @@ exit /b
   call :showResults "goyacc cxgo" "2nd pass -" "ERROR in 2nd pass -"
 
 
-  go build -tags="base opengl" -i -o %BIN_PATH%/cx.exe github.com/skycoin/cx/cmd/cx
+  go build -tags="base cxfx" -i -o %BIN_PATH%\cx.exe github.com\skycoin\cx\cmd\cx
   call :showResults skycoin\CX\CMD\CX "            Built CX.EXE from:" "ERROR building CX.EXE from:"
 exit /b
 


### PR DESCRIPTION
Removed unnecessary cx from `test` command
Changed `go build` command, so cx can be compiled in OpenGL

Fixes #
https://github.com/skycoin/cx/issues/426
https://github.com/skycoin/cx/issues/328

Changes:
Changed `-go build -tags` command 

Does this change need to mentioned in CHANGELOG.md?
