### PR TITLE
Refactor opcodes.

### DIFF
--- a/cx/base/op_cipher.go
+++ b/cx/base/op_cipher.go
@@ -37,9 +37,7 @@ func init() {
 }
 
 // opCipherGenerateKeyPair generates a PubKey and a SecKey.
-func opCipherGenerateKeyPair(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
+func opCipherGenerateKeyPair(expr *CXExpression, fp int) {
 	out1, out2 := expr.Outputs[0], expr.Outputs[1]
 
 	pubKey, secKey := cipher.GenerateKeyPair()

--- a/cx/base/op_json.go
+++ b/cx/base/op_json.go
@@ -42,10 +42,7 @@ var jsons []JSONFile
 var freeJsons []int32
 
 // Open the named json file for reading, returns an i32 identifying the json parser.
-func opJsonOpen(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opJsonOpen(expr *CXExpression, fp int) {
 	handle := int32(-1)
 
 	file, err := CXOpenFile(ReadStr(fp, expr.Inputs[0]))
@@ -77,10 +74,7 @@ func opJsonOpen(prgrm *CXProgram) {
 }
 
 // Close json parser (and all underlying resources) idendified by it's i32 handle.
-func opJsonClose(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opJsonClose(expr *CXExpression, fp int) {
 	success := false
 
 	handle := ReadI32(fp, expr.Inputs[0])
@@ -98,10 +92,7 @@ func opJsonClose(prgrm *CXProgram) {
 }
 
 // More return true if there is another element in the current array or object being parsed.
-func opJsonTokenMore(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opJsonTokenMore(expr *CXExpression, fp int) {
 	more := false
 	success := false
 
@@ -115,10 +106,7 @@ func opJsonTokenMore(prgrm *CXProgram) {
 }
 
 // Token parses the next token.
-func opJsonTokenNext(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opJsonTokenNext(expr *CXExpression, fp int) {
 	tokenType := int32(JSON_TOKEN_INVALID)
 	success := false
 
@@ -165,10 +153,7 @@ func opJsonTokenNext(prgrm *CXProgram) {
 }
 
 // Type returns the type of the current token.
-func opJsonTokenType(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opJsonTokenType(expr *CXExpression, fp int) {
 	tokenType := int32(JSON_TOKEN_INVALID)
 	success := false
 
@@ -182,10 +167,7 @@ func opJsonTokenType(prgrm *CXProgram) {
 }
 
 // Delim returns current token as an int32 delimiter.
-func opJsonTokenDelim(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opJsonTokenDelim(expr *CXExpression, fp int) {
 	tokenDelim := int32(JSON_TOKEN_INVALID)
 	success := false
 
@@ -201,10 +183,7 @@ func opJsonTokenDelim(prgrm *CXProgram) {
 }
 
 // Bool returns current token as a bool value.
-func opJsonTokenBool(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opJsonTokenBool(expr *CXExpression, fp int) {
 	tokenBool := false
 	success := false
 
@@ -220,10 +199,7 @@ func opJsonTokenBool(prgrm *CXProgram) {
 }
 
 // Float64 returns current token as float64 value.
-func opJsonTokenF64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opJsonTokenF64(expr *CXExpression, fp int) {
 	var tokenF64 float64
 	success := false
 
@@ -244,10 +220,7 @@ func opJsonTokenF64(prgrm *CXProgram) {
 }
 
 // Int64 returns current token as int64 value.
-func opJsonTokenI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opJsonTokenI64(expr *CXExpression, fp int) {
 	var tokenI64 int64
 	success := false
 
@@ -265,10 +238,7 @@ func opJsonTokenI64(prgrm *CXProgram) {
 }
 
 // Str returns current token as string value.
-func opJsonTokenStr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opJsonTokenStr(expr *CXExpression, fp int) {
 	var tokenStr string
 	success := false
 

--- a/cx/base/op_os.go
+++ b/cx/base/op_os.go
@@ -41,17 +41,11 @@ func ValidFile(handle int32) *os.File {
 	return nil
 }
 
-func opOsLogFile(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsLogFile(expr *CXExpression, fp int) {
 	CXLogFile(ReadBool(fp, expr.Inputs[0]))
 }
 
-func opOsReadAllText(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadAllText(expr *CXExpression, fp int) {
 	success := false
 
 	if byts, err := CXReadFile(ReadStr(fp, expr.Inputs[0])); err == nil {
@@ -82,10 +76,7 @@ func getFileHandle(file *os.File) int32 {
 	return handle
 }
 
-func opOsOpen(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsOpen(expr *CXExpression, fp int) {
 	handle := int32(-1)
 	if file, err := CXOpenFile(ReadStr(fp, expr.Inputs[0])); err == nil {
 		handle = getFileHandle(file)
@@ -94,10 +85,7 @@ func opOsOpen(prgrm *CXProgram) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(handle))
 }
 
-func opOsCreate(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsCreate(expr *CXExpression, fp int) {
 	handle := int32(-1)
 	if file, err := CXCreateFile(ReadStr(fp, expr.Inputs[0])); err == nil {
 		handle = getFileHandle(file)
@@ -106,10 +94,7 @@ func opOsCreate(prgrm *CXProgram) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(handle))
 }
 
-func opOsClose(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsClose(expr *CXExpression, fp int) {
 	success := false
 
 	handle := ReadI32(fp, expr.Inputs[0])
@@ -125,10 +110,7 @@ func opOsClose(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsSeek(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsSeek(expr *CXExpression, fp int) {
 	offset := int64(-1)
 	if file := validFileFromExpr(expr, fp); file != nil {
 		var err error
@@ -139,10 +121,7 @@ func opOsSeek(prgrm *CXProgram) {
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), offset)
 }
 
-func opOsReadStr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadStr(expr *CXExpression, fp int) {
 	var len uint64
 	var value string
 	success := false
@@ -159,10 +138,7 @@ func opOsReadStr(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadF64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadF64(expr *CXExpression, fp int) {
 	var value float64
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
@@ -175,10 +151,7 @@ func opOsReadF64(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadF32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadF32(expr *CXExpression, fp int) {
 	var value float32
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
@@ -191,10 +164,7 @@ func opOsReadF32(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadUI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadUI64(expr *CXExpression, fp int) {
 	var value uint64
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
@@ -207,10 +177,7 @@ func opOsReadUI64(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadUI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadUI32(expr *CXExpression, fp int) {
 	var value uint32
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
@@ -223,10 +190,7 @@ func opOsReadUI32(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadUI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadUI16(expr *CXExpression, fp int) {
 	var value uint16
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
@@ -239,10 +203,7 @@ func opOsReadUI16(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadUI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadUI8(expr *CXExpression, fp int) {
 	var value uint8
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
@@ -255,10 +216,7 @@ func opOsReadUI8(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadI64(expr *CXExpression, fp int) {
 	var value int64
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
@@ -271,10 +229,7 @@ func opOsReadI64(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadI32(expr *CXExpression, fp int) {
 	var value int32
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
@@ -287,10 +242,7 @@ func opOsReadI32(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadI16(expr *CXExpression, fp int) {
 	var value int16
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
@@ -303,10 +255,7 @@ func opOsReadI16(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadI8(expr *CXExpression, fp int) {
 	var value int8
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
@@ -319,10 +268,7 @@ func opOsReadI8(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadBOOL(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadBOOL(expr *CXExpression, fp int) {
 	var value bool
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
@@ -335,10 +281,7 @@ func opOsReadBOOL(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsWriteStr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteStr(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		value := ReadStr(fp, expr.Inputs[1])
@@ -353,10 +296,7 @@ func opOsWriteStr(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteF64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteF64(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, ReadF64(fp, expr.Inputs[1])); err == nil {
@@ -367,10 +307,7 @@ func opOsWriteF64(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteF32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteF32(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, ReadF32(fp, expr.Inputs[1])); err == nil {
@@ -381,10 +318,7 @@ func opOsWriteF32(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteUI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteUI64(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, ReadUI64(fp, expr.Inputs[1])); err == nil {
@@ -395,10 +329,7 @@ func opOsWriteUI64(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteUI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteUI32(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, ReadUI32(fp, expr.Inputs[1])); err == nil {
@@ -409,10 +340,7 @@ func opOsWriteUI32(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteUI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteUI16(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, ReadUI16(fp, expr.Inputs[1])); err == nil {
@@ -423,10 +351,7 @@ func opOsWriteUI16(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteUI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteUI8(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, ReadUI8(fp, expr.Inputs[1])); err == nil {
@@ -437,10 +362,7 @@ func opOsWriteUI8(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteI64(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, ReadI64(fp, expr.Inputs[1])); err == nil {
@@ -451,10 +373,7 @@ func opOsWriteI64(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteI32(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, ReadI32(fp, expr.Inputs[1])); err == nil {
@@ -465,10 +384,7 @@ func opOsWriteI32(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteI16(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, ReadI16(fp, expr.Inputs[1])); err == nil {
@@ -479,10 +395,7 @@ func opOsWriteI16(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteI8(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, ReadI8(fp, expr.Inputs[1])); err == nil {
@@ -493,10 +406,7 @@ func opOsWriteI8(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteBOOL(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteBOOL(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, ReadBool(fp, expr.Inputs[1])); err == nil {
@@ -519,10 +429,7 @@ func getSlice(expr *CXExpression, fp int) (outputSlicePointer int, outputSliceOf
 	return
 }
 
-func opOsReadF64Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadF64Slice(expr *CXExpression, fp int) {
 	success := false
 	outputSlicePointer, outputSliceOffset, sizeofElement, count := getSlice(expr, fp)
 	if count > 0 {
@@ -542,10 +449,7 @@ func opOsReadF64Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadF32Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadF32Slice(expr *CXExpression, fp int) {
 	success := false
 	outputSlicePointer, outputSliceOffset, sizeofElement, count := getSlice(expr, fp)
 	if count > 0 {
@@ -565,10 +469,7 @@ func opOsReadF32Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadUI64Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadUI64Slice(expr *CXExpression, fp int) {
 	success := false
 	outputSlicePointer, outputSliceOffset, sizeofElement, count := getSlice(expr, fp)
 	if count > 0 {
@@ -588,10 +489,7 @@ func opOsReadUI64Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadUI32Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadUI32Slice(expr *CXExpression, fp int) {
 	success := false
 	outputSlicePointer, outputSliceOffset, sizeofElement, count := getSlice(expr, fp)
 	if count > 0 {
@@ -611,10 +509,7 @@ func opOsReadUI32Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadUI16Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadUI16Slice(expr *CXExpression, fp int) {
 	success := false
 	outputSlicePointer, outputSliceOffset, sizeofElement, count := getSlice(expr, fp)
 	if count > 0 {
@@ -634,10 +529,7 @@ func opOsReadUI16Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadUI8Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadUI8Slice(expr *CXExpression, fp int) {
 	success := false
 	outputSlicePointer, outputSliceOffset, sizeofElement, count := getSlice(expr, fp)
 	if count > 0 {
@@ -657,10 +549,7 @@ func opOsReadUI8Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadI64Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadI64Slice(expr *CXExpression, fp int) {
 	success := false
 	outputSlicePointer, outputSliceOffset, sizeofElement, count := getSlice(expr, fp)
 	if count > 0 {
@@ -680,10 +569,7 @@ func opOsReadI64Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadI32Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadI32Slice(expr *CXExpression, fp int) {
 	success := false
 	outputSlicePointer, outputSliceOffset, sizeofElement, count := getSlice(expr, fp)
 	if count > 0 {
@@ -703,10 +589,7 @@ func opOsReadI32Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadI16Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadI16Slice(expr *CXExpression, fp int) {
 	success := false
 	outputSlicePointer, outputSliceOffset, sizeofElement, count := getSlice(expr, fp)
 	if count > 0 {
@@ -726,10 +609,7 @@ func opOsReadI16Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsReadI8Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsReadI8Slice(expr *CXExpression, fp int) {
 	success := false
 	outputSlicePointer, outputSliceOffset, sizeofElement, count := getSlice(expr, fp)
 	if count > 0 {
@@ -749,10 +629,7 @@ func opOsReadI8Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[1]), success)
 }
 
-func opOsWriteF64Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteF64Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if data := ReadData(fp, expr.Inputs[1], TYPE_F64); data != nil {
@@ -764,10 +641,7 @@ func opOsWriteF64Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteF32Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteF32Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if data := ReadData(fp, expr.Inputs[1], TYPE_F32); data != nil {
@@ -779,10 +653,7 @@ func opOsWriteF32Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteUI64Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteUI64Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if data := ReadData(fp, expr.Inputs[1], TYPE_UI64); data != nil {
@@ -794,10 +665,7 @@ func opOsWriteUI64Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteUI32Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteUI32Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if data := ReadData(fp, expr.Inputs[1], TYPE_UI32); data != nil {
@@ -809,10 +677,7 @@ func opOsWriteUI32Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteUI16Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteUI16Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if data := ReadData(fp, expr.Inputs[1], TYPE_UI16); data != nil {
@@ -824,10 +689,7 @@ func opOsWriteUI16Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteUI8Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteUI8Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if data := ReadData(fp, expr.Inputs[1], TYPE_UI8); data != nil {
@@ -839,10 +701,7 @@ func opOsWriteUI8Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteI64Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteI64Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if data := ReadData(fp, expr.Inputs[1], TYPE_I64); data != nil {
@@ -854,10 +713,7 @@ func opOsWriteI64Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteI32Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteI32Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if data := ReadData(fp, expr.Inputs[1], TYPE_I32); data != nil {
@@ -869,10 +725,7 @@ func opOsWriteI32Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteI16Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteI16Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if data := ReadData(fp, expr.Inputs[1], TYPE_I16); data != nil {
@@ -884,10 +737,7 @@ func opOsWriteI16Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsWriteI8Slice(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsWriteI8Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
 		if data := ReadData(fp, expr.Inputs[1], TYPE_I8); data != nil {
@@ -899,26 +749,17 @@ func opOsWriteI8Slice(prgrm *CXProgram) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), success)
 }
 
-func opOsGetWorkingDirectory(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsGetWorkingDirectory(expr *CXExpression, fp int) {
 	byts := encoder.Serialize(PROGRAM.Path)
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), byts)
 }
 
-func opOsExit(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsExit(expr *CXExpression, fp int) {
 	exitCode := ReadI32(fp, expr.Inputs[0])
 	os.Exit(int(exitCode))
 }
 
-func opOsRun(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opOsRun(expr *CXExpression, fp int) {
 	var runError int32 = OS_RUN_SUCCESS
 
 	command := ReadStr(fp, expr.Inputs[0])

--- a/cx/base/op_profile.go
+++ b/cx/base/op_profile.go
@@ -34,18 +34,12 @@ func stopCPUProfile(f *os.File) {
 	defer pprof.StopCPUProfile()
 }
 
-func opStartProfile(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStartProfile(expr *CXExpression, fp int) {
 	profilePath := ReadStr(fp, expr.Inputs[0])
 	openProfiles[profilePath] = startCPUProfile(profilePath, int(ReadI32(fp, expr.Inputs[1])))
 }
 
-func opStopProfile(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStopProfile(expr *CXExpression, fp int) {
 	profilePath := ReadStr(fp, expr.Inputs[0])
 	stopCPUProfile(openProfiles[profilePath])
 }

--- a/cx/base/op_regexp.go
+++ b/cx/base/op_regexp.go
@@ -26,9 +26,7 @@ func init() {
 // regexpCompile is a helper function for `opRegexpMustCompile` and
 // `opRegexpCompile`. `regexpCompile` compiles a `regexp.Regexp` structure
 // and adds it to global `regexps`. It also writes CX structure `regexp.Regexp`.
-func regexpCompile(prgrm *cxcore.CXProgram) error {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
+func regexpCompile(expr *cxcore.CXExpression, fp int) error {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 
 	// Extracting regular expression to work with, contained in `inp1`.
@@ -76,8 +74,8 @@ func regexpCompile(prgrm *cxcore.CXProgram) error {
 }
 
 // opRegexpMustCompile is a wrapper for golang's `regexp`'s `MustCompile`.
-func opRegexpMustCompile(prgrm *cxcore.CXProgram) {
-	err := regexpCompile(prgrm)
+func opRegexpMustCompile(expr *cxcore.CXExpression, fp int) {
+	err := regexpCompile(expr, fp)
 
 	if err != nil {
 		println(err.Error())
@@ -87,14 +85,12 @@ func opRegexpMustCompile(prgrm *cxcore.CXProgram) {
 }
 
 // opRegexpCompile is a wrapper for golang's `regexp`'s `MustCompile`.
-func opRegexpCompile(prgrm *cxcore.CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
+func opRegexpCompile(expr *cxcore.CXExpression, fp int) {
 	// We're only interested in `out2`, which represents the
 	// returned error.
 	out2 := expr.Outputs[1]
 
-	err := regexpCompile(prgrm)
+	err := regexpCompile(expr, fp)
 
 	// Writing error message to `out2`.
 	if err != nil {
@@ -103,9 +99,7 @@ func opRegexpCompile(prgrm *cxcore.CXProgram) {
 }
 
 // opRegexpCompile is a wrapper for golang's `regexp`'s `MustCompile`.
-func opRegexpFind(prgrm *cxcore.CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
+func opRegexpFind(expr *cxcore.CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 
 	// Output structure `Regexp`.

--- a/cx/base/op_time.go
+++ b/cx/base/op_time.go
@@ -12,23 +12,14 @@ func makeTimestamp() int64 {
 	return time.Now().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
 }
 
-func opTimeUnixMilli(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opTimeUnixMilli(expr *CXExpression, fp int) {
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), makeTimestamp())
 }
 
-func opTimeUnixNano(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opTimeUnixNano(expr *CXExpression, fp int) {
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), time.Now().UnixNano())
 }
 
-func opTimeSleep(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opTimeSleep(expr *CXExpression, fp int) {
 	time.Sleep(time.Duration(ReadI32(fp, expr.Inputs[0])) * time.Millisecond)
 }

--- a/cx/execute.go
+++ b/cx/execute.go
@@ -306,6 +306,7 @@ func (call *CXCall) ccall(prgrm *CXProgram) error {
 		*/
 		fn := call.Operator
 		expr := fn.Expressions[call.Line]
+
 		// if it's a native, then we just process the arguments with execNative
 
 		if expr.Operator == nil {
@@ -319,7 +320,7 @@ func (call *CXCall) ccall(prgrm *CXProgram) error {
 			}
 			call.Line++
 		} else if expr.Operator.IsNative {
-			execNative(prgrm)
+		        opcodeHandlers[expr.Operator.OpCode](expr, call.FramePointer)
 			call.Line++
 		} else {
 			/*

--- a/cx/op_aff.go
+++ b/cx/op_aff.go
@@ -50,10 +50,7 @@ func GetInferActions(inp *CXArgument, fp int) []string {
 	return result
 }
 
-func opAffPrint(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAffPrint(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	fmt.Println(GetInferActions(inp1, fp))
 	// for _, aff := range GetInferActions(inp1, fp) {
@@ -608,10 +605,7 @@ func getAffordances(inp1 *CXArgument, fp int,
 	}
 }
 
-func opAffOn(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAffOn(expr *CXExpression, fp int) {
 	inp1, inp2 := expr.Inputs[0], expr.Inputs[1]
 
 	prevPkg := PROGRAM.CurrentPackage
@@ -647,10 +641,7 @@ func opAffOn(prgrm *CXProgram) {
 	}
 }
 
-func opAffOf(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAffOf(expr *CXExpression, fp int) {
 	inp1, inp2 := expr.Inputs[0], expr.Inputs[1]
 
 	prevPkg := PROGRAM.CurrentPackage
@@ -748,10 +739,7 @@ func readArgAff(aff string, tgtFn *CXFunction) *CXArgument {
 
 }
 
-func opAffInform(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAffInform(expr *CXExpression, fp int) {
 	inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
 
 	prevPkg := PROGRAM.CurrentPackage
@@ -850,10 +838,7 @@ func opAffInform(prgrm *CXProgram) {
 	PROGRAM.CurrentPackage.CurrentFunction.CurrentExpression = prevExpr
 }
 
-func opAffRequest(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAffRequest(expr *CXExpression, fp int) {
 	inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
 
 	prevPkg := PROGRAM.CurrentPackage
@@ -972,10 +957,7 @@ func opAffRequest(prgrm *CXProgram) {
 	PROGRAM.CurrentPackage.CurrentFunction.CurrentExpression = prevExpr
 }
 
-func opAffQuery(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAffQuery(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 
 	out1Offset := GetFinalOffset(fp, out1)

--- a/cx/op_bool.go
+++ b/cx/op_bool.go
@@ -4,49 +4,31 @@ import (
 	"fmt"
 )
 
-func opBoolPrint(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opBoolPrint(expr *CXExpression, fp int) {
 	fmt.Println(ReadBool(fp, expr.Inputs[0]))
 }
 
-func opBoolEqual(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opBoolEqual(expr *CXExpression, fp int) {
 	outV0 := ReadBool(fp, expr.Inputs[0]) == ReadBool(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
-func opBoolUnequal(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opBoolUnequal(expr *CXExpression, fp int) {
 	outV0 := ReadBool(fp, expr.Inputs[0]) != ReadBool(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
-func opBoolNot(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opBoolNot(expr *CXExpression, fp int) {
 	outV0 := !ReadBool(fp, expr.Inputs[0])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
-func opBoolAnd(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opBoolAnd(expr *CXExpression, fp int) {
 	outV0 := ReadBool(fp, expr.Inputs[0]) && ReadBool(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
-func opBoolOr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opBoolOr(expr *CXExpression, fp int) {
 	outV0 := ReadBool(fp, expr.Inputs[0]) || ReadBool(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }

--- a/cx/op_f32.go
+++ b/cx/op_f32.go
@@ -8,334 +8,223 @@ import (
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opF32ToStr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatFloat(float64(ReadF32(fp, expr.Inputs[0])), 'f', -1, 32))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type f32 to type i8.
-func opF32ToI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadF32(fp, expr.Inputs[0]))
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type f32 to type i16.
-func opF32ToI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadF32(fp, expr.Inputs[0]))
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type f32 to type i32.
-func opF32ToI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadF32(fp, expr.Inputs[0]))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type f32 to type i64.
-func opF32ToI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadF32(fp, expr.Inputs[0]))
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type f32 to type ui8.
-func opF32ToUI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadF32(fp, expr.Inputs[0]))
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type f32 to type ui16.
-func opF32ToUI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadF32(fp, expr.Inputs[0]))
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type f32 to type ui32.
-func opF32ToUI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadF32(fp, expr.Inputs[0]))
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type f32 to type ui64.
-func opF32ToUI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadF32(fp, expr.Inputs[0]))
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type f32 to type f64.
-func opF32ToF64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadF32(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in isnan function returns true if operand is nan value.
-func opF32Isnan(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Isnan(expr *CXExpression, fp int) {
 	outV0 := math.IsNaN(float64(ReadF32(fp, expr.Inputs[0])))
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opF32Print(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Print(expr *CXExpression, fp int) {
 	fmt.Println(ReadF32(fp, expr.Inputs[0]))
 }
 
 // The built-in add function returns the sum of the two operands.
-func opF32Add(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Add(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) + ReadF32(fp, expr.Inputs[1])
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference between the two operands.
-func opF32Sub(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Sub(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) - ReadF32(fp, expr.Inputs[1])
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
-func opF32Neg(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Neg(expr *CXExpression, fp int) {
 	outV0 := -ReadF32(fp, expr.Inputs[0])
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of the two operands.
-func opF32Mul(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Mul(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) * ReadF32(fp, expr.Inputs[1])
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient between the two operands.
-func opF32Div(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Div(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) / ReadF32(fp, expr.Inputs[1])
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function return the floating-point remainder of operand 1 divided by operand 2.
-func opF32Mod(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Mod(expr *CXExpression, fp int) {
 	outV0 := float32(math.Mod(float64(ReadF32(fp, expr.Inputs[0])), float64(ReadF32(fp, expr.Inputs[1]))))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in abs function returns the absolute value of the operand.
-func opF32Abs(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Abs(expr *CXExpression, fp int) {
 	outV0 := float32(math.Abs(float64(ReadF32(fp, expr.Inputs[0]))))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in pow function returns x**n for n>0 otherwise 1.
-func opF32Pow(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Pow(expr *CXExpression, fp int) {
 	outV0 := float32(math.Pow(float64(ReadF32(fp, expr.Inputs[0])), float64(ReadF32(fp, expr.Inputs[1]))))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opF32Gt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Gt(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) > ReadF32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if the operand 1 is greater than or
 // equal to operand 2.
-func opF32Gteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) >= ReadF32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opF32Lt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Lt(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) < ReadF32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or
 // equal to operand 2.
-func opF32Lteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) <= ReadF32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opF32Eq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Eq(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) == ReadF32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true operand1 is different from operand 2.
-func opF32Uneq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) != ReadF32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number in [0.0,1.0) from the default Source
-func opF32Rand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Rand(expr *CXExpression, fp int) {
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), rand.Float32())
 }
 
 // The built-in acos function returns the arc cosine of the operand.
-func opF32Acos(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Acos(expr *CXExpression, fp int) {
 	outV0 := float32(math.Acos(float64(ReadF32(fp, expr.Inputs[0]))))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in cos function returns the cosine of the operand.
-func opF32Cos(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Cos(expr *CXExpression, fp int) {
 	outV0 := float32(math.Cos(float64(ReadF32(fp, expr.Inputs[0]))))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in asin function returns the arc sine of the operand.
-func opF32Asin(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Asin(expr *CXExpression, fp int) {
 	outV0 := float32(math.Asin(float64(ReadF32(fp, expr.Inputs[0]))))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sin function returns the sine of the operand.
-func opF32Sin(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Sin(expr *CXExpression, fp int) {
 	outV0 := float32(math.Sin(float64(ReadF32(fp, expr.Inputs[0]))))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sqrt function returns the square root of the operand.
-func opF32Sqrt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Sqrt(expr *CXExpression, fp int) {
 	outV0 := float32(math.Sqrt(float64(ReadF32(fp, expr.Inputs[0]))))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in log function returns the natural logarithm of the operand.
-func opF32Log(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Log(expr *CXExpression, fp int) {
 	outV0 := float32(math.Log(float64(ReadF32(fp, expr.Inputs[0]))))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in log2 function returns the 2-logarithm of the operand.
-func opF32Log2(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Log2(expr *CXExpression, fp int) {
 	outV0 := float32(math.Log2(float64(ReadF32(fp, expr.Inputs[0]))))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in log10 function returns the 10-logarithm of the operand.
-func opF32Log10(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Log10(expr *CXExpression, fp int) {
 	outV0 := float32(math.Log10(float64(ReadF32(fp, expr.Inputs[0]))))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the largest value of the two operands.
-func opF32Max(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Max(expr *CXExpression, fp int) {
 	outV0 := float32(math.Max(float64(ReadF32(fp, expr.Inputs[0])), float64(ReadF32(fp, expr.Inputs[1]))))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in min function returns the smallest value of the two operands.
-func opF32Min(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF32Min(expr *CXExpression, fp int) {
 	outV0 := float32(math.Min(float64(ReadF32(fp, expr.Inputs[0])), float64(ReadF32(fp, expr.Inputs[1]))))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }

--- a/cx/op_f64.go
+++ b/cx/op_f64.go
@@ -8,334 +8,223 @@ import (
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opF64ToStr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatFloat(ReadF64(fp, expr.Inputs[0]), 'f', -1, 64))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type f64 to type i8.
-func opF64ToI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadF64(fp, expr.Inputs[0]))
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type f64 to type i16.
-func opF64ToI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadF64(fp, expr.Inputs[0]))
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type f64 to type i32.
-func opF64ToI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadF64(fp, expr.Inputs[0]))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type f64 to type i64.
-func opF64ToI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadF64(fp, expr.Inputs[0]))
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type f64 to type ui8.
-func opF64ToUI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadF64(fp, expr.Inputs[0]))
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type f64 to type ui16.
-func opF64ToUI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadF64(fp, expr.Inputs[0]))
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type f64 to type ui32.
-func opF64ToUI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadF64(fp, expr.Inputs[0]))
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type f64 to type ui64.
-func opF64ToUI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadF64(fp, expr.Inputs[0]))
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type f64 to type f32.
-func opF64ToF32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadF64(fp, expr.Inputs[0]))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in isnan function returns true if operand is nan value.
-func opF64Isnan(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Isnan(expr *CXExpression, fp int) {
 	outV0 := math.IsNaN(ReadF64(fp, expr.Inputs[0]))
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opF64Print(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Print(expr *CXExpression, fp int) {
 	fmt.Println(ReadF64(fp, expr.Inputs[0]))
 }
 
 // The built-in add function returns the sum of the two operands.
-func opF64Add(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Add(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) + ReadF64(fp, expr.Inputs[1])
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference between the two operands.
-func opF64Sub(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Sub(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) - ReadF64(fp, expr.Inputs[1])
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
-func opF64Neg(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Neg(expr *CXExpression, fp int) {
 	outV0 := -ReadF64(fp, expr.Inputs[0])
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of the two operands.
-func opF64Mul(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Mul(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) * ReadF64(fp, expr.Inputs[1])
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient between the two operands.
-func opF64Div(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Div(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) / ReadF64(fp, expr.Inputs[1])
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function return the floating-point remainder of operand 1 divided by operand 2.
-func opF64Mod(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Mod(expr *CXExpression, fp int) {
 	outV0 := math.Mod(ReadF64(fp, expr.Inputs[0]), ReadF64(fp, expr.Inputs[1]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in abs function returns the absolute value of the operand.
-func opF64Abs(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Abs(expr *CXExpression, fp int) {
 	outV0 := math.Abs(ReadF64(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in pow function returns x**n for n>0 otherwise 1.
-func opF64Pow(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Pow(expr *CXExpression, fp int) {
 	outV0 := math.Pow(ReadF64(fp, expr.Inputs[0]), ReadF64(fp, expr.Inputs[1]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is larger than operand 2.
-func opF64Gt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Gt(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) > ReadF64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opF64Gteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) >= ReadF64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opF64Lt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Lt(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) < ReadF64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 2.
-func opF64Lteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) <= ReadF64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opF64Eq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Eq(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) == ReadF64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opF64Uneq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) != ReadF64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number in [0.0,1.0) from the default Source.
-func opF64Rand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Rand(expr *CXExpression, fp int) {
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), rand.Float64())
 }
 
 // The built-in acos function returns the arc cosine of the operand.
-func opF64Acos(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Acos(expr *CXExpression, fp int) {
 	outV0 := math.Acos(ReadF64(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in cos function returns the cosine of the operand.
-func opF64Cos(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Cos(expr *CXExpression, fp int) {
 	outV0 := math.Cos(ReadF64(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in asin function returns the arc sine of the operand.
-func opF64Asin(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Asin(expr *CXExpression, fp int) {
 	outV0 := math.Asin(ReadF64(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sin function returns the sine of the operand.
-func opF64Sin(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Sin(expr *CXExpression, fp int) {
 	outV0 := math.Sin(ReadF64(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sqrt function returns the square root of the operand.
-func opF64Sqrt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Sqrt(expr *CXExpression, fp int) {
 	outV0 := math.Sqrt(ReadF64(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in log function returns the natural logarithm of the operand.
-func opF64Log(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Log(expr *CXExpression, fp int) {
 	outV0 := math.Log(ReadF64(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in log2 function returns the 2-logarithm of the operand.
-func opF64Log2(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Log2(expr *CXExpression, fp int) {
 	outV0 := math.Log2(ReadF64(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in log10 function returns the 10-logarithm of the operand.
-func opF64Log10(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Log10(expr *CXExpression, fp int) {
 	outV0 := math.Log10(ReadF64(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the largest value of the two operands.
-func opF64Max(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Max(expr *CXExpression, fp int) {
 	outV0 := math.Max(ReadF64(fp, expr.Inputs[0]), ReadF64(fp, expr.Inputs[1]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in min function returns the smallest value of the two operands.
-func opF64Min(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opF64Min(expr *CXExpression, fp int) {
 	outV0 := math.Min(ReadF64(fp, expr.Inputs[0]), ReadF64(fp, expr.Inputs[1]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }

--- a/cx/op_http.go
+++ b/cx/op_http.go
@@ -86,13 +86,11 @@ func init() {
 	PROGRAM.AddPackage(httpPkg)
 }
 
-func opHTTPHandle(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
+func opHTTPHandle(expr *CXExpression, fp int) {
 	inp1, inp2 := expr.Inputs[0], expr.Inputs[1]
 
 	// Getting handler function.
-	handlerPkg, err := prgrm.GetPackage(inp2.Package.Name)
+	handlerPkg, err := PROGRAM.GetPackage(inp2.Package.Name)
 	if err != nil {
 		panic(err)
 	}
@@ -133,14 +131,11 @@ func opHTTPHandle(prgrm *CXProgram) {
 
 var server *http.Server
 
-func opHTTPClose(prgrm *CXProgram) {
+func opHTTPClose(expr *CXExpression, fp int) {
 	server.Close()
 }
 
-func opHTTPListenAndServe(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-
-	fp := prgrm.GetFramePointer()
+func opHTTPListenAndServe(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	url := ReadStr(fp, inp1)
 
@@ -150,10 +145,7 @@ func opHTTPListenAndServe(prgrm *CXProgram) {
 	WriteString(fp, err.Error(), out1)
 }
 
-func opHTTPServe(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-
-	fp := prgrm.GetFramePointer()
+func opHTTPServe(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	url := ReadStr(fp, inp1)
 
@@ -168,12 +160,9 @@ func opHTTPServe(prgrm *CXProgram) {
 	}
 }
 
-func opHTTPNewRequest(prgrm *CXProgram) {
+func opHTTPNewRequest(expr *CXExpression, fp int) {
 	// TODO: This whole OP needs rewriting/finishing.
 	// Seems more a prototype.
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	inp1, inp2, inp3, out1 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Outputs[0]
 
 	method := ReadStr(fp, inp1)
@@ -317,10 +306,7 @@ func writeHTTPRequest(fp int, param *CXArgument, request *http.Request) {
 	WriteMemory(GetFinalOffset(fp, &req), FromBool(request.URL.ForceQuery))
 }
 
-func opHTTPDo(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opHTTPDo(expr *CXExpression, fp int) {
 	inp1, out1, out2 := expr.Inputs[0], expr.Outputs[0], expr.Outputs[1]
 	//TODO read req from the inputs
 	// reqByts := ReadMemory(GetFinalOffset(fp, inp1), inp1)
@@ -484,10 +470,7 @@ func opHTTPDo(prgrm *CXProgram) {
 	WriteString(fp, string(body), &resp)
 }
 
-func opDMSGDo(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opDMSGDo(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	var req http.Request
 	byts1 := ReadMemory(GetFinalOffset(fp, inp1), inp1)

--- a/cx/op_i16.go
+++ b/cx/op_i16.go
@@ -7,153 +7,102 @@ import (
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opI16ToStr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatInt(int64(ReadI16(fp, expr.Inputs[0])), 10))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type i16 to type i8.
-func opI16ToI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16ToI8(expr *CXExpression, fp int) {
 	outB0 := int8(ReadI16(fp, expr.Inputs[0]))
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i32 function returns operand 1 casted from type i16 to type i32.
-func opI16ToI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16ToI32(expr *CXExpression, fp int) {
 	outB0 := int32(ReadI16(fp, expr.Inputs[0]))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i64 function returns operand 1 casted from type i16 to type i64.
-func opI16ToI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16ToI64(expr *CXExpression, fp int) {
 	outB0 := int64(ReadI16(fp, expr.Inputs[0]))
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i16 to type ui8.
-func opI16ToUI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16ToUI8(expr *CXExpression, fp int) {
 	outB0 := uint8(ReadI16(fp, expr.Inputs[0]))
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i16 to type ui16.
-func opI16ToUI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16ToUI16(expr *CXExpression, fp int) {
 	outB0 := uint16(ReadI16(fp, expr.Inputs[0]))
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i16 to type ui32.
-func opI16ToUI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16ToUI32(expr *CXExpression, fp int) {
 	outB0 := uint32(ReadI16(fp, expr.Inputs[0]))
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type i16 to type ui64.
-func opI16ToUI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16ToUI64(expr *CXExpression, fp int) {
 	outB0 := uint64(ReadI16(fp, expr.Inputs[0]))
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i16 to type f32.
-func opI16ToF32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16ToF32(expr *CXExpression, fp int) {
 	outB0 := float32(ReadI16(fp, expr.Inputs[0]))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i16 to type f64.
-func opI16ToF64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16ToF64(expr *CXExpression, fp int) {
 	outB0 := float64(ReadI16(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opI16Print(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Print(expr *CXExpression, fp int) {
 	fmt.Println(ReadI16(fp, expr.Inputs[0]))
 }
 
 // The built-in add function returns the sum of two i16 numbers.
-func opI16Add(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Add(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) + ReadI16(fp, expr.Inputs[1])
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in sub function returns the difference of two i16 numbers.
-func opI16Sub(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Sub(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) - ReadI16(fp, expr.Inputs[1])
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
-func opI16Neg(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Neg(expr *CXExpression, fp int) {
 	outB0 := -ReadI16(fp, expr.Inputs[0])
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in mul function returns the product of two i16 numbers.
-func opI16Mul(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Mul(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) * ReadI16(fp, expr.Inputs[1])
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in div function returns the quotient of two i16 numbers.
-func opI16Div(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Div(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) / ReadI16(fp, expr.Inputs[1])
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in abs function returns the absolute number of the number.
-func opI16Abs(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Abs(expr *CXExpression, fp int) {
 	V0 := ReadI16(fp, expr.Inputs[0])
 	sign := V0 >> 15
 	outB0 := (V0 ^ sign) - sign
@@ -161,75 +110,51 @@ func opI16Abs(prgrm *CXProgram) {
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opI16Gt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Gt(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) > ReadI16(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opI16Gteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Gteq(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) >= ReadI16(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opI16Lt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Lt(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) < ReadI16(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opI16Lteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Lteq(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) <= ReadI16(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opI16Eq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Eq(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) == ReadI16(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opI16Uneq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Uneq(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) != ReadI16(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
-func opI16Mod(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Mod(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) % ReadI16(fp, expr.Inputs[1])
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
-func opI16Rand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Rand(expr *CXExpression, fp int) {
 	minimum := ReadI16(fp, expr.Inputs[0])
 	maximum := ReadI16(fp, expr.Inputs[1])
 
@@ -243,66 +168,45 @@ func opI16Rand(prgrm *CXProgram) {
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opI16Bitand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Bitand(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) & ReadI16(fp, expr.Inputs[1])
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opI16Bitor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Bitor(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) | ReadI16(fp, expr.Inputs[1])
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opI16Bitxor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Bitxor(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) ^ ReadI16(fp, expr.Inputs[1])
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opI16Bitclear(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Bitclear(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) &^ ReadI16(fp, expr.Inputs[1])
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opI16Bitshl(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Bitshl(expr *CXExpression, fp int) {
 	outB0 := int16(ReadI16(fp, expr.Inputs[0]) << uint16(ReadI16(fp, expr.Inputs[1])))
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opI16Bitshr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Bitshr(expr *CXExpression, fp int) {
 	outB0 := int16(ReadI16(fp, expr.Inputs[0]) >> uint16(ReadI16(fp, expr.Inputs[1])))
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opI16Max(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Max(expr *CXExpression, fp int) {
 	inpV0 := ReadI16(fp, expr.Inputs[0])
 	inpV1 := ReadI16(fp, expr.Inputs[1])
 	if inpV1 > inpV0 {
@@ -312,10 +216,7 @@ func opI16Max(prgrm *CXProgram) {
 }
 
 // The built-in min function returns the smallest of the two operands.
-func opI16Min(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI16Min(expr *CXExpression, fp int) {
 	inpV0 := ReadI16(fp, expr.Inputs[0])
 	inpV1 := ReadI16(fp, expr.Inputs[1])
 	if inpV1 < inpV0 {

--- a/cx/op_i32.go
+++ b/cx/op_i32.go
@@ -7,153 +7,102 @@ import (
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opI32ToStr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatInt(int64(ReadI32(fp, expr.Inputs[0])), 10))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type i32 to type i8.
-func opI32ToI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadI32(fp, expr.Inputs[0]))
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type i32 to type i16.
-func opI32ToI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadI32(fp, expr.Inputs[0]))
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type i32 to type i64.
-func opI32ToI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadI32(fp, expr.Inputs[0]))
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i32 to type ui8.
-func opI32ToUI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadI32(fp, expr.Inputs[0]))
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i32 to type ui16.
-func opI32ToUI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadI32(fp, expr.Inputs[0]))
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type i32 to type ui32.
-func opI32ToUI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadI32(fp, expr.Inputs[0]))
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type i32 to type ui64.
-func opI32ToUI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadI32(fp, expr.Inputs[0]))
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i32 to type f32.
-func opI32ToF32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadI32(fp, expr.Inputs[0]))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i32 to type f64.
-func opI32ToF64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadI32(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opI32Print(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Print(expr *CXExpression, fp int) {
 	fmt.Println(ReadI32(fp, expr.Inputs[0]))
 }
 
 // The built-in add function returns the sum of two i32 numbers.
-func opI32Add(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Add(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) + ReadI32(fp, expr.Inputs[1])
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two i32 numbers.
-func opI32Sub(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Sub(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) - ReadI32(fp, expr.Inputs[1])
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
-func opI32Neg(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Neg(expr *CXExpression, fp int) {
 	outV0 := -ReadI32(fp, expr.Inputs[0])
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two i32 numbers.
-func opI32Mul(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Mul(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) * ReadI32(fp, expr.Inputs[1])
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two i32 numbers.
-func opI32Div(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Div(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) / ReadI32(fp, expr.Inputs[1])
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in abs function returns the absolute number of the number.
-func opI32Abs(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Abs(expr *CXExpression, fp int) {
 	inpV0 := ReadI32(fp, expr.Inputs[0])
 	sign := inpV0 >> 31
 	outV0 := (inpV0 ^ sign) - sign
@@ -161,75 +110,51 @@ func opI32Abs(prgrm *CXProgram) {
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opI32Gt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Gt(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) > ReadI32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opI32Gteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) >= ReadI32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opI32Lt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Lt(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) < ReadI32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opI32Lteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) <= ReadI32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opI32Eq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Eq(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) == ReadI32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opI32Uneq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) != ReadI32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 divided by operand 2.
-func opI32Mod(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Mod(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) % ReadI32(fp, expr.Inputs[1])
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
-func opI32Rand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Rand(expr *CXExpression, fp int) {
 	minimum := ReadI32(fp, expr.Inputs[0])
 	maximum := ReadI32(fp, expr.Inputs[1])
 
@@ -243,66 +168,45 @@ func opI32Rand(prgrm *CXProgram) {
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opI32Bitand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) & ReadI32(fp, expr.Inputs[1])
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opI32Bitor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) | ReadI32(fp, expr.Inputs[1])
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opI32Bitxor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) ^ ReadI32(fp, expr.Inputs[1])
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opI32Bitclear(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) &^ ReadI32(fp, expr.Inputs[1])
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opI32Bitshl(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) << uint32(ReadI32(fp, expr.Inputs[1]))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opI32Bitshr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) >> uint32(ReadI32(fp, expr.Inputs[1]))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opI32Max(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Max(expr *CXExpression, fp int) {
 	inpV0 := ReadI32(fp, expr.Inputs[0])
 	inpV1 := ReadI32(fp, expr.Inputs[1])
 	if inpV1 > inpV0 {
@@ -312,10 +216,7 @@ func opI32Max(prgrm *CXProgram) {
 }
 
 // The built-in min function returns the smallest of the two operands.
-func opI32Min(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI32Min(expr *CXExpression, fp int) {
 	inpV0 := ReadI32(fp, expr.Inputs[0])
 	inpV1 := ReadI32(fp, expr.Inputs[1])
 	if inpV1 < inpV0 {

--- a/cx/op_i64.go
+++ b/cx/op_i64.go
@@ -7,153 +7,102 @@ import (
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opI64ToStr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatInt(ReadI64(fp, expr.Inputs[0]), 10))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type i64 to type i8.
-func opI64ToI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64ToI8(expr *CXExpression, fp int) {
 	outB0 := int8(ReadI64(fp, expr.Inputs[0]))
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i16 function returns operand 1 casted from type i64 to type i16.
-func opI64ToI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64ToI16(expr *CXExpression, fp int) {
 	outB0 := int16(ReadI64(fp, expr.Inputs[0]))
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i32 function returns operand 1 casted from type i64 to type i32.
-func opI64ToI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64ToI32(expr *CXExpression, fp int) {
 	outB0 := int32(ReadI64(fp, expr.Inputs[0]))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i64 to type ui8.
-func opI64ToUI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64ToUI8(expr *CXExpression, fp int) {
 	outB0 := uint8(ReadI64(fp, expr.Inputs[0]))
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i64 to type ui16.
-func opI64ToUI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64ToUI16(expr *CXExpression, fp int) {
 	outB0 := uint16(ReadI64(fp, expr.Inputs[0]))
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type i64 to type ui32.
-func opI64ToUI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64ToUI32(expr *CXExpression, fp int) {
 	outB0 := uint32(ReadI64(fp, expr.Inputs[0]))
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type i64 to type ui64.
-func opI64ToUI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64ToUI64(expr *CXExpression, fp int) {
 	outB0 := uint64(ReadI64(fp, expr.Inputs[0]))
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i64 to type f32.
-func opI64ToF32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64ToF32(expr *CXExpression, fp int) {
 	outB0 := float32(ReadI64(fp, expr.Inputs[0]))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i64 to type f64.
-func opI64ToF64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64ToF64(expr *CXExpression, fp int) {
 	outB0 := float64(ReadI64(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opI64Print(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Print(expr *CXExpression, fp int) {
 	fmt.Println(ReadI64(fp, expr.Inputs[0]))
 }
 
 // The built-in add function returns the sum of the two operands.
-func opI64Add(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Add(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) + ReadI64(fp, expr.Inputs[1])
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in sub function returns the difference between the two operands.
-func opI64Sub(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Sub(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) - ReadI64(fp, expr.Inputs[1])
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in neg function returns the opposit of operand 1.
-func opI64Neg(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Neg(expr *CXExpression, fp int) {
 	outB0 := -ReadI64(fp, expr.Inputs[0])
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in mul function returns the product of the two operands.
-func opI64Mul(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Mul(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) * ReadI64(fp, expr.Inputs[1])
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in div function returns the quotient of the two operands.
-func opI64Div(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Div(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) / ReadI64(fp, expr.Inputs[1])
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in abs function returns the absolute value of the operand.
-func opI64Abs(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Abs(expr *CXExpression, fp int) {
 	inpV0 := ReadI64(fp, expr.Inputs[0])
 	sign := inpV0 >> 63
 	outB0 := (inpV0 ^ sign) - sign
@@ -161,75 +110,51 @@ func opI64Abs(prgrm *CXProgram) {
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opI64Gt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Gt(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) > ReadI64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opI64Gteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Gteq(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) >= ReadI64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in lt function returns true if operand 1 is less than oeprand 2.
-func opI64Lt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Lt(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) < ReadI64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or
 // equal to operand 2.
-func opI64Lteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Lteq(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) <= ReadI64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opI64Eq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Eq(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) == ReadI64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opI64Uneq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Uneq(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) != ReadI64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in mod function returns the remainder of operand 1 divided by operand 2.
-func opI64Mod(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Mod(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) % ReadI64(fp, expr.Inputs[1])
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
-func opI64Rand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Rand(expr *CXExpression, fp int) {
 	minimum := ReadI64(fp, expr.Inputs[0])
 	maximum := ReadI64(fp, expr.Inputs[1])
 
@@ -243,66 +168,45 @@ func opI64Rand(prgrm *CXProgram) {
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opI64Bitand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Bitand(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) & ReadI64(fp, expr.Inputs[1])
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opI64Bitor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Bitor(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) | ReadI64(fp, expr.Inputs[1])
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opI64Bitxor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Bitxor(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) ^ ReadI64(fp, expr.Inputs[1])
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opI64Bitclear(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Bitclear(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) &^ ReadI64(fp, expr.Inputs[1])
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opI64Bitshl(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Bitshl(expr *CXExpression, fp int) {
 	outB0 := int64(ReadI64(fp, expr.Inputs[0]) << uint64(ReadI64(fp, expr.Inputs[1])))
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opI64Bitshr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Bitshr(expr *CXExpression, fp int) {
 	outB0 := int64(ReadI64(fp, expr.Inputs[0]) >> uint64(ReadI64(fp, expr.Inputs[1])))
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in max function returns the greatest value of the two operands.
-func opI64Max(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Max(expr *CXExpression, fp int) {
 	inpV0 := ReadI64(fp, expr.Inputs[0])
 	inpV1 := ReadI64(fp, expr.Inputs[1])
 	if inpV1 > inpV0 {
@@ -312,10 +216,7 @@ func opI64Max(prgrm *CXProgram) {
 }
 
 // The built-in min function returns the smallest value of the two operands.
-func opI64Min(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI64Min(expr *CXExpression, fp int) {
 	inpV0 := ReadI64(fp, expr.Inputs[0])
 	inpV1 := ReadI64(fp, expr.Inputs[1])
 	if inpV1 < inpV0 {

--- a/cx/op_i8.go
+++ b/cx/op_i8.go
@@ -7,153 +7,102 @@ import (
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opI8ToStr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatInt(int64(ReadI8(fp, expr.Inputs[0])), 10))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i16 function returns operand 1 casted from type i8 to type i16.
-func opI8ToI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadI8(fp, expr.Inputs[0]))
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function returns operand 1 casted from type i8 to type i32.
-func opI8ToI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadI8(fp, expr.Inputs[0]))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type i8 to type i64.
-func opI8ToI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadI8(fp, expr.Inputs[0]))
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i8 to type ui8.
-func opI8ToUI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadI8(fp, expr.Inputs[0]))
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns operand 1 casted from type i8 to type ui16.
-func opI8ToUI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadI8(fp, expr.Inputs[0]))
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns operand 1 casted from type i8 to type ui32.
-func opI8ToUI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadI8(fp, expr.Inputs[0]))
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns operand 1 casted from type i8 to type ui64.
-func opI8ToUI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadI8(fp, expr.Inputs[0]))
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i8 to type f32.
-func opI8ToF32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadI8(fp, expr.Inputs[0]))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i8 to type uf64.
-func opI8ToF64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadI8(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opI8Print(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Print(expr *CXExpression, fp int) {
 	fmt.Println(ReadI8(fp, expr.Inputs[0]))
 }
 
 // The built-in add function returns the sum of two i8 numbers.
-func opI8Add(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Add(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) + ReadI8(fp, expr.Inputs[1])
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two i8 numbers.
-func opI8Sub(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Sub(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) - ReadI8(fp, expr.Inputs[1])
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
-func opI8Neg(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Neg(expr *CXExpression, fp int) {
 	outV0 := -ReadI8(fp, expr.Inputs[0])
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two i8 numbers.
-func opI8Mul(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Mul(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) * ReadI8(fp, expr.Inputs[1])
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two i8 numbers.
-func opI8Div(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Div(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) / ReadI8(fp, expr.Inputs[1])
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in abs function returns the absolute number of the number.
-func opI8Abs(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Abs(expr *CXExpression, fp int) {
 	inpV0 := ReadI8(fp, expr.Inputs[0])
 	sign := inpV0 >> 7
 	outV0 := (inpV0 ^ sign) - sign
@@ -161,75 +110,51 @@ func opI8Abs(prgrm *CXProgram) {
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opI8Gt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Gt(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) > ReadI8(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opI8Gteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) >= ReadI8(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opI8Lt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Lt(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) < ReadI8(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opI8Lteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) <= ReadI8(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opI8Eq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Eq(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) == ReadI8(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opI8Uneq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) != ReadI8(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
-func opI8Mod(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Mod(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) % ReadI8(fp, expr.Inputs[1])
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
-func opI8Rand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Rand(expr *CXExpression, fp int) {
 	minimum := ReadI8(fp, expr.Inputs[0])
 	maximum := ReadI8(fp, expr.Inputs[1])
 
@@ -243,66 +168,45 @@ func opI8Rand(prgrm *CXProgram) {
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opI8Bitand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) & ReadI8(fp, expr.Inputs[1])
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opI8Bitor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) | ReadI8(fp, expr.Inputs[1])
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opI8Bitxor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) ^ ReadI8(fp, expr.Inputs[1])
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opI8Bitclear(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) &^ ReadI8(fp, expr.Inputs[1])
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opI8Bitshl(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) << uint8(ReadI8(fp, expr.Inputs[1]))
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opI8Bitshr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) >> uint8(ReadI8(fp, expr.Inputs[1]))
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opI8Max(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Max(expr *CXExpression, fp int) {
 	inpV0 := ReadI8(fp, expr.Inputs[0])
 	inpV1 := ReadI8(fp, expr.Inputs[1])
 	if inpV1 > inpV0 {
@@ -312,10 +216,7 @@ func opI8Max(prgrm *CXProgram) {
 }
 
 // The built-in min function returns the smallest of the two operands.
-func opI8Min(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opI8Min(expr *CXExpression, fp int) {
 	inpV0 := ReadI8(fp, expr.Inputs[0])
 	inpV1 := ReadI8(fp, expr.Inputs[1])
 	if inpV1 < inpV0 {

--- a/cx/op_misc.go
+++ b/cx/op_misc.go
@@ -18,10 +18,7 @@ func EscapeAnalysis(fp int, inpOffset, outOffset int, arg *CXArgument) {
 	WriteI32(outOffset, int32(heapOffset))
 }
 
-func opIdentity(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opIdentity(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	inp1Offset := GetFinalOffset(fp, inp1)
 	out1Offset := GetFinalOffset(fp, out1)
@@ -45,11 +42,8 @@ func opIdentity(prgrm *CXProgram) {
 	}
 }
 
-func opJmp(prgrm *CXProgram) {
-	call := prgrm.GetCall()
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opJmp(expr *CXExpression, fp int) {
+	call := PROGRAM.GetCall()
 	inp1 := expr.Inputs[0]
 	var predicate bool
 

--- a/cx/op_str.go
+++ b/cx/op_str.go
@@ -8,10 +8,7 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 )
 
-func opStrToI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrToI8(expr *CXExpression, fp int) {
 	outV0, err := strconv.ParseInt(ReadStr(fp, expr.Inputs[0]), 10, 8)
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
@@ -19,10 +16,7 @@ func opStrToI8(prgrm *CXProgram) {
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), int8(outV0))
 }
 
-func opStrToI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrToI16(expr *CXExpression, fp int) {
 	outV0, err := strconv.ParseInt(ReadStr(fp, expr.Inputs[0]), 10, 16)
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
@@ -30,10 +24,7 @@ func opStrToI16(prgrm *CXProgram) {
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), int16(outV0))
 }
 
-func opStrToI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrToI32(expr *CXExpression, fp int) {
 	outV0, err := strconv.ParseInt(ReadStr(fp, expr.Inputs[0]), 10, 32)
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
@@ -41,10 +32,7 @@ func opStrToI32(prgrm *CXProgram) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(outV0))
 }
 
-func opStrToI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrToI64(expr *CXExpression, fp int) {
 	outV0, err := strconv.ParseInt(ReadStr(fp, expr.Inputs[0]), 10, 64)
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
@@ -52,10 +40,7 @@ func opStrToI64(prgrm *CXProgram) {
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
-func opStrToUI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrToUI8(expr *CXExpression, fp int) {
 	outV0, err := strconv.ParseUint(ReadStr(fp, expr.Inputs[0]), 10, 8)
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
@@ -63,10 +48,7 @@ func opStrToUI8(prgrm *CXProgram) {
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), uint8(outV0))
 }
 
-func opStrToUI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrToUI16(expr *CXExpression, fp int) {
 	outV0, err := strconv.ParseUint(ReadStr(fp, expr.Inputs[0]), 10, 16)
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
@@ -74,10 +56,7 @@ func opStrToUI16(prgrm *CXProgram) {
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), uint16(outV0))
 }
 
-func opStrToUI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrToUI32(expr *CXExpression, fp int) {
 	outV0, err := strconv.ParseUint(ReadStr(fp, expr.Inputs[0]), 10, 32)
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
@@ -85,10 +64,7 @@ func opStrToUI32(prgrm *CXProgram) {
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), uint32(outV0))
 }
 
-func opStrToUI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrToUI64(expr *CXExpression, fp int) {
 	outV0, err := strconv.ParseUint(ReadStr(fp, expr.Inputs[0]), 10, 64)
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
@@ -96,10 +72,7 @@ func opStrToUI64(prgrm *CXProgram) {
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
-func opStrToF32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrToF32(expr *CXExpression, fp int) {
 	outV0, err := strconv.ParseFloat(ReadStr(fp, expr.Inputs[0]), 32)
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
@@ -107,10 +80,7 @@ func opStrToF32(prgrm *CXProgram) {
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), float32(outV0))
 }
 
-func opStrToF64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrToF64(expr *CXExpression, fp int) {
 	outV0, err := strconv.ParseFloat(ReadStr(fp, expr.Inputs[0]), 64)
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
@@ -118,58 +88,37 @@ func opStrToF64(prgrm *CXProgram) {
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
-func opStrPrint(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrPrint(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	fmt.Println(ReadStr(fp, inp1))
 }
 
-func opStrEq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrEq(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) == ReadStr(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
-func opStrUneq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrUneq(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) != ReadStr(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
-func opStrLt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrLt(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) < ReadStr(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
-func opStrLteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrLteq(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) <= ReadStr(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
-func opStrGt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrGt(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) >= ReadStr(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
-func opStrGteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrGteq(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) >= ReadStr(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
@@ -189,17 +138,11 @@ func WriteString(fp int, str string, out *CXArgument) {
 	WriteI32(GetFinalOffset(fp, out), int32(heapOffset))
 }
 
-func opStrConcat(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrConcat(expr *CXExpression, fp int) {
 	WriteString(fp, ReadStr(fp, expr.Inputs[0])+ReadStr(fp, expr.Inputs[1]), expr.Outputs[0])
 }
 
-func opStrSubstr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrSubstr(expr *CXExpression, fp int) {
 	str := ReadStr(fp, expr.Inputs[0])
 	begin := ReadI32(fp, expr.Inputs[1])
 	end := ReadI32(fp, expr.Inputs[2])
@@ -207,25 +150,16 @@ func opStrSubstr(prgrm *CXProgram) {
 	WriteString(fp, str[begin:end], expr.Outputs[0])
 }
 
-func opStrIndex(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrIndex(expr *CXExpression, fp int) {
 	str := ReadStr(fp, expr.Inputs[0])
 	substr := ReadStr(fp, expr.Inputs[1])
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(strings.Index(str, substr)))
 }
 
-func opStrLastIndex(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrLastIndex(expr *CXExpression, fp int) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(strings.LastIndex(ReadStr(fp, expr.Inputs[0]), ReadStr(fp, expr.Inputs[1]))))
 }
 
-func opStrTrimSpace(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrTrimSpace(expr *CXExpression, fp int) {
 	WriteString(fp, strings.TrimSpace(ReadStr(fp, expr.Inputs[0])), expr.Outputs[0])
 }

--- a/cx/op_testing.go
+++ b/cx/op_testing.go
@@ -56,34 +56,23 @@ func assert(expr *CXExpression, fp int) (same bool) {
 	return same
 }
 
-func opAssertValue(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAssertValue(expr *CXExpression, fp int) {
 	same := assert(expr, fp)
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), same)
 }
 
-func opTest(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opTest(expr *CXExpression, fp int) {
 	assert(expr, fp)
 }
 
-func opPanic(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opPanic(expr *CXExpression, fp int) {
 	if !assert(expr, fp) {
 		panic(CX_ASSERT)
 	}
 }
 
 // panicIf/panicIfNot implementation
-func panicIf(prgrm *CXProgram, condition bool) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
+func panicIf(expr *CXExpression, fp int, condition bool) {
 	if ReadBool(fp, expr.Inputs[0]) == condition {
 		fmt.Printf("%s : %d, %s\n", expr.FileName, expr.FileLine, ReadStr(fp, expr.Inputs[1]))
 		panic(CX_ASSERT)
@@ -91,18 +80,15 @@ func panicIf(prgrm *CXProgram, condition bool) {
 }
 
 // panic with CX_ASSERT exit code if condition is true
-func opPanicIf(prgrm *CXProgram) {
-	panicIf(prgrm, true)
+func opPanicIf(expr *CXExpression, fp int) {
+	panicIf(expr, fp, true)
 }
 
 // panic with CX_ASSERT exit code if condition is false
-func opPanicIfNot(prgrm *CXProgram) {
-	panicIf(prgrm, false)
+func opPanicIfNot(expr *CXExpression, fp int) {
+	panicIf(expr, fp, false)
 }
 
-func opStrError(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opStrError(expr *CXExpression, fp int) {
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr(ErrorString(int(ReadI32(fp, expr.Inputs[0])))))
 }

--- a/cx/op_ui16.go
+++ b/cx/op_ui16.go
@@ -8,274 +8,184 @@ import (
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opUI16ToStr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatUint(uint64(ReadUI16(fp, expr.Inputs[0])), 10))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui16 to type i8.
-func opUI16ToI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16ToI8(expr *CXExpression, fp int) {
 	outV0 := int16(ReadUI16(fp, expr.Inputs[0]))
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type ui16 to type i16.
-func opUI16ToI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16ToI16(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0])
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui16 to type i32.
-func opUI16ToI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadUI16(fp, expr.Inputs[0]))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type ui16 to type i64.
-func opUI16ToI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadUI16(fp, expr.Inputs[0]))
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type ui16 to type ui8.
-func opUI16ToUI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadUI16(fp, expr.Inputs[0]))
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type ui16 to type ui32.
-func opUI16ToUI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadUI16(fp, expr.Inputs[0]))
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type ui16 to type ui64.
-func opUI16ToUI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadUI16(fp, expr.Inputs[0]))
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui16 to type f32.
-func opUI16ToF32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadUI16(fp, expr.Inputs[0]))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui16 to type f64.
-func opUI16ToF64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadUI16(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opUI16Print(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Print(expr *CXExpression, fp int) {
 	fmt.Println(ReadUI16(fp, expr.Inputs[0]))
 }
 
 // The built-in add function returns the sum of two ui16 numbers.
-func opUI16Add(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Add(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) + ReadUI16(fp, expr.Inputs[1])
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two ui16 numbers.
-func opUI16Sub(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Sub(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) - ReadUI16(fp, expr.Inputs[1])
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two ui16 numbers.
-func opUI16Mul(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Mul(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) * ReadUI16(fp, expr.Inputs[1])
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two ui16 numbers.
-func opUI16Div(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Div(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) / ReadUI16(fp, expr.Inputs[1])
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opUI16Gt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Gt(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) > ReadUI16(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opUI16Gteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) >= ReadUI16(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opUI16Lt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Lt(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) < ReadUI16(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opUI16Lteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) <= ReadUI16(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opUI16Eq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Eq(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) == ReadUI16(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opUI16Uneq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) != ReadUI16(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
-func opUI16Mod(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Mod(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) % ReadUI16(fp, expr.Inputs[1])
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
-func opUI16Rand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Rand(expr *CXExpression, fp int) {
 	outV0 := uint16(rand.Int31n(int32(math.MaxUint16)))
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opUI16Bitand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) & ReadUI16(fp, expr.Inputs[1])
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opUI16Bitor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) | ReadUI16(fp, expr.Inputs[1])
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opUI16Bitxor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) ^ ReadUI16(fp, expr.Inputs[1])
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opUI16Bitclear(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) &^ ReadUI16(fp, expr.Inputs[1])
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opUI16Bitshl(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) << ReadUI16(fp, expr.Inputs[1])
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opUI16Bitshr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) >> ReadUI16(fp, expr.Inputs[1])
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands..
-func opUI16Max(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Max(expr *CXExpression, fp int) {
 	inpV0 := ReadUI16(fp, expr.Inputs[0])
 	inpV1 := ReadUI16(fp, expr.Inputs[1])
 	if inpV1 > inpV0 {
@@ -285,10 +195,7 @@ func opUI16Max(prgrm *CXProgram) {
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opUI16Min(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI16Min(expr *CXExpression, fp int) {
 	inpV0 := ReadUI16(fp, expr.Inputs[0])
 	inpV1 := ReadUI16(fp, expr.Inputs[1])
 	if inpV1 < inpV0 {

--- a/cx/op_ui32.go
+++ b/cx/op_ui32.go
@@ -7,274 +7,184 @@ import (
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opUI32ToStr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatUint(uint64(ReadUI32(fp, expr.Inputs[0])), 10))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui32 to type i8.
-func opUI32ToI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadUI32(fp, expr.Inputs[0]))
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type ui32 to type i16.
-func opUI32ToI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadUI32(fp, expr.Inputs[0]))
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui32 to type i32.
-func opUI32ToI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadUI32(fp, expr.Inputs[0]))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type ui32 to type i64.
-func opUI32ToI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadUI32(fp, expr.Inputs[0]))
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type ui32 to type ui8.
-func opUI32ToUI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadUI32(fp, expr.Inputs[0]))
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type ui32 to type ui16.
-func opUI32ToUI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadUI32(fp, expr.Inputs[0]))
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type ui32 to type ui64.
-func opUI32ToUI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadUI32(fp, expr.Inputs[0]))
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui32 to type f32.
-func opUI32ToF32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadUI32(fp, expr.Inputs[0]))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui32 to type f64.
-func opUI32ToF64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadUI32(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opUI32Print(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Print(expr *CXExpression, fp int) {
 	fmt.Println(ReadUI32(fp, expr.Inputs[0]))
 }
 
 // The built-in add function returns the sum of two ui32 numbers.
-func opUI32Add(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Add(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) + ReadUI32(fp, expr.Inputs[1])
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two ui32 numbers.
-func opUI32Sub(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Sub(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) - ReadUI32(fp, expr.Inputs[1])
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two ui32 numbers.
-func opUI32Mul(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Mul(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) * ReadUI32(fp, expr.Inputs[1])
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two ui32 numbers.
-func opUI32Div(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Div(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) / ReadUI32(fp, expr.Inputs[1])
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opUI32Gt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Gt(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) > ReadUI32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opUI32Gteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) >= ReadUI32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opUI32Lt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Lt(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) < ReadUI32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opUI32Lteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) <= ReadUI32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opUI32Eq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Eq(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) == ReadUI32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opUI32Uneq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) != ReadUI32(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
-func opUI32Mod(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Mod(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) % ReadUI32(fp, expr.Inputs[1])
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
-func opUI32Rand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Rand(expr *CXExpression, fp int) {
 	outV0 := rand.Uint32()
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opUI32Bitand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) & ReadUI32(fp, expr.Inputs[1])
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opUI32Bitor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) | ReadUI32(fp, expr.Inputs[1])
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opUI32Bitxor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) ^ ReadUI32(fp, expr.Inputs[1])
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opUI32Bitclear(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) &^ ReadUI32(fp, expr.Inputs[1])
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opUI32Bitshl(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) << ReadUI32(fp, expr.Inputs[1])
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opUI32Bitshr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) >> ReadUI32(fp, expr.Inputs[1])
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opUI32Max(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Max(expr *CXExpression, fp int) {
 	inpV0 := ReadUI32(fp, expr.Inputs[0])
 	inpV1 := ReadUI32(fp, expr.Inputs[1])
 	if inpV1 > inpV0 {
@@ -284,10 +194,7 @@ func opUI32Max(prgrm *CXProgram) {
 }
 
 // The built-in min function returns the smallest of the two operands.
-func opUI32Min(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI32Min(expr *CXExpression, fp int) {
 	inpV0 := ReadUI32(fp, expr.Inputs[0])
 	inpV1 := ReadUI32(fp, expr.Inputs[1])
 	if inpV1 < inpV0 {

--- a/cx/op_ui64.go
+++ b/cx/op_ui64.go
@@ -7,274 +7,184 @@ import (
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opUI64ToStr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatUint(ReadUI64(fp, expr.Inputs[0]), 10))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui64 to type i8.
-func opUI64ToI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadUI64(fp, expr.Outputs[0]))
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function retruns operand 1 casted from type ui64 to i16.
-func opUI64ToI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadUI64(fp, expr.Outputs[0]))
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui64 to type i32.
-func opUI64ToI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadUI64(fp, expr.Inputs[0]))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function return operand 1 casted from type ui64 to type i64.
-func opUI64ToI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadUI64(fp, expr.Inputs[0]))
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type ui64 to type ui8.
-func opUI64ToUI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadUI64(fp, expr.Inputs[0]))
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type ui64 to type ui16.
-func opUI64ToUI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadUI64(fp, expr.Inputs[0]))
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type ui64 to type ui32.
-func opUI64ToUI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadUI64(fp, expr.Inputs[0]))
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui64 to type f32.
-func opUI64ToF32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadUI64(fp, expr.Inputs[0]))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui64 to type f64.
-func opUI64ToF64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadUI64(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opUI64Print(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Print(expr *CXExpression, fp int) {
 	fmt.Println(ReadUI64(fp, expr.Inputs[0]))
 }
 
 // The built-in add function returns the sum of two ui64 numbers.
-func opUI64Add(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Add(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) + ReadUI64(fp, expr.Inputs[1])
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two ui64 numbers.
-func opUI64Sub(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Sub(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) - ReadUI64(fp, expr.Inputs[1])
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two ui64 numbers.
-func opUI64Mul(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Mul(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) * ReadUI64(fp, expr.Inputs[1])
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two ui64 numbers.
-func opUI64Div(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Div(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) / ReadUI64(fp, expr.Inputs[1])
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opUI64Gt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Gt(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) > ReadUI64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opUI64Gteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) >= ReadUI64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opUI64Lt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Lt(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) < ReadUI64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opUI64Lteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) <= ReadUI64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opUI64Eq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Eq(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) == ReadUI64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opUI64Uneq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) != ReadUI64(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
-func opUI64Mod(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Mod(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) % ReadUI64(fp, expr.Inputs[1])
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
-func opUI64Rand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Rand(expr *CXExpression, fp int) {
 	outV0 := rand.Uint64()
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opUI64Bitand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) & ReadUI64(fp, expr.Inputs[1])
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opUI64Bitor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) | ReadUI64(fp, expr.Inputs[1])
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opUI64Bitxor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) ^ ReadUI64(fp, expr.Inputs[1])
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opUI64Bitclear(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) &^ ReadUI64(fp, expr.Inputs[1])
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opUI64Bitshl(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) << ReadUI64(fp, expr.Inputs[1])
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opUI64Bitshr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) >> ReadUI64(fp, expr.Inputs[1])
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opUI64Max(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Max(expr *CXExpression, fp int) {
 	inpV0 := ReadUI64(fp, expr.Inputs[0])
 	inpV1 := ReadUI64(fp, expr.Inputs[1])
 	if inpV1 > inpV0 {
@@ -284,10 +194,7 @@ func opUI64Max(prgrm *CXProgram) {
 }
 
 // The built-in min function returns the smallest of the two operands.
-func opUI64Min(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI64Min(expr *CXExpression, fp int) {
 	inpV0 := ReadUI64(fp, expr.Inputs[0])
 	inpV1 := ReadUI64(fp, expr.Inputs[1])
 	if inpV1 < inpV0 {

--- a/cx/op_ui8.go
+++ b/cx/op_ui8.go
@@ -8,274 +8,184 @@ import (
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opUI8ToStr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatUint(uint64(ReadUI8(fp, expr.Inputs[0])), 10))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui8 to type i8.
-func opUI8ToI8(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadUI8(fp, expr.Inputs[0]))
 	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type ui8 to type i16.
-func opUI8ToI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadUI8(fp, expr.Inputs[0]))
 	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui8 to type i32.
-func opUI8ToI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadUI8(fp, expr.Inputs[0]))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type ui8 to type i64.
-func opUI8ToI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadUI8(fp, expr.Inputs[0]))
 	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type ui8 to type ui16.
-func opUI8ToUI16(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadUI8(fp, expr.Inputs[0]))
 	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type ui8 to type ui32.
-func opUI8ToUI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadUI8(fp, expr.Inputs[0]))
 	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type ui8 to type ui64.
-func opUI8ToUI64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadUI8(fp, expr.Inputs[0]))
 	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui8 to type f32.
-func opUI8ToF32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadUI8(fp, expr.Inputs[0]))
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui8 to type f64.
-func opUI8ToF64(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadUI8(fp, expr.Inputs[0]))
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opUI8Print(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Print(expr *CXExpression, fp int) {
 	fmt.Println(ReadUI8(fp, expr.Inputs[0]))
 }
 
 // The built-in add function returns the sum of two ui8 numbers.
-func opUI8Add(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Add(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) + ReadUI8(fp, expr.Inputs[1])
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two ui8 numbers.
-func opUI8Sub(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Sub(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) - ReadUI8(fp, expr.Inputs[1])
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two ui8 numbers.
-func opUI8Mul(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Mul(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) * ReadUI8(fp, expr.Inputs[1])
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two ui8 numbers.
-func opUI8Div(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Div(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) / ReadUI8(fp, expr.Inputs[1])
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opUI8Gt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Gt(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) > ReadUI8(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opUI8Gteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) >= ReadUI8(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opUI8Lt(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Lt(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) < ReadUI8(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opUI8Lteq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) <= ReadUI8(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opUI8Eq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Eq(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) == ReadUI8(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opUI8Uneq(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) != ReadUI8(fp, expr.Inputs[1])
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
-func opUI8Mod(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Mod(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) % ReadUI8(fp, expr.Inputs[1])
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
-func opUI8Rand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Rand(expr *CXExpression, fp int) {
 	outV0 := uint8(rand.Int31n(int32(math.MaxUint8)))
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opUI8Bitand(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) & ReadUI8(fp, expr.Inputs[1])
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opUI8Bitor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) | ReadUI8(fp, expr.Inputs[1])
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opUI8Bitxor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) ^ ReadUI8(fp, expr.Inputs[1])
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opUI8Bitclear(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) &^ ReadUI8(fp, expr.Inputs[1])
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opUI8Bitshl(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) << ReadUI8(fp, expr.Inputs[1])
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opUI8Bitshr(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) >> uint32(ReadUI8(fp, expr.Inputs[1]))
 	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opUI8Max(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Max(expr *CXExpression, fp int) {
 	inpV0 := ReadUI8(fp, expr.Inputs[0])
 	inpV1 := ReadUI8(fp, expr.Inputs[1])
 	if inpV1 > inpV0 {
@@ -285,10 +195,7 @@ func opUI8Max(prgrm *CXProgram) {
 }
 
 // The built-in min function returns the smallest of the two operands.
-func opUI8Min(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opUI8Min(expr *CXExpression, fp int) {
 	inpV0 := ReadUI8(fp, expr.Inputs[0])
 	inpV1 := ReadUI8(fp, expr.Inputs[1])
 	if inpV1 < inpV0 {

--- a/cx/op_und.go
+++ b/cx/op_und.go
@@ -10,480 +10,477 @@ import (
 	"github.com/skycoin/skycoin/src/cipher/encoder"
 )
 
-func opLt(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opLt(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_STR:
-		opStrLt(prgrm)
+		opStrLt(expr, fp)
 	case TYPE_I8:
-		opI8Lt(prgrm)
+		opI8Lt(expr, fp)
 	case TYPE_I16:
-		opI16Lt(prgrm)
+		opI16Lt(expr, fp)
 	case TYPE_I32:
-		opI32Lt(prgrm)
+		opI32Lt(expr, fp)
 	case TYPE_I64:
-		opI64Lt(prgrm)
+		opI64Lt(expr, fp)
 	case TYPE_UI8:
-		opUI8Lt(prgrm)
+		opUI8Lt(expr, fp)
 	case TYPE_UI16:
-		opUI16Lt(prgrm)
+		opUI16Lt(expr, fp)
 	case TYPE_UI32:
-		opUI32Lt(prgrm)
+		opUI32Lt(expr, fp)
 	case TYPE_UI64:
-		opUI64Lt(prgrm)
+		opUI64Lt(expr, fp)
 	case TYPE_F32:
-		opF32Lt(prgrm)
+		opF32Lt(expr, fp)
 	case TYPE_F64:
-		opF64Lt(prgrm)
+		opF64Lt(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opGt(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opGt(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_STR:
-		opStrGt(prgrm)
+		opStrGt(expr, fp)
 	case TYPE_I8:
-		opI8Gt(prgrm)
+		opI8Gt(expr, fp)
 	case TYPE_I16:
-		opI16Gt(prgrm)
+		opI16Gt(expr, fp)
 	case TYPE_I32:
-		opI32Gt(prgrm)
+		opI32Gt(expr, fp)
 	case TYPE_I64:
-		opI64Gt(prgrm)
+		opI64Gt(expr, fp)
 	case TYPE_UI8:
-		opUI8Gt(prgrm)
+		opUI8Gt(expr, fp)
 	case TYPE_UI16:
-		opUI16Gt(prgrm)
+		opUI16Gt(expr, fp)
 	case TYPE_UI32:
-		opUI32Gt(prgrm)
+		opUI32Gt(expr, fp)
 	case TYPE_UI64:
-		opUI64Gt(prgrm)
+		opUI64Gt(expr, fp)
 	case TYPE_F32:
-		opF32Gt(prgrm)
+		opF32Gt(expr, fp)
 	case TYPE_F64:
-		opF64Gt(prgrm)
+		opF64Gt(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opLteq(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opLteq(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_STR:
-		opStrLteq(prgrm)
+		opStrLteq(expr, fp)
 	case TYPE_I8:
-		opI8Lteq(prgrm)
+		opI8Lteq(expr, fp)
 	case TYPE_I16:
-		opI16Lteq(prgrm)
+		opI16Lteq(expr, fp)
 	case TYPE_I32:
-		opI32Lteq(prgrm)
+		opI32Lteq(expr, fp)
 	case TYPE_I64:
-		opI64Lteq(prgrm)
+		opI64Lteq(expr, fp)
 	case TYPE_UI8:
-		opUI8Lteq(prgrm)
+		opUI8Lteq(expr, fp)
 	case TYPE_UI16:
-		opUI16Lteq(prgrm)
+		opUI16Lteq(expr, fp)
 	case TYPE_UI32:
-		opUI32Lteq(prgrm)
+		opUI32Lteq(expr, fp)
 	case TYPE_UI64:
-		opUI64Lteq(prgrm)
+		opUI64Lteq(expr, fp)
 	case TYPE_F32:
-		opF32Lteq(prgrm)
+		opF32Lteq(expr, fp)
 	case TYPE_F64:
-		opF64Lteq(prgrm)
+		opF64Lteq(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opGteq(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opGteq(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_STR:
-		opStrGteq(prgrm)
+		opStrGteq(expr, fp)
 	case TYPE_I8:
-		opI8Gteq(prgrm)
+		opI8Gteq(expr, fp)
 	case TYPE_I16:
-		opI16Gteq(prgrm)
+		opI16Gteq(expr, fp)
 	case TYPE_I32:
-		opI32Gteq(prgrm)
+		opI32Gteq(expr, fp)
 	case TYPE_I64:
-		opI64Gteq(prgrm)
+		opI64Gteq(expr, fp)
 	case TYPE_UI8:
-		opUI8Gteq(prgrm)
+		opUI8Gteq(expr, fp)
 	case TYPE_UI16:
-		opUI16Gteq(prgrm)
+		opUI16Gteq(expr, fp)
 	case TYPE_UI32:
-		opUI32Gteq(prgrm)
+		opUI32Gteq(expr, fp)
 	case TYPE_UI64:
-		opUI64Gteq(prgrm)
+		opUI64Gteq(expr, fp)
 	case TYPE_F32:
-		opF32Gteq(prgrm)
+		opF32Gteq(expr, fp)
 	case TYPE_F64:
-		opF64Gteq(prgrm)
+		opF64Gteq(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opEqual(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opEqual(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_BOOL:
-		opBoolEqual(prgrm)
+		opBoolEqual(expr, fp)
 	case TYPE_STR:
-		opStrEq(prgrm)
+		opStrEq(expr, fp)
 	case TYPE_I8:
-		opI8Eq(prgrm)
+		opI8Eq(expr, fp)
 	case TYPE_I16:
-		opI16Eq(prgrm)
+		opI16Eq(expr, fp)
 	case TYPE_I32:
-		opI32Eq(prgrm)
+		opI32Eq(expr, fp)
 	case TYPE_I64:
-		opI64Eq(prgrm)
+		opI64Eq(expr, fp)
 	case TYPE_UI8:
-		opUI8Eq(prgrm)
+		opUI8Eq(expr, fp)
 	case TYPE_UI16:
-		opUI16Eq(prgrm)
+		opUI16Eq(expr, fp)
 	case TYPE_UI32:
-		opUI32Eq(prgrm)
+		opUI32Eq(expr, fp)
 	case TYPE_UI64:
-		opUI64Eq(prgrm)
+		opUI64Eq(expr, fp)
 	case TYPE_F32:
-		opF32Eq(prgrm)
+		opF32Eq(expr, fp)
 	case TYPE_F64:
-		opF64Eq(prgrm)
+		opF64Eq(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opUnequal(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opUnequal(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_BOOL:
-		opBoolUnequal(prgrm)
+		opBoolUnequal(expr, fp)
 	case TYPE_STR:
-		opStrUneq(prgrm)
+		opStrUneq(expr, fp)
 	case TYPE_I8:
-		opI8Uneq(prgrm)
+		opI8Uneq(expr, fp)
 	case TYPE_I16:
-		opI16Uneq(prgrm)
+		opI16Uneq(expr, fp)
 	case TYPE_I32:
-		opI32Uneq(prgrm)
+		opI32Uneq(expr, fp)
 	case TYPE_I64:
-		opI64Uneq(prgrm)
+		opI64Uneq(expr, fp)
 	case TYPE_UI8:
-		opUI8Uneq(prgrm)
+		opUI8Uneq(expr, fp)
 	case TYPE_UI16:
-		opUI16Uneq(prgrm)
+		opUI16Uneq(expr, fp)
 	case TYPE_UI32:
-		opUI32Uneq(prgrm)
+		opUI32Uneq(expr, fp)
 	case TYPE_UI64:
-		opUI64Uneq(prgrm)
+		opUI64Uneq(expr, fp)
 	case TYPE_F32:
-		opF32Uneq(prgrm)
+		opF32Uneq(expr, fp)
 	case TYPE_F64:
-		opF64Uneq(prgrm)
+		opF64Uneq(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opBitand(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opBitand(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_I8:
-		opI8Bitand(prgrm)
+		opI8Bitand(expr, fp)
 	case TYPE_I16:
-		opI16Bitand(prgrm)
+		opI16Bitand(expr, fp)
 	case TYPE_I32:
-		opI32Bitand(prgrm)
+		opI32Bitand(expr, fp)
 	case TYPE_I64:
-		opI64Bitand(prgrm)
+		opI64Bitand(expr, fp)
 	case TYPE_UI8:
-		opUI8Bitand(prgrm)
+		opUI8Bitand(expr, fp)
 	case TYPE_UI16:
-		opUI16Bitand(prgrm)
+		opUI16Bitand(expr, fp)
 	case TYPE_UI32:
-		opUI32Bitand(prgrm)
+		opUI32Bitand(expr, fp)
 	case TYPE_UI64:
-		opUI64Bitand(prgrm)
+		opUI64Bitand(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opBitor(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opBitor(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_I8:
-		opI8Bitor(prgrm)
+		opI8Bitor(expr, fp)
 	case TYPE_I16:
-		opI16Bitor(prgrm)
+		opI16Bitor(expr, fp)
 	case TYPE_I32:
-		opI32Bitor(prgrm)
+		opI32Bitor(expr, fp)
 	case TYPE_I64:
-		opI64Bitor(prgrm)
+		opI64Bitor(expr, fp)
 	case TYPE_UI8:
-		opUI8Bitor(prgrm)
+		opUI8Bitor(expr, fp)
 	case TYPE_UI16:
-		opUI16Bitor(prgrm)
+		opUI16Bitor(expr, fp)
 	case TYPE_UI32:
-		opUI32Bitor(prgrm)
+		opUI32Bitor(expr, fp)
 	case TYPE_UI64:
-		opUI64Bitor(prgrm)
+		opUI64Bitor(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opBitxor(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opBitxor(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_I8:
-		opI8Bitxor(prgrm)
+		opI8Bitxor(expr, fp)
 	case TYPE_I16:
-		opI16Bitxor(prgrm)
+		opI16Bitxor(expr, fp)
 	case TYPE_I32:
-		opI32Bitxor(prgrm)
+		opI32Bitxor(expr, fp)
 	case TYPE_I64:
-		opI64Bitxor(prgrm)
+		opI64Bitxor(expr, fp)
 	case TYPE_UI8:
-		opUI8Bitxor(prgrm)
+		opUI8Bitxor(expr, fp)
 	case TYPE_UI16:
-		opUI16Bitxor(prgrm)
+		opUI16Bitxor(expr, fp)
 	case TYPE_UI32:
-		opUI32Bitxor(prgrm)
+		opUI32Bitxor(expr, fp)
 	case TYPE_UI64:
-		opUI64Bitxor(prgrm)
+		opUI64Bitxor(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opMul(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opMul(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_I8:
-		opI8Mul(prgrm)
+		opI8Mul(expr, fp)
 	case TYPE_I16:
-		opI16Mul(prgrm)
+		opI16Mul(expr, fp)
 	case TYPE_I32:
-		opI32Mul(prgrm)
+		opI32Mul(expr, fp)
 	case TYPE_I64:
-		opI64Mul(prgrm)
+		opI64Mul(expr, fp)
 	case TYPE_UI8:
-		opUI8Mul(prgrm)
+		opUI8Mul(expr, fp)
 	case TYPE_UI16:
-		opUI16Mul(prgrm)
+		opUI16Mul(expr, fp)
 	case TYPE_UI32:
-		opUI32Mul(prgrm)
+		opUI32Mul(expr, fp)
 	case TYPE_UI64:
-		opUI64Mul(prgrm)
+		opUI64Mul(expr, fp)
 	case TYPE_F32:
-		opF32Mul(prgrm)
+		opF32Mul(expr, fp)
 	case TYPE_F64:
-		opF64Mul(prgrm)
+		opF64Mul(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opDiv(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opDiv(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_I8:
-		opI8Div(prgrm)
+		opI8Div(expr, fp)
 	case TYPE_I16:
-		opI16Div(prgrm)
+		opI16Div(expr, fp)
 	case TYPE_I32:
-		opI32Div(prgrm)
+		opI32Div(expr, fp)
 	case TYPE_I64:
-		opI64Div(prgrm)
+		opI64Div(expr, fp)
 	case TYPE_UI8:
-		opUI8Div(prgrm)
+		opUI8Div(expr, fp)
 	case TYPE_UI16:
-		opUI16Div(prgrm)
+		opUI16Div(expr, fp)
 	case TYPE_UI32:
-		opUI32Div(prgrm)
+		opUI32Div(expr, fp)
 	case TYPE_UI64:
-		opUI64Div(prgrm)
+		opUI64Div(expr, fp)
 	case TYPE_F32:
-		opF32Div(prgrm)
+		opF32Div(expr, fp)
 	case TYPE_F64:
-		opF64Div(prgrm)
+		opF64Div(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opMod(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opMod(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_I8:
-		opI8Mod(prgrm)
+		opI8Mod(expr, fp)
 	case TYPE_I16:
-		opI16Mod(prgrm)
+		opI16Mod(expr, fp)
 	case TYPE_I32:
-		opI32Mod(prgrm)
+		opI32Mod(expr, fp)
 	case TYPE_I64:
-		opI64Mod(prgrm)
+		opI64Mod(expr, fp)
 	case TYPE_UI8:
-		opUI8Mod(prgrm)
+		opUI8Mod(expr, fp)
 	case TYPE_UI16:
-		opUI16Mod(prgrm)
+		opUI16Mod(expr, fp)
 	case TYPE_UI32:
-		opUI32Mod(prgrm)
+		opUI32Mod(expr, fp)
 	case TYPE_UI64:
-		opUI64Mod(prgrm)
+		opUI64Mod(expr, fp)
 	case TYPE_F32:
-		opF32Mod(prgrm)
+		opF32Mod(expr, fp)
 	case TYPE_F64:
-		opF64Mod(prgrm)
+		opF64Mod(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opAdd(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opAdd(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_I8:
-		opI8Add(prgrm)
+		opI8Add(expr, fp)
 	case TYPE_I16:
-		opI16Add(prgrm)
+		opI16Add(expr, fp)
 	case TYPE_I32:
-		opI32Add(prgrm)
+		opI32Add(expr, fp)
 	case TYPE_I64:
-		opI64Add(prgrm)
+		opI64Add(expr, fp)
 	case TYPE_UI8:
-		opUI8Add(prgrm)
+		opUI8Add(expr, fp)
 	case TYPE_UI16:
-		opUI16Add(prgrm)
+		opUI16Add(expr, fp)
 	case TYPE_UI32:
-		opUI32Add(prgrm)
+		opUI32Add(expr, fp)
 	case TYPE_UI64:
-		opUI64Add(prgrm)
+		opUI64Add(expr, fp)
 	case TYPE_F32:
-		opF32Add(prgrm)
+		opF32Add(expr, fp)
 	case TYPE_F64:
-		opF64Add(prgrm)
+		opF64Add(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opSub(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opSub(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_I8:
-		opI8Sub(prgrm)
+		opI8Sub(expr, fp)
 	case TYPE_I16:
-		opI16Sub(prgrm)
+		opI16Sub(expr, fp)
 	case TYPE_I32:
-		opI32Sub(prgrm)
+		opI32Sub(expr, fp)
 	case TYPE_I64:
-		opI64Sub(prgrm)
+		opI64Sub(expr, fp)
 	case TYPE_UI8:
-		opUI8Sub(prgrm)
+		opUI8Sub(expr, fp)
 	case TYPE_UI16:
-		opUI16Sub(prgrm)
+		opUI16Sub(expr, fp)
 	case TYPE_UI32:
-		opUI32Sub(prgrm)
+		opUI32Sub(expr, fp)
 	case TYPE_UI64:
-		opUI64Sub(prgrm)
+		opUI64Sub(expr, fp)
 	case TYPE_F32:
-		opF32Sub(prgrm)
+		opF32Sub(expr, fp)
 	case TYPE_F64:
-		opF64Sub(prgrm)
+		opF64Sub(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opNeg(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opNeg(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_I8:
-		opI8Neg(prgrm)
+		opI8Neg(expr, fp)
 	case TYPE_I16:
-		opI16Neg(prgrm)
+		opI16Neg(expr, fp)
 	case TYPE_I32:
-		opI32Neg(prgrm)
+		opI32Neg(expr, fp)
 	case TYPE_I64:
-		opI64Neg(prgrm)
+		opI64Neg(expr, fp)
 	case TYPE_F32:
-		opF32Neg(prgrm)
+		opF32Neg(expr, fp)
 	case TYPE_F64:
-		opF64Neg(prgrm)
+		opF64Neg(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opBitshl(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opBitshl(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_I8:
-		opI8Bitshl(prgrm)
+		opI8Bitshl(expr, fp)
 	case TYPE_I16:
-		opI16Bitshl(prgrm)
+		opI16Bitshl(expr, fp)
 	case TYPE_I32:
-		opI32Bitshl(prgrm)
+		opI32Bitshl(expr, fp)
 	case TYPE_I64:
-		opI64Bitshl(prgrm)
+		opI64Bitshl(expr, fp)
 	case TYPE_UI8:
-		opUI8Bitshl(prgrm)
+		opUI8Bitshl(expr, fp)
 	case TYPE_UI16:
-		opUI16Bitshl(prgrm)
+		opUI16Bitshl(expr, fp)
 	case TYPE_UI32:
-		opUI32Bitshl(prgrm)
+		opUI32Bitshl(expr, fp)
 	case TYPE_UI64:
-		opUI64Bitshl(prgrm)
+		opUI64Bitshl(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opBitshr(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opBitshr(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_I8:
-		opI8Bitshr(prgrm)
+		opI8Bitshr(expr, fp)
 	case TYPE_I16:
-		opI16Bitshr(prgrm)
+		opI16Bitshr(expr, fp)
 	case TYPE_I32:
-		opI32Bitshr(prgrm)
+		opI32Bitshr(expr, fp)
 	case TYPE_I64:
-		opI64Bitshr(prgrm)
+		opI64Bitshr(expr, fp)
 	case TYPE_UI8:
-		opUI8Bitshr(prgrm)
+		opUI8Bitshr(expr, fp)
 	case TYPE_UI16:
-		opUI16Bitshr(prgrm)
+		opUI16Bitshr(expr, fp)
 	case TYPE_UI32:
-		opUI32Bitshr(prgrm)
+		opUI32Bitshr(expr, fp)
 	case TYPE_UI64:
-		opUI64Bitshr(prgrm)
+		opUI64Bitshr(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opBitclear(prgrm *CXProgram) {
-	switch prgrm.GetExpr().Inputs[0].Type {
+func opBitclear(expr *CXExpression, fp int) {
+	switch expr.Inputs[0].Type {
 	case TYPE_I8:
-		opI8Bitclear(prgrm)
+		opI8Bitclear(expr, fp)
 	case TYPE_I16:
-		opI16Bitclear(prgrm)
+		opI16Bitclear(expr, fp)
 	case TYPE_I32:
-		opI32Bitclear(prgrm)
+		opI32Bitclear(expr, fp)
 	case TYPE_I64:
-		opI64Bitclear(prgrm)
+		opI64Bitclear(expr, fp)
 	case TYPE_UI8:
-		opUI8Bitclear(prgrm)
+		opUI8Bitclear(expr, fp)
 	case TYPE_UI16:
-		opUI16Bitclear(prgrm)
+		opUI16Bitclear(expr, fp)
 	case TYPE_UI32:
-		opUI32Bitclear(prgrm)
+		opUI32Bitclear(expr, fp)
 	case TYPE_UI64:
-		opUI64Bitclear(prgrm)
+		opUI64Bitclear(expr, fp)
 	default:
 		panic(CX_INTERNAL_ERROR)
 	}
 }
 
-func opLen(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opLen(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	elt := GetAssignmentElement(inp1)
 
@@ -515,10 +512,7 @@ func opLen(prgrm *CXProgram) {
 	}
 }
 
-func opAppend(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAppend(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 
 	eltInp1 := GetAssignmentElement(inp1)
@@ -552,10 +546,7 @@ func opAppend(prgrm *CXProgram) {
 	WriteI32(outputSlicePointer, outputSliceOffset)
 }
 
-func opResize(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opResize(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 
 	if inp1.Type != out1.Type || !GetAssignmentElement(inp1).IsSlice || !GetAssignmentElement(out1).IsSlice {
@@ -567,10 +558,7 @@ func opResize(prgrm *CXProgram) {
 	WriteI32(outputSlicePointer, outputSliceOffset)
 }
 
-func opInsert(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opInsert(expr *CXExpression, fp int) {
 	inp1, inp2, inp3, out1 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Outputs[0]
 
 	if inp1.Type != inp3.Type || inp1.Type != out1.Type || !GetAssignmentElement(inp1).IsSlice || !GetAssignmentElement(out1).IsSlice {
@@ -591,10 +579,7 @@ func opInsert(prgrm *CXProgram) {
 	}
 }
 
-func opRemove(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opRemove(expr *CXExpression, fp int) {
 	inp1, inp2, out1 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0]
 
 	if inp1.Type != out1.Type || !GetAssignmentElement(inp1).IsSlice || !GetAssignmentElement(out1).IsSlice {
@@ -606,10 +591,7 @@ func opRemove(prgrm *CXProgram) {
 	WriteI32(outputSlicePointer, outputSliceOffset)
 }
 
-func opCopy(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opCopy(expr *CXExpression, fp int) {
 	dstInput := expr.Inputs[0]
 	srcInput := expr.Inputs[1]
 	dstOffset := GetSliceOffset(fp, dstInput)
@@ -744,10 +726,7 @@ func buildString(expr *CXExpression, fp int) []byte {
 	return res
 }
 
-func opSprintf(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opSprintf(expr *CXExpression, fp int) {
 	out1 := expr.Outputs[0]
 	out1Offset := GetFinalOffset(fp, out1)
 
@@ -755,17 +734,11 @@ func opSprintf(prgrm *CXProgram) {
 	WriteObject(out1Offset, byts)
 }
 
-func opPrintf(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opPrintf(expr *CXExpression, fp int) {
 	fmt.Print(string(buildString(expr, fp)))
 }
 
-func opRead(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opRead(expr *CXExpression, fp int) {
 	out1 := expr.Outputs[0]
 	out1Offset := GetFinalOffset(fp, out1)
 

--- a/cx/opcodes.go
+++ b/cx/opcodes.go
@@ -458,7 +458,7 @@ const (
 )
 
 // OpcodeHandler ...
-type OpcodeHandler func(prgrm *CXProgram)
+type OpcodeHandler func(expr *CXExpression, fp int)
 
 var (
 	// OpNames ...
@@ -471,11 +471,6 @@ var (
 	Natives        = map[int]*CXFunction{}
 	opcodeHandlers []OpcodeHandler
 )
-
-func execNative(prgrm *CXProgram) {
-	//defer RuntimeError() // High runtime cost.
-	opcodeHandlers[prgrm.GetOpCode()](prgrm)
-}
 
 // RegisterPackage registers a package on the CX standard library. This does not create a `CXPackage` structure,
 // it only tells the CX runtime that `pkgName` will exist by the time a CX program is run.
@@ -653,8 +648,8 @@ func Out(params ...*CXArgument) []*CXArgument {
 	return params
 }
 
-func opDebug(prgrm *CXProgram) {
-	prgrm.PrintStack()
+func opDebug(*CXExpression, int) {
+	PROGRAM.PrintStack()
 }
 
 func init() {

--- a/cx/serialize.go
+++ b/cx/serialize.go
@@ -818,10 +818,7 @@ func Serialize(prgrm *CXProgram, split int) (byts []byte) {
 	return byts
 }
 
-func opSerialize(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opSerialize(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	out1Offset := GetFinalOffset(fp, out1)
 
@@ -836,10 +833,7 @@ func opSerialize(prgrm *CXProgram) {
 	WriteI32(out1Offset, int32(slcOff))
 }
 
-func opDeserialize(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opDeserialize(expr *CXExpression, fp int) {
 	inp := expr.Inputs[0]
 
 	inpOffset := GetFinalOffset(fp, inp)

--- a/cxfx/cxgl_desktop.go
+++ b/cxfx/cxgl_desktop.go
@@ -92,27 +92,21 @@ func readUI32Ptr(fp int, inp *CXArgument) *uint32 {
 }
 
 // gogl
-func opGlInit(_ *CXProgram) {
+func opGlInit(expr *CXExpression, fp int) {
 	gl.Init()
 }
 
-func opGlDestroy(_ *CXProgram) {
+func opGlDestroy(expr *CXExpression, fp int) {
 	for k, _ := range cSources {
 		freeCString(k)
 	}
 }
 
-func opGlStrs(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlStrs(expr *CXExpression, fp int) {
 	getCString(ReadStr(fp, expr.Inputs[0]), ReadStr(fp, expr.Inputs[1]))
 }
 
-func opGlFree(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlFree(expr *CXExpression, fp int) {
 	freeCString(ReadStr(fp, expr.Inputs[0]))
 }
 
@@ -559,151 +553,103 @@ func cxglGenVertexArrays(n int32, arrays *uint32) {
 }
 
 // gl_0_0
-func opGlMatrixMode(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlMatrixMode(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	gl.MatrixMode(uint32(ReadI32(fp, inp1)))
 }
 
-func opGlRotatef(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlRotatef(expr *CXExpression, fp int) {
 	inp1, inp2, inp3, inp4 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Inputs[3]
 	gl.Rotatef(ReadF32(fp, inp1), ReadF32(fp, inp2), ReadF32(fp, inp3), ReadF32(fp, inp4))
 }
 
-func opGlTranslatef(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlTranslatef(expr *CXExpression, fp int) {
 	inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
 	gl.Translatef(ReadF32(fp, inp1), ReadF32(fp, inp2), ReadF32(fp, inp3))
 }
 
-func opGlLoadIdentity(_ *CXProgram) {
+func opGlLoadIdentity(expr *CXExpression, fp int) {
 	gl.LoadIdentity()
 }
 
-func opGlPushMatrix(_ *CXProgram) {
+func opGlPushMatrix(expr *CXExpression, fp int) {
 	gl.PushMatrix()
 }
 
-func opGlPopMatrix(_ *CXProgram) {
+func opGlPopMatrix(expr *CXExpression, fp int) {
 	gl.PopMatrix()
 }
 
-func opGlEnableClientState(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlEnableClientState(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	gl.EnableClientState(uint32(ReadI32(fp, inp1)))
 }
 
-func opGlColor3f(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlColor3f(expr *CXExpression, fp int) {
 	inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
 	gl.Color3f(ReadF32(fp, inp1), ReadF32(fp, inp2), ReadF32(fp, inp3))
 }
 
-func opGlColor4f(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlColor4f(expr *CXExpression, fp int) {
 	inp1, inp2, inp3, inp4 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Inputs[3]
 	gl.Color4f(ReadF32(fp, inp1), ReadF32(fp, inp2), ReadF32(fp, inp3), ReadF32(fp, inp4))
 }
 
-func opGlBegin(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlBegin(expr *CXExpression, fp int) {
 	inp1 := expr.Inputs[0]
 	gl.Begin(uint32(ReadI32(fp, inp1)))
 }
 
-func opGlEnd(_ *CXProgram) {
+func opGlEnd(expr *CXExpression, fp int) {
 	gl.End()
 }
 
-func opGlNormal3f(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlNormal3f(expr *CXExpression, fp int) {
 	inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
 	gl.Normal3f(ReadF32(fp, inp1), ReadF32(fp, inp2), ReadF32(fp, inp3))
 }
 
-func opGlVertex2f(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlVertex2f(expr *CXExpression, fp int) {
 	inp1, inp2 := expr.Inputs[0], expr.Inputs[1]
 	gl.Vertex2f(ReadF32(fp, inp1), ReadF32(fp, inp2))
 }
 
-func opGlVertex3f(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlVertex3f(expr *CXExpression, fp int) {
 	inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
 	gl.Vertex3f(ReadF32(fp, inp1), ReadF32(fp, inp2), ReadF32(fp, inp3))
 }
 
-func opGlLightfv(_ *CXProgram) {
+func opGlLightfv(expr *CXExpression, fp int) {
 	// pointers
 	panic("gl.Lightfv")
 }
 
-func opGlFrustum(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlFrustum(expr *CXExpression, fp int) {
 	inp1, inp2, inp3, inp4, inp5, inp6 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Inputs[3], expr.Inputs[4], expr.Inputs[5]
 	gl.Frustum(ReadF64(fp, inp1), ReadF64(fp, inp2), ReadF64(fp, inp3), ReadF64(fp, inp4), ReadF64(fp, inp5), ReadF64(fp, inp6))
 }
 
-func opGlTexEnvi(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlTexEnvi(expr *CXExpression, fp int) {
 	inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
 	gl.TexEnvi(uint32(ReadI32(fp, inp1)), uint32(ReadI32(fp, inp2)), ReadI32(fp, inp3))
 }
 
-func opGlOrtho(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlOrtho(expr *CXExpression, fp int) {
 	inp1, inp2, inp3, inp4, inp5, inp6 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Inputs[3], expr.Inputs[4], expr.Inputs[5]
 	gl.Ortho(ReadF64(fp, inp1), ReadF64(fp, inp2), ReadF64(fp, inp3), ReadF64(fp, inp4), ReadF64(fp, inp5), ReadF64(fp, inp6))
 }
 
-func opGlScalef(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlScalef(expr *CXExpression, fp int) {
 	inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
 	gl.Scalef(ReadF32(fp, inp1), ReadF32(fp, inp2), ReadF32(fp, inp3))
 }
 
-func opGlTexCoord2d(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlTexCoord2d(expr *CXExpression, fp int) {
 	inp1, inp2 := expr.Inputs[0], expr.Inputs[1]
 	gl.TexCoord2d(ReadF64(fp, inp1), ReadF64(fp, inp2))
 }
 
-func opGlTexCoord2f(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlTexCoord2f(expr *CXExpression, fp int) {
 	inp1, inp2 := expr.Inputs[0], expr.Inputs[1]
 	gl.TexCoord2f(ReadF32(fp, inp1), ReadF32(fp, inp2))
 }

--- a/cxfx/cxgl_mobile.go
+++ b/cxfx/cxgl_mobile.go
@@ -104,19 +104,19 @@ func SetGLContext(ctx gl.Context) {
 }
 
 // gogl
-func opGlInit(_ *CXProgram) {
+func opGlInit(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlDestroy(_ *CXProgram) {
+func opGlDestroy(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlStrs(prgrm *CXProgram) {
+func opGlStrs(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlFree(prgrm *CXProgram) {
+func opGlFree(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
@@ -582,86 +582,86 @@ func cxglGenVertexArrays(n int32, arrays *uint32) {
 }
 
 // gl_0_0
-func opGlMatrixMode(prgrm *CXProgram) {
+func opGlMatrixMode(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlRotatef(prgrm *CXProgram) {
+func opGlRotatef(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlTranslatef(prgrm *CXProgram) {
+func opGlTranslatef(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlLoadIdentity(_ *CXProgram) {
+func opGlLoadIdentity(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlPushMatrix(_ *CXProgram) {
+func opGlPushMatrix(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlPopMatrix(_ *CXProgram) {
+func opGlPopMatrix(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlEnableClientState(prgrm *CXProgram) {
+func opGlEnableClientState(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlColor3f(prgrm *CXProgram) {
+func opGlColor3f(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlColor4f(prgrm *CXProgram) {
+func opGlColor4f(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlBegin(prgrm *CXProgram) {
+func opGlBegin(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlEnd(_ *CXProgram) {
+func opGlEnd(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlNormal3f(prgrm *CXProgram) {
+func opGlNormal3f(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlVertex2f(prgrm *CXProgram) {
+func opGlVertex2f(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlVertex3f(prgrm *CXProgram) {
+func opGlVertex3f(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlLightfv(_ *CXProgram) {
+func opGlLightfv(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlFrustum(prgrm *CXProgram) {
+func opGlFrustum(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlTexEnvi(prgrm *CXProgram) {
+func opGlTexEnvi(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlOrtho(prgrm *CXProgram) {
+func opGlOrtho(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlScalef(prgrm *CXProgram) {
+func opGlScalef(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlTexCoord2d(prgrm *CXProgram) {
+func opGlTexCoord2d(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlTexCoord2f(prgrm *CXProgram) {
+func opGlTexCoord2f(expr *CXExpression, fp int) {
 	panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }

--- a/cxfx/event.go
+++ b/cxfx/event.go
@@ -47,7 +47,6 @@ type Event struct {
 }
 
 type CXCallback struct {
-	prgrm           *CXProgram
 	expr            *CXExpression
 	fp              int
 	windowNameBytes []byte
@@ -56,8 +55,7 @@ type CXCallback struct {
 	functionName    string
 }
 
-func (cb *CXCallback) init(prgrm *CXProgram, expr *CXExpression, fp int, packageName string) {
-	cb.prgrm = prgrm
+func (cb *CXCallback) init(expr *CXExpression, fp int, packageName string) {
 	cb.expr = expr
 	cb.fp = fp
 	cb.windowName = ReadStr(fp, expr.Inputs[0])
@@ -66,21 +64,17 @@ func (cb *CXCallback) init(prgrm *CXProgram, expr *CXExpression, fp int, package
 	cb.packageName = packageName
 }
 
-func (cb *CXCallback) Init(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-	cb.init(prgrm, expr, fp, expr.Package.Name)
+func (cb *CXCallback) Init(expr *CXExpression, fp int) {
+	cb.init(expr, fp, expr.Package.Name)
 }
 
-func (cb *CXCallback) InitEx(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-	cb.init(prgrm, expr, fp, ReadStr(fp, expr.Inputs[2]))
+func (cb *CXCallback) InitEx(expr *CXExpression, fp int) {
+	cb.init(expr, fp, ReadStr(fp, expr.Inputs[2]))
 }
 
 func (cb *CXCallback) Call(inputs [][]byte) {
-	if fn, err := cb.prgrm.GetFunction(cb.functionName, cb.packageName); err == nil {
-		cb.prgrm.Callback(fn, inputs)
+	if fn, err := PROGRAM.GetFunction(cb.functionName, cb.packageName); err == nil {
+		PROGRAM.Callback(fn, inputs)
 	}
 }
 

--- a/cxfx/op_glfw_desktop.go
+++ b/cxfx/op_glfw_desktop.go
@@ -10,10 +10,7 @@ import (
 
 var windows map[string]*glfw.Window = make(map[string]*glfw.Window, 0)
 
-func opGlfwFullscreen(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwFullscreen(expr *CXExpression, fp int) {
 	window := windows[ReadStr(fp, expr.Inputs[0])]
 	fullscreen := ReadBool(fp, expr.Inputs[1])
 	x := ReadI32(fp, expr.Inputs[2])
@@ -34,62 +31,41 @@ func opGlfwFullscreen(prgrm *CXProgram) {
 
 var initialized bool
 
-func opGlfwInit(prgrm *CXProgram) {
+func opGlfwInit(expr *CXExpression, fp int) {
 	glfw.Init()
 	initialized = true
 }
 
-func opGlfwSwapBuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwSwapBuffers(expr *CXExpression, fp int) {
 	windows[ReadStr(fp, expr.Inputs[0])].SwapBuffers()
 }
 
-func opGlfwMakeContextCurrent(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwMakeContextCurrent(expr *CXExpression, fp int) {
 	windows[ReadStr(fp, expr.Inputs[0])].MakeContextCurrent()
 }
 
-func opGlfwWindowHint(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwWindowHint(expr *CXExpression, fp int) {
 	glfw.WindowHint(glfw.Hint(ReadI32(fp, expr.Inputs[0])), int(ReadI32(fp, expr.Inputs[1])))
 }
 
-func opGlfwSetInputMode(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwSetInputMode(expr *CXExpression, fp int) {
 	windows[ReadStr(fp, expr.Inputs[0])].SetInputMode(
 		glfw.InputMode(ReadI32(fp, expr.Inputs[1])),
 		int(ReadI32(fp, expr.Inputs[2])))
 }
 
-func opGlfwGetCursorPos(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwGetCursorPos(expr *CXExpression, fp int) {
 	x, y := windows[ReadStr(fp, expr.Inputs[0])].GetCursorPos()
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), x)
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), y)
 }
 
-func opGlfwGetKey(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwGetKey(expr *CXExpression, fp int) {
 	act := int32(windows[ReadStr(fp, expr.Inputs[0])].GetKey(glfw.Key(ReadI32(fp, expr.Inputs[1]))))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), act)
 }
 
-func opGlfwCreateWindow(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwCreateWindow(expr *CXExpression, fp int) {
 	if win, err := glfw.CreateWindow(
 		int(ReadI32(fp, expr.Inputs[1])),
 		int(ReadI32(fp, expr.Inputs[2])),
@@ -100,92 +76,63 @@ func opGlfwCreateWindow(prgrm *CXProgram) {
 	}
 }
 
-func opGlfwGetWindowContentScale(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwGetWindowContentScale(expr *CXExpression, fp int) {
 	xscale, yscale := windows[ReadStr(fp, expr.Inputs[0])].GetContentScale()
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), xscale)
 	WriteF32(GetFinalOffset(fp, expr.Outputs[1]), yscale)
 }
 
-func opGlfwGetMonitorContentScale(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwGetMonitorContentScale(expr *CXExpression, fp int) {
 	xscale, yscale := glfw.GetPrimaryMonitor().GetContentScale()
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), xscale)
 	WriteF32(GetFinalOffset(fp, expr.Outputs[1]), yscale)
 }
 
-func opGlfwSetWindowPos(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwSetWindowPos(expr *CXExpression, fp int) {
 	windows[ReadStr(fp, expr.Inputs[0])].SetPos(
 		int(ReadI32(fp, expr.Inputs[1])),
 		int(ReadI32(fp, expr.Inputs[2])))
 }
 
-func opGlfwShouldClose(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwShouldClose(expr *CXExpression, fp int) {
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), windows[ReadStr(fp, expr.Inputs[0])].ShouldClose())
 }
 
-func opGlfwGetFramebufferSize(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwGetFramebufferSize(expr *CXExpression, fp int) {
 	width, height := windows[ReadStr(fp, expr.Inputs[0])].GetFramebufferSize()
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(width))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[1]), int32(height))
 }
 
-func opGlfwGetWindowPos(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwGetWindowPos(expr *CXExpression, fp int) {
 	x, y := windows[ReadStr(fp, expr.Inputs[0])].GetPos()
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(x))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[1]), int32(y))
 }
 
-func opGlfwGetWindowSize(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwGetWindowSize(expr *CXExpression, fp int) {
 	width, height := windows[ReadStr(fp, expr.Inputs[0])].GetSize()
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(width))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[1]), int32(height))
 }
 
-func opGlfwSwapInterval(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwSwapInterval(expr *CXExpression, fp int) {
 	glfw.SwapInterval(int(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlfwPollEvents(_ *CXProgram) {
+func opGlfwPollEvents(expr *CXExpression, fp int) {
 	if initialized {
 		glfw.PollEvents()
 	}
 	PollEvents()
 }
 
-func opGlfwGetTime(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwGetTime(expr *CXExpression, fp int) {
 	out1 := expr.Outputs[0]
 	WriteF64(GetFinalOffset(fp, out1), glfw.GetTime())
 }
 
-func glfwSetKeyCallback(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
+func glfwSetKeyCallback(expr *CXExpression, fp int) {
 	window := ReadStr(fp, expr.Inputs[0])
 	windows[window].SetKeyCallback(
 		func(w *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
@@ -193,9 +140,7 @@ func glfwSetKeyCallback(prgrm *CXProgram) {
 		})
 }
 
-func glfwSetCursorPosCallback(prgrm *CXProgram, eventType EventType) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
+func glfwSetCursorPosCallback(expr *CXExpression, fp int, eventType EventType) {
 	window := ReadStr(fp, expr.Inputs[0])
 	windows[window].SetCursorPosCallback(
 		func(w *glfw.Window, xpos float64, ypos float64) {
@@ -203,9 +148,7 @@ func glfwSetCursorPosCallback(prgrm *CXProgram, eventType EventType) {
 		})
 }
 
-func glfwSetMouseButtonCallback(prgrm *CXProgram, eventType EventType) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
+func glfwSetMouseButtonCallback(expr *CXExpression, fp int, eventType EventType) {
 	window := ReadStr(fp, expr.Inputs[0])
 	windows[window].SetMouseButtonCallback(
 		func(w *glfw.Window, key glfw.MouseButton, action glfw.Action, mods glfw.ModifierKey) {
@@ -214,81 +157,72 @@ func glfwSetMouseButtonCallback(prgrm *CXProgram, eventType EventType) {
 		})
 }
 
-func opGlfwSetKeyCallback(prgrm *CXProgram) { // TODO : to deprecate
-	glfwSetKeyCallback(prgrm)
-	appKeyboardCallback.Init(prgrm)
+func opGlfwSetKeyCallback(expr *CXExpression, fp int) { // TODO : to deprecate
+	glfwSetKeyCallback(expr, fp)
+	appKeyboardCallback.Init(expr, fp)
 }
 
-func opGlfwSetCursorPosCallback(prgrm *CXProgram) { // TODO : to deprecate
-	glfwSetCursorPosCallback(prgrm, APP_CURSOR_POS)
-	appCursorPositionCallback.Init(prgrm)
+func opGlfwSetCursorPosCallback(expr *CXExpression, fp int) { // TODO : to deprecate
+	glfwSetCursorPosCallback(expr, fp, APP_CURSOR_POS)
+	appCursorPositionCallback.Init(expr, fp)
 }
 
-func opGlfwSetMouseButtonCallback(prgrm *CXProgram) { // TODO : to deprecate
-	glfwSetMouseButtonCallback(prgrm, APP_MOUSE_BUTTON)
-	appMouseButtonCallback.Init(prgrm)
+func opGlfwSetMouseButtonCallback(expr *CXExpression, fp int) { // TODO : to deprecate
+	glfwSetMouseButtonCallback(expr, fp, APP_MOUSE_BUTTON)
+	appMouseButtonCallback.Init(expr, fp)
 }
 
-func opGlfwSetKeyboardCallback(prgrm *CXProgram) {
-	glfwSetKeyCallback(prgrm)
-	appKeyboardCallback.InitEx(prgrm)
+func opGlfwSetKeyboardCallback(expr *CXExpression, fp int) {
+	glfwSetKeyCallback(expr, fp)
+	appKeyboardCallback.InitEx(expr, fp)
 }
 
-func opGlfwSetMouseCallback(prgrm *CXProgram) {
-	glfwSetCursorPosCallback(prgrm, APP_MOUSE)
-	glfwSetMouseButtonCallback(prgrm, APP_MOUSE)
-	appMouseCallback.InitEx(prgrm)
+func opGlfwSetMouseCallback(expr *CXExpression, fp int) {
+	glfwSetCursorPosCallback(expr, fp, APP_MOUSE)
+	glfwSetMouseButtonCallback(expr, fp, APP_MOUSE)
+	appMouseCallback.InitEx(expr, fp)
 }
 
-func opGlfwSetFramebufferSizeCallback(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
+func opGlfwSetFramebufferSizeCallback(expr *CXExpression, fp int) {
 	window := ReadStr(fp, expr.Inputs[0])
 
 	windows[window].SetFramebufferSizeCallback(
 		func(w *glfw.Window, width int, height int) {
 			PushFramebufferSizeEvent(float64(width), float64(height)) // TODO : to deprecate, use float64
 		})
-	appFramebufferSizeCallback.InitEx(prgrm)
+	appFramebufferSizeCallback.InitEx(expr, fp)
 }
 
-func opGlfwSetWindowSizeCallback(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
+func opGlfwSetWindowSizeCallback(expr *CXExpression, fp int) {
 	window := ReadStr(fp, expr.Inputs[0])
 
 	windows[window].SetSizeCallback(
 		func(w *glfw.Window, width int, height int) {
 			PushWindowSizeEvent(float64(width), float64(height)) // TODO : to deprecate, use float64
 		})
-	appWindowSizeCallback.InitEx(prgrm)
+	appWindowSizeCallback.InitEx(expr, fp)
 }
 
-func opGlfwSetWindowPosCallback(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
+func opGlfwSetWindowPosCallback(expr *CXExpression, fp int) {
 	window := ReadStr(fp, expr.Inputs[0])
 
 	windows[window].SetPosCallback(
 		func(w *glfw.Window, x int, y int) {
 			PushWindowPositionEvent(float64(x), float64(y)) // TODO to deprecate, use float64
 		})
-	appWindowPosCallback.InitEx(prgrm)
+	appWindowPosCallback.InitEx(expr, fp)
 }
 
-func opGlfwSetStartCallback(prgrm *CXProgram) {
-	appStartCallback.InitEx(prgrm)
+func opGlfwSetStartCallback(expr *CXExpression, fp int) {
+	appStartCallback.InitEx(expr, fp)
 	PushEvent(APP_START)
 }
 
-func opGlfwSetStopCallback(prgrm *CXProgram) {
-	appStopCallback.InitEx(prgrm)
+func opGlfwSetStopCallback(expr *CXExpression, fp int) {
+	appStopCallback.InitEx(expr, fp)
 }
 
-func opGlfwSetShouldClose(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwSetShouldClose(expr *CXExpression, fp int) {
 	shouldClose := ReadBool(fp, expr.Inputs[1])
 	windows[ReadStr(fp, expr.Inputs[0])].SetShouldClose(shouldClose)
 }

--- a/cxfx/op_glfw_mobile.go
+++ b/cxfx/op_glfw_mobile.go
@@ -15,165 +15,138 @@ func SetGOApp(a app.App) {
 	goapp = a
 }
 
-func opGlfwFullscreen(prgrm *CXProgram) {
+func opGlfwFullscreen(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlfwInit(prgrm *CXProgram) {
+func opGlfwInit(expr *CXExpression, fp int) {
 	goapp.CreateSurface()
 }
 
-func opGlfwSwapBuffers(prgrm *CXProgram) {
+func opGlfwSwapBuffers(expr *CXExpression, fp int) {
 	goapp.SwapBuffers()
 }
 
-func opGlfwMakeContextCurrent(prgrm *CXProgram) {
+func opGlfwMakeContextCurrent(expr *CXExpression, fp int) {
 	goapp.MakeCurrent()
 }
 
-func opGlfwWindowHint(prgrm *CXProgram) {
+func opGlfwWindowHint(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlfwSetInputMode(prgrm *CXProgram) {
+func opGlfwSetInputMode(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlfwGetCursorPos(prgrm *CXProgram) {
+func opGlfwGetCursorPos(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), 0.0)
 	WriteF64(GetFinalOffset(fp, expr.Outputs[1]), 0.0)
 }
 
-func opGlfwGetKey(prgrm *CXProgram) {
+func opGlfwGetKey(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), 0)
 }
 
-func opGlfwCreateWindow(prgrm *CXProgram) {
+func opGlfwCreateWindow(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlfwGetWindowContentScale(prgrm *CXProgram) {
+func opGlfwGetWindowContentScale(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), 1.0)
 	WriteF32(GetFinalOffset(fp, expr.Outputs[1]), 1.0)
 }
 
-func opGlfwGetMonitorContentScale(prgrm *CXProgram) {
+func opGlfwGetMonitorContentScale(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), 1.0)
 	WriteF32(GetFinalOffset(fp, expr.Outputs[1]), 1.0)
 }
 
-func opGlfwSetWindowPos(prgrm *CXProgram) {
+func opGlfwSetWindowPos(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlfwShouldClose(prgrm *CXProgram) {
+func opGlfwShouldClose(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), false)
 }
 
-func opGlfwGetFramebufferSize(prgrm *CXProgram) {
+func opGlfwGetFramebufferSize(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	width, height := goapp.GetWindowSize()
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(width))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[1]), int32(height))
 }
 
-func opGlfwGetWindowPos(prgrm *CXProgram) {
+func opGlfwGetWindowPos(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), 0)
 	WriteI32(GetFinalOffset(fp, expr.Outputs[1]), 0)
 }
 
-func opGlfwGetWindowSize(prgrm *CXProgram) {
+func opGlfwGetWindowSize(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	width, height := goapp.GetWindowSize()
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(width))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[1]), int32(height))
 }
 
-func opGlfwSwapInterval(prgrm *CXProgram) {
+func opGlfwSwapInterval(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opGlfwPollEvents(prgrm *CXProgram) {
+func opGlfwPollEvents(expr *CXExpression, fp int) {
 	PollEvents()
 }
 
-func opGlfwGetTime(prgrm *CXProgram) {
+func opGlfwGetTime(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), 0.0)
 }
 
-func opGlfwSetKeyCallback(prgrm *CXProgram) { // TODO : to deprecate
+func opGlfwSetKeyCallback(expr *CXExpression, fp int) { // TODO : to deprecate
 	appKeyboardCallback.Init(prgrm)
 }
 
-func opGlfwSetCursorPosCallback(prgrm *CXProgram) { // TODO : to deprecate
+func opGlfwSetCursorPosCallback(expr *CXExpression, fp int) { // TODO : to deprecate
 	appCursorPositionCallback.Init(prgrm)
 }
 
-func opGlfwSetMouseButtonCallback(prgrm *CXProgram) { // TODO : to deprecate
+func opGlfwSetMouseButtonCallback(expr *CXExpression, fp int) { // TODO : to deprecate
 	appMouseButtonCallback.Init(prgrm)
 }
 
-func opGlfwSetKeyboardCallback(prgrm *CXProgram) {
+func opGlfwSetKeyboardCallback(expr *CXExpression, fp int) {
 	appKeyboardCallback.InitEx(prgrm)
 }
 
-func opGlfwSetMouseCallback(prgrm *CXProgram) {
+func opGlfwSetMouseCallback(expr *CXExpression, fp int) {
 	appMouseCallback.InitEx(prgrm)
 }
 
-func opGlfwSetFramebufferSizeCallback(prgrm *CXProgram) {
+func opGlfwSetFramebufferSizeCallback(expr *CXExpression, fp int) {
 	appFramebufferSizeCallback.InitEx(prgrm)
 }
 
-func opGlfwSetWindowSizeCallback(prgrm *CXProgram) {
+func opGlfwSetWindowSizeCallback(expr *CXExpression, fp int) {
 	appWindowSizeCallback.InitEx(prgrm)
 }
 
-func opGlfwSetWindowPosCallback(prgrm *CXProgram) {
+func opGlfwSetWindowPosCallback(expr *CXExpression, fp int) {
 	appWindowPosCallback.InitEx(prgrm)
 }
 
-func opGlfwSetStartCallback(prgrm *CXProgram) {
+func opGlfwSetStartCallback(expr *CXExpression, fp int) {
 	appStartCallback.InitEx(prgrm)
 }
 
-func opGlfwSetStopCallback(prgrm *CXProgram) {
+func opGlfwSetStopCallback(expr *CXExpression, fp int) {
 	appStopCallback.InitEx(prgrm)
 }
-func opGlfwSetShouldClose(prgrm *CXProgram) {
+func opGlfwSetShouldClose(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }

--- a/cxfx/op_gltext.go
+++ b/cxfx/op_gltext.go
@@ -13,10 +13,7 @@ import (
 
 var fonts map[string]*gltext.Font = make(map[string]*gltext.Font, 0)
 
-func loadTrueType(prgrm *CXProgram, fixedPipeline bool) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func loadTrueType(expr *CXExpression, fp int, fixedPipeline bool) {
 	inp1, inp2, inp3, inp4, inp5, inp6 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Inputs[3], expr.Inputs[4], expr.Inputs[5]
 	if file := ValidFile(ReadI32(fp, inp1)); file != nil {
 		if theFont, err := gltext.LoadTruetype(file, ReadI32(fp, inp3), rune(ReadI32(fp, inp4)), rune(ReadI32(fp, inp5)), gltext.Direction(ReadI32(fp, inp6)), fixedPipeline); err == nil {
@@ -25,18 +22,15 @@ func loadTrueType(prgrm *CXProgram, fixedPipeline bool) {
 	}
 }
 
-func opGltextLoadTrueType(prgrm *CXProgram) {
-	loadTrueType(prgrm, true)
+func opGltextLoadTrueType(expr *CXExpression, fp int) {
+	loadTrueType(expr, fp, true)
 }
 
-func opGltextLoadTrueTypeCore(prgrm *CXProgram) {
-	loadTrueType(prgrm, false)
+func opGltextLoadTrueTypeCore(expr *CXExpression, fp int) {
+	loadTrueType(expr, fp, false)
 }
 
-func opGltextPrintf(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGltextPrintf(expr *CXExpression, fp int) {
 	inp1, inp2, inp3, inp4 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2], expr.Inputs[3]
 
 	if err := fonts[ReadStr(fp, inp1)].Printf(ReadF32(fp, inp2), ReadF32(fp, inp3), ReadStr(fp, inp4)); err != nil {
@@ -44,10 +38,7 @@ func opGltextPrintf(prgrm *CXProgram) {
 	}
 }
 
-func opGltextMetrics(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGltextMetrics(expr *CXExpression, fp int) {
 	inp1, inp2, out1, out2 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0], expr.Outputs[1]
 
 	width, height := fonts[ReadStr(fp, inp1)].Metrics(ReadStr(fp, inp2))
@@ -56,18 +47,12 @@ func opGltextMetrics(prgrm *CXProgram) {
 	WriteI32(GetFinalOffset(fp, out2), int32(height))
 }
 
-func opGltextTexture(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGltextTexture(expr *CXExpression, fp int) {
 	inp1, out1 := expr.Inputs[0], expr.Outputs[0]
 	WriteI32(GetFinalOffset(fp, out1), int32(fonts[ReadStr(fp, inp1)].Texture()))
 }
 
-func opGltextNextGlyph(prgrm *CXProgram) { // refactor
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGltextNextGlyph(expr *CXExpression, fp int) { // refactor
 	inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
 	out1, out2, out3, out4, out5, out6, out7 := expr.Outputs[0], expr.Outputs[1], expr.Outputs[2], expr.Outputs[3], expr.Outputs[4], expr.Outputs[5], expr.Outputs[6]
 	font := fonts[ReadStr(fp, inp1)]
@@ -99,10 +84,7 @@ func opGltextNextGlyph(prgrm *CXProgram) { // refactor
 	WriteI32(GetFinalOffset(fp, out7), int32(advance))
 }
 
-func opGltextGlyphBounds(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGltextGlyphBounds(expr *CXExpression, fp int) {
 	inp1, out1, out2 := expr.Inputs[0], expr.Outputs[0], expr.Outputs[1]
 	font := fonts[ReadStr(fp, inp1)]
 	var maxGlyphWidth, maxGlyphHeight int = font.GlyphBounds()
@@ -110,10 +92,7 @@ func opGltextGlyphBounds(prgrm *CXProgram) {
 	WriteI32(GetFinalOffset(fp, out2), int32(maxGlyphHeight))
 }
 
-func opGltextGlyphMetrics(prgrm *CXProgram) { // refactor
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGltextGlyphMetrics(expr *CXExpression, fp int) { // refactor
 	inp1, inp2, out1, out2 := expr.Inputs[0], expr.Inputs[1], expr.Outputs[0], expr.Outputs[1]
 
 	width, height := fonts[ReadStr(fp, inp1)].GlyphMetrics(uint32(ReadI32(fp, inp2)))
@@ -122,10 +101,7 @@ func opGltextGlyphMetrics(prgrm *CXProgram) { // refactor
 	WriteI32(GetFinalOffset(fp, out2), int32(height))
 }
 
-func opGltextGlyphInfo(prgrm *CXProgram) { // refactor
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGltextGlyphInfo(expr *CXExpression, fp int) { // refactor
 	inp1, inp2 := expr.Inputs[0], expr.Inputs[1]
 	out1, out2, out3, out4, out5 := expr.Outputs[0], expr.Outputs[1], expr.Outputs[2], expr.Outputs[3], expr.Outputs[4]
 	font := fonts[ReadStr(fp, inp1)]

--- a/cxfx/op_openal.go
+++ b/cxfx/op_openal.go
@@ -12,10 +12,7 @@ import (
 	//"golang.org/x/mobile/exp/audio/al"
 )
 
-func opAlLoadWav(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlLoadWav(expr *CXExpression, fp int) {
 	file, err := CXOpenFile(ReadStr(fp, expr.Inputs[0]))
 	defer file.Close()
 	if err != nil {
@@ -76,116 +73,77 @@ func toBytes(in interface{}) []byte { // REFACTOR : ??
 	return out
 }*/
 
-/*func opAlCloseDevice(_ *CXProgram) {
+/*func opAlCloseDevice(expr *CXExpression, fp int) {
 	al.CloseDevice()
 }
 
-func opAlDeleteBuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlDeleteBuffers(expr *CXExpression, fp int) {
 	buffers := toBuffers(ReadData(fp, expr.Inputs[0], TYPE_I32))
 	al.DeleteBuffers(buffers...)
 }
 
-func opAlDeleteSources(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlDeleteSources(expr *CXExpression, fp int) {
 	sources := toSources(ReadData(fp, expr.Inputs[0], TYPE_I32))
 	al.DeleteSources(sources...)
 }
 
-func opAlDeviceError(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlDeviceError(expr *CXExpression, fp int) {
 	err := al.DeviceError()
 	WriteMemory(GetFinalOffset(fp, expr.Outputs[0]), FromI32(err))
 }
 
-func opAlError(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlError(expr *CXExpression, fp int) {
 	err := al.Error()
 	WriteMemory(GetFinalOffset(fp, expr.Outputs[0]), FromI32(err))
 }
 
-func opAlExtensions(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlExtensions(expr *CXExpression, fp int) {
 	extensions := al.Extensions()
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr(extensions))
 }
 
-func opAlOpenDevice(_ *CXProgram) {
+func opAlOpenDevice(expr *CXExpression, fp int) {
 	if err := al.OpenDevice(); err != nil {
 		panic(err)
 	}
 }
 
-func opAlPauseSources(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlPauseSources(expr *CXExpression, fp int) {
 	sources := toSources(ReadData(fp, expr.Inputs[0], TYPE_I32))
 	al.PauseSources(sources...)
 }
 
-func opAlPlaySources(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlPlaySources(expr *CXExpression, fp int) {
 	sources := toSources(ReadData(fp, expr.Inputs[0], TYPE_I32))
 	al.PlaySources(sources...)
 }
 
-func opAlRenderer(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlRenderer(expr *CXExpression, fp int) {
 	renderer := al.Renderer()
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr(renderer))
 }
 
-func opAlRewindSources(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlRewindSources(expr *CXExpression, fp int) {
 	sources := toSources(ReadData(fp, expr.Inputs[0], TYPE_I32))
 	al.RewindSources(sources...)
 }
 
-func opAlStopSources(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlStopSources(expr *CXExpression, fp int) {
 	sources := toSources(ReadData(fp, expr.Inputs[0], TYPE_I32))
 	al.StopSources(sources...)
 }
 
-func opAlVendor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlVendor(expr *CXExpression, fp int) {
 	vendor := al.Vendor()
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr(vendor))
 }
 
-func opAlVersion(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlVersion(expr *CXExpression, fp int) {
 	version := al.Version()
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr(version))
 }
 
-func opAlGenBuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlGenBuffers(expr *CXExpression, fp int) {
 	buffers := al.GenBuffers(int(ReadI32(fp, expr.Inputs[0])))
 	outputSlice := expr.Outputs[0]
 	outputSlicePointer := GetFinalOffset(fp, outputSlice)
@@ -197,10 +155,7 @@ func opAlGenBuffers(prgrm *CXProgram) {
 	copy(PROGRAM.Memory[outputSlicePointer:], FromI32(outputSliceOffset))
 }
 
-func opAlBufferData(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlBufferData(expr *CXExpression, fp int) {
 	buffer := al.Buffer(ReadI32(fp, expr.Inputs[0]))
 	format := ReadI32(fp, expr.Inputs[1])
 	data := toBytes(ReadData(fp, expr.Inputs[2], TYPE_UI8))
@@ -208,10 +163,7 @@ func opAlBufferData(prgrm *CXProgram) {
 	buffer.BufferData(uint32(format), data, frequency)
 }
 
-func opAlGenSources(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlGenSources(expr *CXExpression, fp int) {
 	sources := al.GenSources(int(ReadI32(fp, expr.Inputs[0])))
 	outputSlice := expr.Outputs[0]
 	outputSlicePointer := GetFinalOffset(fp, outputSlice)
@@ -223,43 +175,28 @@ func opAlGenSources(prgrm *CXProgram) {
 	copy(PROGRAM.Memory[outputSlicePointer:], FromI32(outputSliceOffset))
 }
 
-func opAlSourceBuffersProcessed(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlSourceBuffersProcessed(expr *CXExpression, fp int) {
 	source := al.Source(ReadI32(fp, expr.Inputs[0]))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromI32(source.BuffersProcessed()))
 }
 
-func opAlSourceBuffersQueued(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlSourceBuffersQueued(expr *CXExpression, fp int) {
 	source := al.Source(ReadI32(fp, expr.Inputs[0]))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromI32(source.BuffersQueued()))
 }
 
-func opAlSourceQueueBuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlSourceQueueBuffers(expr *CXExpression, fp int) {
 	source := al.Source(ReadI32(fp, expr.Inputs[0]))
 	buffers := toBuffers(ReadData(fp, expr.Inputs[1], TYPE_I32))
 	source.QueueBuffers(buffers...)
 }
 
-func opAlSourceState(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlSourceState(expr *CXExpression, fp int) {
 	source := al.Source(ReadI32(fp, expr.Inputs[0]))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromI32(source.State()))
 }
 
-func opAlSourceUnqueueBuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlSourceUnqueueBuffers(expr *CXExpression, fp int) {
 	source := al.Source(ReadI32(fp, expr.Inputs[0]))
 	buffers := toBuffers(ReadData(fp, expr.Inputs[1], TYPE_I32))
 	source.UnqueueBuffers(buffers...)

--- a/cxfx/op_openal_desktop.go
+++ b/cxfx/op_openal_desktop.go
@@ -10,10 +10,7 @@ import (
 	"golang.org/x/mobile/exp/audio/al"
 )
 
-/*func opAlLoadWav(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+/*func opAlLoadWav(expr *CXExpression, fp int) {
 	file, err := CXOpenFile(ReadStr(fp, expr.Inputs[0]))
 	defer file.Close()
 	if err != nil {
@@ -74,116 +71,77 @@ func toSources(in interface{}) []al.Source { // REFACTOR : ??
 	return out
 }
 
-func opAlCloseDevice(_ *CXProgram) {
+func opAlCloseDevice(expr *CXExpression, fp int) {
 	al.CloseDevice()
 }
 
-func opAlDeleteBuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlDeleteBuffers(expr *CXExpression, fp int) {
 	buffers := toBuffers(ReadData(fp, expr.Inputs[0], TYPE_I32))
 	al.DeleteBuffers(buffers...)
 }
 
-func opAlDeleteSources(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlDeleteSources(expr *CXExpression, fp int) {
 	sources := toSources(ReadData(fp, expr.Inputs[0], TYPE_I32))
 	al.DeleteSources(sources...)
 }
 
-func opAlDeviceError(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlDeviceError(expr *CXExpression, fp int) {
 	err := al.DeviceError()
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), err)
 }
 
-func opAlError(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlError(expr *CXExpression, fp int) {
 	err := al.Error()
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), err)
 }
 
-func opAlExtensions(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlExtensions(expr *CXExpression, fp int) {
 	extensions := al.Extensions()
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr(extensions))
 }
 
-func opAlOpenDevice(_ *CXProgram) {
+func opAlOpenDevice(expr *CXExpression, fp int) {
 	if err := al.OpenDevice(); err != nil {
 		panic(err)
 	}
 }
 
-func opAlPauseSources(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlPauseSources(expr *CXExpression, fp int) {
 	sources := toSources(ReadData(fp, expr.Inputs[0], TYPE_I32))
 	al.PauseSources(sources...)
 }
 
-func opAlPlaySources(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlPlaySources(expr *CXExpression, fp int) {
 	sources := toSources(ReadData(fp, expr.Inputs[0], TYPE_I32))
 	al.PlaySources(sources...)
 }
 
-func opAlRenderer(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlRenderer(expr *CXExpression, fp int) {
 	renderer := al.Renderer()
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr(renderer))
 }
 
-func opAlRewindSources(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlRewindSources(expr *CXExpression, fp int) {
 	sources := toSources(ReadData(fp, expr.Inputs[0], TYPE_I32))
 	al.RewindSources(sources...)
 }
 
-func opAlStopSources(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlStopSources(expr *CXExpression, fp int) {
 	sources := toSources(ReadData(fp, expr.Inputs[0], TYPE_I32))
 	al.StopSources(sources...)
 }
 
-func opAlVendor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlVendor(expr *CXExpression, fp int) {
 	vendor := al.Vendor()
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr(vendor))
 }
 
-func opAlVersion(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlVersion(expr *CXExpression, fp int) {
 	version := al.Version()
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr(version))
 }
 
-func opAlGenBuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlGenBuffers(expr *CXExpression, fp int) {
 	buffers := al.GenBuffers(int(ReadI32(fp, expr.Inputs[0])))
 	outputSlice := expr.Outputs[0]
 	outputSlicePointer := GetFinalOffset(fp, outputSlice)
@@ -196,10 +154,7 @@ func opAlGenBuffers(prgrm *CXProgram) {
 	//copy(PROGRAM.Memory[outputSlicePointer:], FromI32(outputSliceOffset))
 }
 
-func opAlBufferData(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlBufferData(expr *CXExpression, fp int) {
 	buffer := al.Buffer(ReadI32(fp, expr.Inputs[0]))
 	format := ReadI32(fp, expr.Inputs[1])
 	data := toBytes(ReadData(fp, expr.Inputs[2], TYPE_UI8))
@@ -207,10 +162,7 @@ func opAlBufferData(prgrm *CXProgram) {
 	buffer.BufferData(uint32(format), data, frequency)
 }
 
-func opAlGenSources(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlGenSources(expr *CXExpression, fp int) {
 	sources := al.GenSources(int(ReadI32(fp, expr.Inputs[0])))
 	outputSlice := expr.Outputs[0]
 	outputSlicePointer := GetFinalOffset(fp, outputSlice)
@@ -223,43 +175,28 @@ func opAlGenSources(prgrm *CXProgram) {
 	//copy(PROGRAM.Memory[outputSlicePointer:], FromI32(outputSliceOffset))
 }
 
-func opAlSourceBuffersProcessed(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlSourceBuffersProcessed(expr *CXExpression, fp int) {
 	source := al.Source(ReadI32(fp, expr.Inputs[0]))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromI32(source.BuffersProcessed()))
 }
 
-func opAlSourceBuffersQueued(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlSourceBuffersQueued(expr *CXExpression, fp int) {
 	source := al.Source(ReadI32(fp, expr.Inputs[0]))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromI32(source.BuffersQueued()))
 }
 
-func opAlSourceQueueBuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlSourceQueueBuffers(expr *CXExpression, fp int) {
 	source := al.Source(ReadI32(fp, expr.Inputs[0]))
 	buffers := toBuffers(ReadData(fp, expr.Inputs[1], TYPE_I32))
 	source.QueueBuffers(buffers...)
 }
 
-func opAlSourceState(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlSourceState(expr *CXExpression, fp int) {
 	source := al.Source(ReadI32(fp, expr.Inputs[0]))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromI32(source.State()))
 }
 
-func opAlSourceUnqueueBuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opAlSourceUnqueueBuffers(expr *CXExpression, fp int) {
 	source := al.Source(ReadI32(fp, expr.Inputs[0]))
 	buffers := toBuffers(ReadData(fp, expr.Inputs[1], TYPE_I32))
 	source.UnqueueBuffers(buffers...)

--- a/cxfx/op_openal_mobile.go
+++ b/cxfx/op_openal_mobile.go
@@ -9,128 +9,104 @@ import (
 	  "github.com/mjibson/go-dsp/wav"
 	  "golang.org/x/mobile/exp/audio/al"*/)
 
-func opAlCloseDevice(_ *CXProgram) {
+func opAlCloseDevice(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opAlDeleteBuffers(prgrm *CXProgram) {
+func opAlDeleteBuffers(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opAlDeleteSources(prgrm *CXProgram) {
+func opAlDeleteSources(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opAlDeviceError(prgrm *CXProgram) {
+func opAlDeviceError(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), 0)
 }
 
-func opAlError(prgrm *CXProgram) {
+func opAlError(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), 0)
 }
 
-func opAlExtensions(prgrm *CXProgram) {
+func opAlExtensions(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr("CX_RUNTIME_NOT_IMPLEMENTED"))
 }
 
-func opAlOpenDevice(_ *CXProgram) {
+func opAlOpenDevice(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opAlPauseSources(prgrm *CXProgram) {
+func opAlPauseSources(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opAlPlaySources(prgrm *CXProgram) {
+func opAlPlaySources(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opAlRenderer(prgrm *CXProgram) {
+func opAlRenderer(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr("CX_RUNTIME_NOT_IMPLEMENTED"))
 }
 
-func opAlRewindSources(prgrm *CXProgram) {
+func opAlRewindSources(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opAlStopSources(prgrm *CXProgram) {
+func opAlStopSources(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opAlVendor(prgrm *CXProgram) {
+func opAlVendor(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr("CX_RUNTIME_NOT_IMPLEMENTED"))
 }
 
-func opAlVersion(prgrm *CXProgram) {
+func opAlVersion(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr("CX_RUNTIME_NOT_IMPLEMENTED"))
 }
 
-func opAlGenBuffers(prgrm *CXProgram) {
+func opAlGenBuffers(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	outputSlice := expr.Outputs[0]
 	outputSlicePointer := GetFinalOffset(fp, outputSlice)
 	outputSliceOffset := GetPointerOffset(int32(outputSlicePointer))
 	WriteI32(outputSlicePointer, outputSliceOffset)
 }
 
-func opAlBufferData(prgrm *CXProgram) {
+func opAlBufferData(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opAlGenSources(prgrm *CXProgram) {
+func opAlGenSources(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
 	outputSlice := expr.Outputs[0]
 	outputSlicePointer := GetFinalOffset(fp, outputSlice)
 	outputSliceOffset := GetPointerOffset(int32(outputSlicePointer))
 	WriteI32(outputSlicePointer, outputSliceOffset)
 }
 
-func opAlSourceBuffersProcessed(prgrm *CXProgram) {
+func opAlSourceBuffersProcessed(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opAlSourceBuffersQueued(prgrm *CXProgram) {
+func opAlSourceBuffersQueued(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opAlSourceQueueBuffers(prgrm *CXProgram) {
+func opAlSourceQueueBuffers(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opAlSourceState(prgrm *CXProgram) {
+func opAlSourceState(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }
 
-func opAlSourceUnqueueBuffers(prgrm *CXProgram) {
+func opAlSourceUnqueueBuffers(expr *CXExpression, fp int) {
 	//panic(CX_RUNTIME_NOT_IMPLEMENTED)
 }

--- a/cxfx/op_opengl.go
+++ b/cxfx/op_opengl.go
@@ -273,10 +273,7 @@ func uploadTexture(path string, target uint32, level uint32, cpuCopy bool) {
 }
 
 // gogl
-func opGlNewTexture(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlNewTexture(expr *CXExpression, fp int) {
 	var texture uint32
 	cxglEnable(cxglTEXTURE_2D)
 	cxglGenTextures(1, &texture)
@@ -291,10 +288,7 @@ func opGlNewTexture(prgrm *CXProgram) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(texture))
 }
 
-func opGlNewTextureCube(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlNewTextureCube(expr *CXExpression, fp int) {
 	var texture uint32
 	cxglEnable(cxglTEXTURE_CUBE_MAP)
 	cxglGenTextures(1, &texture)
@@ -314,17 +308,11 @@ func opGlNewTextureCube(prgrm *CXProgram) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(texture))
 }
 
-func opCxReleaseTexture(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opCxReleaseTexture(expr *CXExpression, fp int) {
 	textures[ReadStr(fp, expr.Inputs[0])] = Texture{}
 }
 
-func opCxTextureGetPixel(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opCxTextureGetPixel(expr *CXExpression, fp int) {
 	var r float32
 	var g float32
 	var b float32
@@ -348,17 +336,11 @@ func opCxTextureGetPixel(prgrm *CXProgram) {
 	WriteF32(GetFinalOffset(fp, expr.Outputs[3]), a)
 }
 
-func opGlUploadImageToTexture(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUploadImageToTexture(expr *CXExpression, fp int) {
 	uploadTexture(ReadStr(fp, expr.Inputs[0]), uint32(ReadI32(fp, expr.Inputs[1])), uint32(ReadI32(fp, expr.Inputs[2])), ReadBool(fp, expr.Inputs[3]))
 }
 
-func opGlNewGIF(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlNewGIF(expr *CXExpression, fp int) {
 	path := ReadStr(fp, expr.Inputs[0])
 
 	file, err := CXOpenFile(path)
@@ -381,17 +363,11 @@ func opGlNewGIF(prgrm *CXProgram) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[3]), int32(gif.Config.Height))
 }
 
-func opGlFreeGIF(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlFreeGIF(expr *CXExpression, fp int) {
 	gifs[ReadStr(fp, expr.Inputs[0])] = nil
 }
 
-func opGlGIFFrameToTexture(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGIFFrameToTexture(expr *CXExpression, fp int) {
 	path := ReadStr(fp, expr.Inputs[0])
 	frame := ReadI32(fp, expr.Inputs[1])
 	texture := ReadI32(fp, expr.Inputs[2])
@@ -420,10 +396,7 @@ func opGlGIFFrameToTexture(prgrm *CXProgram) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[1]), disposal)
 }
 
-func opGlAppend(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlAppend(expr *CXExpression, fp int) {
 	outputSlicePointer := GetFinalOffset(fp, expr.Outputs[0])
 	outputSliceOffset := GetPointerOffset(int32(outputSlicePointer))
 
@@ -444,33 +417,21 @@ func opGlAppend(prgrm *CXProgram) {
 }
 
 // gl_1_0
-func opGlCullFace(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlCullFace(expr *CXExpression, fp int) {
 	cxglCullFace(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlFrontFace(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlFrontFace(expr *CXExpression, fp int) {
 	cxglFrontFace(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlHint(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlHint(expr *CXExpression, fp int) {
 	cxglHint(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])))
 }
 
-func opGlScissor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlScissor(expr *CXExpression, fp int) {
 	cxglScissor(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
@@ -478,20 +439,14 @@ func opGlScissor(prgrm *CXProgram) {
 		ReadI32(fp, expr.Inputs[3]))
 }
 
-func opGlTexParameteri(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlTexParameteri(expr *CXExpression, fp int) {
 	cxglTexParameteri(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])),
 		ReadI32(fp, expr.Inputs[2]))
 }
 
-func opGlTexImage2D(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlTexImage2D(expr *CXExpression, fp int) {
 	cxglTexImage2D(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		ReadI32(fp, expr.Inputs[1]),
@@ -504,17 +459,11 @@ func opGlTexImage2D(prgrm *CXProgram) {
 		ReadData(fp, expr.Inputs[8], -1))
 }
 
-func opGlClear(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlClear(expr *CXExpression, fp int) {
 	cxglClear(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlClearColor(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlClearColor(expr *CXExpression, fp int) {
 	cxglClearColor(
 		ReadF32(fp, expr.Inputs[0]),
 		ReadF32(fp, expr.Inputs[1]),
@@ -522,31 +471,19 @@ func opGlClearColor(prgrm *CXProgram) {
 		ReadF32(fp, expr.Inputs[3]))
 }
 
-func opGlClearStencil(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlClearStencil(expr *CXExpression, fp int) {
 	cxglClearStencil(ReadI32(fp, expr.Inputs[0]))
 }
 
-func opGlClearDepth(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlClearDepth(expr *CXExpression, fp int) {
 	cxglClearDepth(ReadF64(fp, expr.Inputs[0]))
 }
 
-func opGlStencilMask(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlStencilMask(expr *CXExpression, fp int) {
 	cxglStencilMask(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlColorMask(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlColorMask(expr *CXExpression, fp int) {
 	cxglColorMask(
 		ReadBool(fp, expr.Inputs[0]),
 		ReadBool(fp, expr.Inputs[1]),
@@ -554,73 +491,47 @@ func opGlColorMask(prgrm *CXProgram) {
 		ReadBool(fp, expr.Inputs[3]))
 }
 
-func opGlDepthMask(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDepthMask(expr *CXExpression, fp int) {
 	cxglDepthMask(ReadBool(fp, expr.Inputs[0]))
 }
 
-func opGlDisable(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
+func opGlDisable(expr *CXExpression, fp int) {
 	cxglDisable(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlEnable(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlEnable(expr *CXExpression, fp int) {
 	cxglEnable(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlBlendFunc(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlBlendFunc(expr *CXExpression, fp int) {
 	cxglBlendFunc(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])))
 }
 
-func opGlStencilFunc(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlStencilFunc(expr *CXExpression, fp int) {
 	cxglStencilFunc(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		ReadI32(fp, expr.Inputs[1]),
 		uint32(ReadI32(fp, expr.Inputs[2])))
 }
 
-func opGlStencilOp(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlStencilOp(expr *CXExpression, fp int) {
 	cxglStencilOp(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])),
 		uint32(ReadI32(fp, expr.Inputs[2])))
 }
 
-func opGlDepthFunc(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDepthFunc(expr *CXExpression, fp int) {
 	cxglDepthFunc(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlGetError(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGetError(expr *CXExpression, fp int) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(cxglGetError()))
 }
 
-func opGlGetTexLevelParameteriv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGetTexLevelParameteriv(expr *CXExpression, fp int) {
 	var outValue int32 = 0
 	cxglGetTexLevelParameteriv(
 		uint32(ReadI32(fp, expr.Inputs[0])),
@@ -630,19 +541,13 @@ func opGlGetTexLevelParameteriv(prgrm *CXProgram) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outValue)
 }
 
-func opGlDepthRange(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDepthRange(expr *CXExpression, fp int) {
 	cxglDepthRange(
 		ReadF64(fp, expr.Inputs[0]),
 		ReadF64(fp, expr.Inputs[1]))
 }
 
-func opGlViewport(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlViewport(expr *CXExpression, fp int) {
 	cxglViewport(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
@@ -651,20 +556,14 @@ func opGlViewport(prgrm *CXProgram) {
 }
 
 // gl_1_1
-func opGlDrawArrays(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDrawArrays(expr *CXExpression, fp int) {
 	cxglDrawArrays(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		ReadI32(fp, expr.Inputs[1]),
 		ReadI32(fp, expr.Inputs[2]))
 }
 
-func opGlDrawElements(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDrawElements(expr *CXExpression, fp int) {
 	cxglDrawElements(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		ReadI32(fp, expr.Inputs[1]),
@@ -672,45 +571,30 @@ func opGlDrawElements(prgrm *CXProgram) {
 		ReadData(fp, expr.Inputs[3], -1))
 }
 
-func opGlBindTexture(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlBindTexture(expr *CXExpression, fp int) {
 	cxglBindTexture(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])))
 }
 
-func opGlDeleteTextures(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDeleteTextures(expr *CXExpression, fp int) {
 	inpV1 := uint32(ReadI32(fp, expr.Inputs[1]))
 	cxglDeleteTextures(ReadI32(fp, expr.Inputs[0]), &inpV1) // will panic if inp0 > 1
 }
 
-func opGlGenTextures(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGenTextures(expr *CXExpression, fp int) {
 	inpV1 := uint32(ReadI32(fp, expr.Inputs[1]))
 	cxglGenTextures(ReadI32(fp, expr.Inputs[0]), &inpV1) // will panic if inp0 > 1
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(inpV1))
 }
 
 // gl_1_3
-func opGlActiveTexture(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlActiveTexture(expr *CXExpression, fp int) {
 	cxglActiveTexture(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
 // gl_1_4
-func opGlBlendFuncSeparate(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlBlendFuncSeparate(expr *CXExpression, fp int) {
 	cxglBlendFuncSeparate(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])),
@@ -719,29 +603,20 @@ func opGlBlendFuncSeparate(prgrm *CXProgram) {
 }
 
 // gl_1_5
-func opGlBindBuffer(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlBindBuffer(expr *CXExpression, fp int) {
 	cxglBindBuffer(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])))
 }
 
-func opGlDeleteBuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDeleteBuffers(expr *CXExpression, fp int) {
 	inpV1 := uint32(ReadI32(fp, expr.Inputs[1]))
 	cxglDeleteBuffers(
 		ReadI32(fp, expr.Inputs[0]),
 		&inpV1) // will panic if inp0 > 1
 }
 
-func opGlGenBuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGenBuffers(expr *CXExpression, fp int) {
 	inpV1 := uint32(ReadI32(fp, expr.Inputs[1]))
 	cxglGenBuffers(
 		ReadI32(fp, expr.Inputs[0]),
@@ -749,10 +624,7 @@ func opGlGenBuffers(prgrm *CXProgram) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(inpV1))
 }
 
-func opGlBufferData(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlBufferData(expr *CXExpression, fp int) {
 	cxglBufferData(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		int(ReadI32(fp, expr.Inputs[1])),
@@ -760,10 +632,7 @@ func opGlBufferData(prgrm *CXProgram) {
 		uint32(ReadI32(fp, expr.Inputs[3])))
 }
 
-func opGlBufferSubData(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlBufferSubData(expr *CXExpression, fp int) {
 	cxglBufferSubData(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		int(ReadI32(fp, expr.Inputs[1])),
@@ -771,19 +640,13 @@ func opGlBufferSubData(prgrm *CXProgram) {
 		ReadData(fp, expr.Inputs[3], -1))
 }
 
-func opGlDrawBuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDrawBuffers(expr *CXExpression, fp int) {
 	cxglDrawBuffers(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadData(fp, expr.Inputs[1], TYPE_UI32))
 }
 
-func opGlStencilOpSeparate(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlStencilOpSeparate(expr *CXExpression, fp int) {
 	cxglStencilOpSeparate(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])),
@@ -791,10 +654,7 @@ func opGlStencilOpSeparate(prgrm *CXProgram) {
 		uint32(ReadI32(fp, expr.Inputs[3])))
 }
 
-func opGlStencilFuncSeparate(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlStencilFuncSeparate(expr *CXExpression, fp int) {
 	cxglStencilFuncSeparate(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])),
@@ -802,195 +662,129 @@ func opGlStencilFuncSeparate(prgrm *CXProgram) {
 		uint32(ReadI32(fp, expr.Inputs[3])))
 }
 
-func opGlStencilMaskSeparate(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlStencilMaskSeparate(expr *CXExpression, fp int) {
 	cxglStencilMaskSeparate(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])))
 }
 
-func opGlAttachShader(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlAttachShader(expr *CXExpression, fp int) {
 	cxglAttachShader(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])))
 }
 
-func opGlBindAttribLocation(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlBindAttribLocation(expr *CXExpression, fp int) {
 	cxglBindAttribLocation(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])),
 		ReadStr(fp, expr.Inputs[2]))
 }
 
-func opGlCompileShader(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlCompileShader(expr *CXExpression, fp int) {
 	shader := uint32(ReadI32(fp, expr.Inputs[0]))
 	cxglCompileShader(shader)
 }
 
-func opGlCreateProgram(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlCreateProgram(expr *CXExpression, fp int) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(cxglCreateProgram()))
 }
 
-func opGlCreateShader(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlCreateShader(expr *CXExpression, fp int) {
 	outV0 := int32(cxglCreateShader(uint32(ReadI32(fp, expr.Inputs[0]))))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
-func opGlDeleteProgram(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDeleteProgram(expr *CXExpression, fp int) {
 	cxglDeleteShader(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlDeleteShader(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDeleteShader(expr *CXExpression, fp int) {
 	cxglDeleteShader(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlDetachShader(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDetachShader(expr *CXExpression, fp int) {
 	cxglDetachShader(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])))
 }
 
-func opGlEnableVertexAttribArray(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlEnableVertexAttribArray(expr *CXExpression, fp int) {
 	cxglEnableVertexAttribArray(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlGetAttribLocation(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGetAttribLocation(expr *CXExpression, fp int) {
 	outV0 := cxglGetAttribLocation(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		ReadStr(fp, expr.Inputs[1]))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
-func opGlGetProgramiv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGetProgramiv(expr *CXExpression, fp int) {
 	outV0 := cxglGetProgramiv(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
-func opGlGetProgramInfoLog(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGetProgramInfoLog(expr *CXExpression, fp int) {
 	outV0 := cxglGetProgramInfoLog(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		ReadI32(fp, expr.Inputs[1]))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr(outV0))
 }
 
-func opGlGetShaderiv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGetShaderiv(expr *CXExpression, fp int) {
 	outV0 := cxglGetShaderiv(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
-func opGlGetShaderInfoLog(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGetShaderInfoLog(expr *CXExpression, fp int) {
 	outV0 := cxglGetShaderInfoLog(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		ReadI32(fp, expr.Inputs[1]))
 	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), FromStr(outV0))
 }
 
-func opGlGetUniformLocation(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGetUniformLocation(expr *CXExpression, fp int) {
 	outV0 := cxglGetUniformLocation(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		ReadStr(fp, expr.Inputs[1]))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
-func opGlLinkProgram(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlLinkProgram(expr *CXExpression, fp int) {
 	program := uint32(ReadI32(fp, expr.Inputs[0]))
 	cxglLinkProgram(program)
 }
 
-func opGlShaderSource(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlShaderSource(expr *CXExpression, fp int) {
 	cxglShaderSource(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		ReadI32(fp, expr.Inputs[1]),
 		ReadStr(fp, expr.Inputs[2]))
 }
 
-func opGlUseProgram(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUseProgram(expr *CXExpression, fp int) {
 	cxglUseProgram(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlUniform1f(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform1f(expr *CXExpression, fp int) {
 	cxglUniform1f(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadF32(fp, expr.Inputs[1]))
 }
 
-func opGlUniform2f(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform2f(expr *CXExpression, fp int) {
 	cxglUniform2f(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadF32(fp, expr.Inputs[1]),
 		ReadF32(fp, expr.Inputs[2]))
 }
 
-func opGlUniform3f(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform3f(expr *CXExpression, fp int) {
 	cxglUniform3f(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadF32(fp, expr.Inputs[1]),
@@ -998,10 +792,7 @@ func opGlUniform3f(prgrm *CXProgram) {
 		ReadF32(fp, expr.Inputs[3]))
 }
 
-func opGlUniform4f(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform4f(expr *CXExpression, fp int) {
 	cxglUniform4f(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadF32(fp, expr.Inputs[1]),
@@ -1010,29 +801,20 @@ func opGlUniform4f(prgrm *CXProgram) {
 		ReadF32(fp, expr.Inputs[4]))
 }
 
-func opGlUniform1i(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform1i(expr *CXExpression, fp int) {
 	cxglUniform1i(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]))
 }
 
-func opGlUniform2i(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform2i(expr *CXExpression, fp int) {
 	cxglUniform2i(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
 		ReadI32(fp, expr.Inputs[2]))
 }
 
-func opGlUniform3i(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform3i(expr *CXExpression, fp int) {
 	cxglUniform3i(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
@@ -1040,10 +822,7 @@ func opGlUniform3i(prgrm *CXProgram) {
 		ReadI32(fp, expr.Inputs[3]))
 }
 
-func opGlUniform4i(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform4i(expr *CXExpression, fp int) {
 	cxglUniform4i(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
@@ -1052,90 +831,63 @@ func opGlUniform4i(prgrm *CXProgram) {
 		ReadI32(fp, expr.Inputs[4]))
 }
 
-func opGlUniform1fv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform1fv(expr *CXExpression, fp int) {
 	cxglUniform1fv(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
 		ReadData(fp, expr.Inputs[2], TYPE_F32))
 }
 
-func opGlUniform2fv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform2fv(expr *CXExpression, fp int) {
 	cxglUniform2fv(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
 		ReadData(fp, expr.Inputs[2], TYPE_F32))
 }
 
-func opGlUniform3fv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform3fv(expr *CXExpression, fp int) {
 	cxglUniform3fv(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
 		ReadData(fp, expr.Inputs[2], TYPE_F32))
 }
 
-func opGlUniform4fv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform4fv(expr *CXExpression, fp int) {
 	cxglUniform4fv(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
 		ReadData(fp, expr.Inputs[2], TYPE_F32))
 }
 
-func opGlUniform1iv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform1iv(expr *CXExpression, fp int) {
 	cxglUniform1iv(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
 		ReadData(fp, expr.Inputs[2], TYPE_I32))
 }
 
-func opGlUniform2iv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform2iv(expr *CXExpression, fp int) {
 	cxglUniform2iv(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
 		ReadData(fp, expr.Inputs[2], TYPE_I32))
 }
 
-func opGlUniform3iv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform3iv(expr *CXExpression, fp int) {
 	cxglUniform3iv(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
 		ReadData(fp, expr.Inputs[2], TYPE_I32))
 }
 
-func opGlUniform4iv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniform4iv(expr *CXExpression, fp int) {
 	cxglUniform4iv(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
 		ReadData(fp, expr.Inputs[2], TYPE_I32))
 }
 
-func opGlUniformMatrix2fv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniformMatrix2fv(expr *CXExpression, fp int) {
 	cxglUniformMatrix2fv(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
@@ -1143,10 +895,7 @@ func opGlUniformMatrix2fv(prgrm *CXProgram) {
 		ReadData(fp, expr.Inputs[3], TYPE_F32))
 }
 
-func opGlUniformMatrix3fv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniformMatrix3fv(expr *CXExpression, fp int) {
 	cxglUniformMatrix3fv(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
@@ -1154,10 +903,7 @@ func opGlUniformMatrix3fv(prgrm *CXProgram) {
 		ReadData(fp, expr.Inputs[3], TYPE_F32))
 }
 
-func opGlUniformMatrix4fv(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniformMatrix4fv(expr *CXExpression, fp int) {
 	cxglUniformMatrix4fv(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
@@ -1165,20 +911,14 @@ func opGlUniformMatrix4fv(prgrm *CXProgram) {
 		ReadData(fp, expr.Inputs[3], TYPE_F32))
 }
 
-func opGlUniformV4F(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniformV4F(expr *CXExpression, fp int) {
 	cxglUniform4fv(
 		ReadI32(fp, expr.Inputs[0]),
 		1,
 		ReadData(fp, expr.Inputs[1], -1))
 }
 
-func opGlUniformM44F(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniformM44F(expr *CXExpression, fp int) {
 	cxglUniformMatrix4fv(
 		ReadI32(fp, expr.Inputs[0]),
 		1,
@@ -1186,10 +926,7 @@ func opGlUniformM44F(prgrm *CXProgram) {
 		ReadData(fp, expr.Inputs[2], -1))
 }
 
-func opGlUniformM44FV(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlUniformM44FV(expr *CXExpression, fp int) {
 	cxglUniformMatrix4fv(
 		ReadI32(fp, expr.Inputs[0]),
 		ReadI32(fp, expr.Inputs[1]),
@@ -1197,10 +934,7 @@ func opGlUniformM44FV(prgrm *CXProgram) {
 		ReadData(fp, expr.Inputs[3], -1))
 }
 
-func opGlVertexAttribPointer(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlVertexAttribPointer(expr *CXExpression, fp int) {
 	cxglVertexAttribPointer(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		ReadI32(fp, expr.Inputs[1]),
@@ -1209,10 +943,7 @@ func opGlVertexAttribPointer(prgrm *CXProgram) {
 		ReadI32(fp, expr.Inputs[4]), 0)
 }
 
-func opGlVertexAttribPointerI32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlVertexAttribPointerI32(expr *CXExpression, fp int) {
 	cxglVertexAttribPointer(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		ReadI32(fp, expr.Inputs[1]),
@@ -1222,10 +953,7 @@ func opGlVertexAttribPointerI32(prgrm *CXProgram) {
 		ReadI32(fp, expr.Inputs[5]))
 }
 
-func opGlClearBufferI(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlClearBufferI(expr *CXExpression, fp int) {
 	color := []int32{
 		ReadI32(fp, expr.Inputs[2]),
 		ReadI32(fp, expr.Inputs[3]),
@@ -1238,10 +966,7 @@ func opGlClearBufferI(prgrm *CXProgram) {
 		color)
 }
 
-func opGlClearBufferUI(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlClearBufferUI(expr *CXExpression, fp int) {
 	color := []uint32{
 		ReadUI32(fp, expr.Inputs[2]),
 		ReadUI32(fp, expr.Inputs[3]),
@@ -1254,10 +979,7 @@ func opGlClearBufferUI(prgrm *CXProgram) {
 		color)
 }
 
-func opGlClearBufferF(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlClearBufferF(expr *CXExpression, fp int) {
 	color := []float32{
 		ReadF32(fp, expr.Inputs[2]),
 		ReadF32(fp, expr.Inputs[3]),
@@ -1270,36 +992,24 @@ func opGlClearBufferF(prgrm *CXProgram) {
 		color)
 }
 
-func opGlBindRenderbuffer(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlBindRenderbuffer(expr *CXExpression, fp int) {
 	cxglBindRenderbuffer(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])))
 }
 
-func opGlDeleteRenderbuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDeleteRenderbuffers(expr *CXExpression, fp int) {
 	inpV1 := uint32(ReadI32(fp, expr.Inputs[1]))
 	cxglDeleteRenderbuffers(ReadI32(fp, expr.Inputs[0]), &inpV1) // will panic if inp0 > 1
 }
 
-func opGlGenRenderbuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGenRenderbuffers(expr *CXExpression, fp int) {
 	inpV1 := uint32(ReadI32(fp, expr.Inputs[1]))
 	cxglGenRenderbuffers(ReadI32(fp, expr.Inputs[0]), &inpV1) // will panic if inp0 > 1
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(inpV1))
 }
 
-func opGlRenderbufferStorage(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlRenderbufferStorage(expr *CXExpression, fp int) {
 	cxglRenderbufferStorage(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])),
@@ -1307,44 +1017,29 @@ func opGlRenderbufferStorage(prgrm *CXProgram) {
 		ReadI32(fp, expr.Inputs[3]))
 }
 
-func opGlBindFramebuffer(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlBindFramebuffer(expr *CXExpression, fp int) {
 	cxglBindFramebuffer(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])))
 }
 
-func opGlDeleteFramebuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDeleteFramebuffers(expr *CXExpression, fp int) {
 	inpV1 := uint32(ReadI32(fp, expr.Inputs[1]))
 	cxglDeleteFramebuffers(ReadI32(fp, expr.Inputs[0]), &inpV1) // will panic if inp0 > 1
 }
 
-func opGlGenFramebuffers(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGenFramebuffers(expr *CXExpression, fp int) {
 	inpV1 := uint32(ReadI32(fp, expr.Inputs[1]))
 	cxglGenFramebuffers(ReadI32(fp, expr.Inputs[0]), &inpV1) // will panic if inp0 > 1
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(inpV1))
 }
 
-func opGlCheckFramebufferStatus(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlCheckFramebufferStatus(expr *CXExpression, fp int) {
 	outV0 := int32(cxglCheckFramebufferStatus(uint32(ReadI32(fp, expr.Inputs[0]))))
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
 }
 
-func opGlFramebufferTexture2D(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlFramebufferTexture2D(expr *CXExpression, fp int) {
 	cxglFramebufferTexture2D(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])),
@@ -1353,10 +1048,7 @@ func opGlFramebufferTexture2D(prgrm *CXProgram) {
 		ReadI32(fp, expr.Inputs[4]))
 }
 
-func opGlFramebufferRenderbuffer(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlFramebufferRenderbuffer(expr *CXExpression, fp int) {
 	cxglFramebufferRenderbuffer(
 		uint32(ReadI32(fp, expr.Inputs[0])),
 		uint32(ReadI32(fp, expr.Inputs[1])),
@@ -1364,17 +1056,11 @@ func opGlFramebufferRenderbuffer(prgrm *CXProgram) {
 		uint32(ReadI32(fp, expr.Inputs[3])))
 }
 
-func opGlGenerateMipmap(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGenerateMipmap(expr *CXExpression, fp int) {
 	cxglGenerateMipmap(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlBindVertexArray(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlBindVertexArray(expr *CXExpression, fp int) {
 	inpV0 := uint32(ReadI32(fp, expr.Inputs[0]))
 	if runtime.GOOS == "darwin" {
 		cxglBindVertexArrayAPPLE(inpV0)
@@ -1383,17 +1069,11 @@ func opGlBindVertexArray(prgrm *CXProgram) {
 	}
 }
 
-func opGlBindVertexArrayCore(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlBindVertexArrayCore(expr *CXExpression, fp int) {
 	cxglBindVertexArray(uint32(ReadI32(fp, expr.Inputs[0])))
 }
 
-func opGlDeleteVertexArrays(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDeleteVertexArrays(expr *CXExpression, fp int) {
 	inpV0 := ReadI32(fp, expr.Inputs[0])
 	inpV1 := uint32(ReadI32(fp, expr.Inputs[1]))
 	if runtime.GOOS == "darwin" {
@@ -1403,18 +1083,12 @@ func opGlDeleteVertexArrays(prgrm *CXProgram) {
 	}
 }
 
-func opGlDeleteVertexArraysCore(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlDeleteVertexArraysCore(expr *CXExpression, fp int) {
 	inpV1 := uint32(ReadI32(fp, expr.Inputs[1]))
 	cxglDeleteVertexArrays(ReadI32(fp, expr.Inputs[0]), &inpV1) // will panic if inp0 > 1
 }
 
-func opGlGenVertexArrays(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGenVertexArrays(expr *CXExpression, fp int) {
 	inpV0 := ReadI32(fp, expr.Inputs[0])
 	inpV1 := uint32(ReadI32(fp, expr.Inputs[1]))
 	if runtime.GOOS == "darwin" {
@@ -1425,10 +1099,7 @@ func opGlGenVertexArrays(prgrm *CXProgram) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(inpV1))
 }
 
-func opGlGenVertexArraysCore(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlGenVertexArraysCore(expr *CXExpression, fp int) {
 	inpV1 := uint32(ReadI32(fp, expr.Inputs[1]))
 	cxglGenVertexArrays(ReadI32(fp, expr.Inputs[0]), &inpV1) // will panic if inp0 > 1
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(inpV1))

--- a/cxfx/utils.go
+++ b/cxfx/utils.go
@@ -12,17 +12,14 @@ var Functions_i32_i32 []Func_i32_i32
 var freeFns map[string]*func() = make(map[string]*func(), 0)
 var cSources map[string]**uint8 = make(map[string]**uint8, 0)
 
-func opGlfwFuncI32I32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwFuncI32I32(expr *CXExpression, fp int) {
 	packageName := ReadStr(fp, expr.Inputs[0])
 	functionName := ReadStr(fp, expr.Inputs[1])
 	callback := func(a int32, b int32) {
 		var inps [][]byte = make([][]byte, 2)
 		inps[0] = FromI32(a)
 		inps[1] = FromI32(b)
-		if fn, err := prgrm.GetFunction(functionName, packageName); err == nil {
+		if fn, err := PROGRAM.GetFunction(functionName, packageName); err == nil {
 			PROGRAM.Callback(fn, inps)
 		}
 	}
@@ -31,10 +28,7 @@ func opGlfwFuncI32I32(prgrm *CXProgram) {
 	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(len(Functions_i32_i32)-1))
 }
 
-func opGlfwCallI32I32(prgrm *CXProgram) {
-	expr := prgrm.GetExpr()
-	fp := prgrm.GetFramePointer()
-
+func opGlfwCallI32I32(expr *CXExpression, fp int) {
 	inp1, inp2, inp3 := expr.Inputs[0], expr.Inputs[1], expr.Inputs[2]
 	index := ReadI32(fp, inp1)
 	count := int32(len(Functions_i32_i32))


### PR DESCRIPTION
Changes:
- Change opcode signature from (*CXProgram) to (*CXExpression, int) in order to remove unnecessary function calls.

Does this change need to mentioned in CHANGELOG.md?
No