### PR TITLE
#445 add template for new cx playground

### DIFF
--- a/cmd/cxplayground/README.md
+++ b/cmd/cxplayground/README.md
@@ -11,3 +11,18 @@ Starting web service for CX playground on http://127.0.0.1:5336/
 ```
 curl -H "Content-Type: application/json" -X POST -d '{"code": "package main; func main() {str.print(\"Hello, world!\");}"}' http://localhost:5336/eval
 ```
+
+- Get playgournd page
+```
+curl -H "Content-Type: application/json" -X GET http://localhost:5336/playground
+```
+
+- Get example file list
+```
+curl -H "Content-Type: application/json" -X GET http://localhost:5336/playground/examples
+```
+
+- Get example file content
+```
+curl -H "Content-Type: application/json" -X POST  -d '{"examplename": "example1.cx"}' http://localhost:5336/playground/examples/code
+```

--- a/cmd/cxplayground/examples/example1.cx
+++ b/cmd/cxplayground/examples/example1.cx
@@ -1,0 +1,5 @@
+package main; 
+
+func main() {
+	str.print("Hello, world example1!");
+}

--- a/cmd/cxplayground/examples/example2.cx
+++ b/cmd/cxplayground/examples/example2.cx
@@ -1,0 +1,5 @@
+package main; 
+
+func main() {
+	str.print("Hello, world example2!");
+}

--- a/cmd/cxplayground/main.go
+++ b/cmd/cxplayground/main.go
@@ -19,6 +19,8 @@ import (
 	"github.com/skycoin/cx/cxgo/cxgo"
 	"github.com/skycoin/cx/cxgo/cxgo0"
 	"github.com/skycoin/cx/cxgo/parser"
+
+	"github.com/skycoin/cx/cmd/cxplayground/playground"
 )
 
 type SourceCode struct {
@@ -29,6 +31,16 @@ func main() {
 	host := ":5336"
 
 	mux := http.NewServeMux()
+
+	workingDir, _ := os.Getwd()
+	if err := playground.InitPlayground(workingDir); err != nil {
+		// error captured while initiating the playground examples, should be handled in the future
+		fmt.Println("Fail to initiating palyground examples")
+	}
+
+	mux.HandleFunc("/playground", playground.GetPlayground)
+	mux.HandleFunc("/playground/examples", playground.GetExampleFileList)
+	mux.HandleFunc("/playground/examples/code", playground.GetExampleFileContent)
 
 	mux.Handle("/", http.FileServer(http.Dir("./dist")))
 	mux.Handle("/program/", api.NewAPI("/program", actions.PRGRM))

--- a/cmd/cxplayground/playground/playground.go
+++ b/cmd/cxplayground/playground/playground.go
@@ -1,0 +1,179 @@
+package playground
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+)
+
+var exampleCollection map[string]string
+var exampleNames []string
+var examplesDir string
+
+type ExampleContent struct {
+	ExampleName string
+}
+
+func InitPlayground(workingDir string) error {
+	examplesDir = filepath.Join(workingDir, "examples")
+	exampleCollection = make(map[string]string)
+
+	exampleInfoList, err := ioutil.ReadDir(examplesDir)
+	if err != nil {
+		fmt.Printf("Fail to get file list under examples dir: %s\n", err.Error())
+		return err
+	}
+
+	for _, exp := range exampleInfoList {
+		if exp.IsDir() {
+			continue
+		}
+		path := filepath.Join(examplesDir, exp.Name())
+
+		bytes, err := ioutil.ReadFile(path)
+		if err != nil {
+			fmt.Printf("Fail to read example file %s\n", path)
+			// coninue if fail to read the current example file
+			continue
+		}
+
+		exampleName := exp.Name()
+		exampleNames = append(exampleNames, exampleName)
+		exampleCollection[exampleName] = string(bytes)
+	}
+
+	return nil
+}
+
+func GetPlayground(w http.ResponseWriter, r *http.Request) {
+	playgroundHtml := `<html>
+
+<head>
+    <title>test</title>
+    <script src="https://libs.baidu.com/jquery/1.7.2/jquery.min.js"></script>
+</head>
+<script>
+    // var url = "http://localhost:5336/"
+    $().ready(function () {
+        $.getJSON("playground/examples", function (inputData) {
+            $.each(inputData, function (i) {
+                $("#list").append("<option value='" + i + "'>" + inputData[i] + "</option>");
+            });
+        });
+        $("#list").bind("change", function () {
+            var data = { "examplename": $("#list").find("option:selected").text() };
+            $.ajax({
+                type: "POST",
+                url: "/playground/examples/code",
+                contentType: "application/json;charset=utf-8",
+                data: JSON.stringify(data),
+                cache: false,
+                success: function (message) {
+                    $("#inputData").html(message);
+
+                },
+                error: function (message) {
+                    $("#inputData").html(message);
+                }
+            });
+        });
+        $("#run").click(function () {
+            var data = { "code": $("#inputData").text() };
+            $.ajax({
+                type: "POST",
+                url: "/eval",
+                contentType: "application/json;charset=utf-8",
+                data: JSON.stringify(data),
+                cache: false,
+                success: function (message) {
+                    $("#result").text(function (i, origText) {
+                        return message;
+                    });
+                },
+                error: function (message) {
+                    $("#result").text(function (i, origText) {
+                        return message;
+                    });
+                }
+            });
+        });
+    });
+
+</script>
+
+<body>
+    <div style="text-align:center;">
+        <div id="banner">
+            <div id="head" itemprop="name">Playground</div>
+            <select id="list">
+                <option value="hello">Hello, World</option>
+            </select>
+            <input type="button" value="Run" id="run">
+        </div>
+        <div>
+            <textarea id="inputData" rows="20" cols="80">
+package main;
+
+func main(){
+    str.print("Hello, world!")
+}
+</textarea>
+            <p>result:</p>
+            <p id="result"></p>
+        </div>
+    </div>
+</body>
+
+</html>`
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	fmt.Fprintf(w, playgroundHtml)
+
+}
+
+func GetExampleFileList(w http.ResponseWriter, r *http.Request) {
+	exampleNamesBytes, err := json.Marshal(exampleNames)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+
+	fmt.Fprintf(w, string(exampleNamesBytes))
+}
+
+func GetExampleFileContent(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	var b []byte
+	var err error
+	if b, err = ioutil.ReadAll(r.Body); err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+
+	var example ExampleContent
+	if err := json.Unmarshal(b, &example); err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+
+	content, err := getExampleFileContent(example.ExampleName)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+
+	fmt.Fprintf(w, content)
+}
+
+func getExampleFileContent(exampleName string) (string, error) {
+	exampleContent, ok := exampleCollection[exampleName]
+	if !ok {
+		err := fmt.Errorf("example name %s not found", exampleName)
+
+		return "", err
+	}
+	return exampleContent, nil
+}


### PR DESCRIPTION
Fixes #445 

Changes:

- developing 3 http api for requesting playground page and querying backend example code. 
- writing a html template to interact with backend server
