### PR TITLE
Fix build-full and add documentation to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export GO111MODULE=on
 
 .DEFAULT_GOAL := help
-.PHONY: build-parser build test
+.PHONY: build-parser build test build-full
 .PHONY: install
 .PHONY: dep
 
@@ -68,16 +68,20 @@ build:  ## Build CX from sources
 	go build $(GO_OPTS) -tags="base" -o ./bin/cx github.com/skycoin/cx/cmd/cx
 	chmod +x ./bin/cx
 
+build-full: ## Build CX with CXFX support. Done via satisfying 'cxfx' build tag.
+	$(GO_OPTS) go build -tags="base cxfx" -o ./bin/cx github.com/skycoin/cx/cmd/cx
+	chmod +x ./bin/cx
+
+build-parser: ## Generate lexer and parser for CX grammar
+	./bin/goyacc -o cxgo/cxgo0/cxgo0.go cxgo/cxgo0/cxgo0.y
+	./bin/goyacc -o cxgo/parser/cxgo.go cxgo/parser/cxgo.y
+
 clean: ## Removes binaries.
 	rm -r ./bin/cx
 
 token-fuzzer:
 	go build $(GO_OPTS) -o ./bin/cx-token-fuzzer $(PWD)/development/token-fuzzer/main.go
 	chmod +x ./bin/cx-token-fuzzer
-
-build-parser: ## Generate lexer and parser for CX grammar
-	./bin/goyacc -o cxgo/cxgo0/cxgo0.go cxgo/cxgo0/cxgo0.y
-	./bin/goyacc -o cxgo/parser/cxgo.go cxgo/parser/cxgo.y
 
 install: configure-workspace ## Install CX from sources. Build dependencies
 	@echo 'NOTE:\tWe recommend you to test your CX installation by running "cx ./tests"'


### PR DESCRIPTION
Changes:
- add back in `make build-full` that builds with `cxfx` support and add a brief documentation of behavior

