### PR TITLE
Build cxfx library by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - GOARCH=amd64
 
 before_install:
-  - sudp apt-get update 
+  - sudo apt-get update 
   - sudo apt-get -y lade xvfb libxinerama-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev libxi-dev libperl-dev libcairo2-dev libpango1.0-dev libglib2.0-dev libopenal-dev libxxf86vm-dev make
 
 # Use a matrix to define SO and possible future changes

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 
 before_install:
   - sudo apt-get update 
-  - sudo apt-get -y install lade xvfb libxinerama-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev libxi-dev libperl-dev libcairo2-dev libpango1.0-dev libglib2.0-dev libopenal-dev libxxf86vm-dev make
+  - sudo apt-get -y install glade xvfb libxinerama-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev libxi-dev libperl-dev libcairo2-dev libpango1.0-dev libglib2.0-dev libopenal-dev libxxf86vm-dev make
 
 # Use a matrix to define SO and possible future changes
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,23 @@ go:
 env:
   - GOARCH=amd64
 
-before_install:
-  - sudo apt-get update 
-  - sudo apt-get -y install glade xvfb libxinerama-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev libxi-dev libperl-dev libcairo2-dev libpango1.0-dev libglib2.0-dev libopenal-dev libxxf86vm-dev make
+addons:
+  apt:
+    packages:
+    - make
+    - glade
+    - xvfb
+    - libxinerama-dev 
+    - libxcursor-dev
+    - libxrandr-dev
+    - libgl1-mesa-dev
+    - libxi-dev
+    - libperl-dev
+    - libcairo2-dev
+    - libpango1.0-dev
+    - libglib2.0-dev
+    - libopenal-dev
+    - libxxf86vm-dev
 
 # Use a matrix to define SO and possible future changes
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 
 before_install:
   - sudo apt-get update 
-  - sudo apt-get -y lade xvfb libxinerama-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev libxi-dev libperl-dev libcairo2-dev libpango1.0-dev libglib2.0-dev libopenal-dev libxxf86vm-dev make
+  - sudo apt-get -y install lade xvfb libxinerama-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev libxi-dev libperl-dev libcairo2-dev libpango1.0-dev libglib2.0-dev libopenal-dev libxxf86vm-dev make
 
 # Use a matrix to define SO and possible future changes
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ go:
 env:
   - GOARCH=amd64
 
+before_install:
+  - sudp apt-get update 
+  - sudo apt-get -y lade xvfb libxinerama-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev libxi-dev libperl-dev libcairo2-dev libpango1.0-dev libglib2.0-dev libopenal-dev libxxf86vm-dev make
+
 # Use a matrix to define SO and possible future changes
 matrix:
   include:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export GO111MODULE=on
 
 .DEFAULT_GOAL := help
-.PHONY: build-parser build test build-full
+.PHONY: build-parser build test build-core
 .PHONY: install
 .PHONY: dep
 
@@ -65,11 +65,11 @@ ifeq ($(UNAME_S), Linux)
 endif
 
 build:  ## Build CX from sources
-	go build $(GO_OPTS) -tags="base" -o ./bin/cx github.com/skycoin/cx/cmd/cx
+	$(GO_OPTS) go build -tags="base cxfx" -o ./bin/cx github.com/skycoin/cx/cmd/cx
 	chmod +x ./bin/cx
 
-build-full: ## Build CX with CXFX support. Done via satisfying 'cxfx' build tag.
-	$(GO_OPTS) go build -tags="base cxfx" -o ./bin/cx github.com/skycoin/cx/cmd/cx
+build-core: ## Build CX with CXFX support. Done via satisfying 'cxfx' build tag.
+	$(GO_OPTS) go build -tags="base" -o ./bin/cx github.com/skycoin/cx/cmd/cx
 	chmod +x ./bin/cx
 
 build-parser: ## Generate lexer and parser for CX grammar

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ You can find binary releases for most major systems on the [release page](https:
 If you are using a `apt` compatible system, install the dependencies with"
 
 ```
-sudo apt-get update -qq
+sudo apt-get update
 
-sudo apt-get install -y glade xvfb libxinerama-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev libxi-dev libperl-dev libcairo2-dev libpango1.0-dev libglib2.0-dev libopenal-dev libxxf86vm-dev make --no-install-recommends
+sudo apt-get install -y glade xvfb libxinerama-dev libxcursor-dev libxrandr-dev libgl1-mesa-dev libxi-dev libperl-dev libcairo2-dev libpango1.0-dev libglib2.0-dev libopenal-dev libxxf86vm-dev make
 ```
 
 If you have not setup Golang on your machine, follow this [guide](https://www.tecmint.com/install-go-in-ubuntu/) to install and setup Go. 


### PR DESCRIPTION
Fixes #433 

Changes:
- `make build` now compiles CX with `cxfx` (graphics and audio library). `make build-core` was added as a Makefile target to only build cx base.
