### PR TITLE
#341: Added support for 'cx version' command.

### DIFF
--- a/cmd/cx/flags.go
+++ b/cmd/cx/flags.go
@@ -77,10 +77,22 @@ func defaultCmdFlags() cxCmdFlags {
 
 var commandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
+func appendDash(args []string) {
+
+	for k, v := range args {
+		switch v {
+		case "version":
+			args[k] = "-version"
+		}
+	}
+}
+
 func parseFlags(options *cxCmdFlags, args []string) {
 	if len(args) <= 0 {
 		options.replMode = true
 	}
+
+	appendDash(args)
 
 	commandLine.BoolVar(&options.printVersion, "version", options.printVersion, "Print CX version")
 	commandLine.BoolVar(&options.printVersion, "v", options.printVersion, "alias for -version")


### PR DESCRIPTION
Fixes #
issue 341. 

Changes:
Added code to append a dash to 'version' argument passed as command line to support the 'cx version' command. Previously only 'cx -version' or 'cx --version' worked.

Does this change need to mentioned in CHANGELOG.md?
