### PR TITLE
Remove osx build from matrix for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
   include:
     - os: linux
       dist: xenial
-    - os: osx
 
 # Build, test & run cx test
 script:


### PR DESCRIPTION
Changes:
- remove osx builds from Travis Matrix

