### PR TITLE
Mod/specialize func calculate dereferences

### DIFF
--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -61,3 +61,33 @@ func GetOffsetI32(fp int, arg *CXArgument) int {
 func GetOffsetI64(fp int, arg *CXArgument) int {
 	return GetFinalOffset(fp, arg)
 }
+
+// GetOffsetUI8 ...
+func GetOffsetUI8(fp int, arg *CXArgument) int {
+	return GetFinalOffset(fp, arg)
+}
+
+// GetOffsetUI16 ...
+func GetOffsetUI16(fp int, arg *CXArgument) int {
+	return GetFinalOffset(fp, arg)
+}
+
+// GetOffsetUI32 ...
+func GetOffsetUI32(fp int, arg *CXArgument) int {
+	return GetFinalOffset(fp, arg)
+}
+
+// GetOffsetUI64 ...
+func GetOffsetUI64(fp int, arg *CXArgument) int {
+	return GetFinalOffset(fp, arg)
+}
+
+// GetOffsetBool ...
+func GetOffsetBool(fp int, arg *CXArgument) int {
+	return GetFinalOffset(fp, arg)
+}
+
+// GetOffsetStr ...
+func GetOffsetStr(fp int, arg *CXArgument) int {
+	return GetFinalOffset(fp, arg)
+}

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -42,52 +42,52 @@ func GetFinalOffset(fp int, arg *CXArgument) int {
 	return finalOffset
 }
 
-// GetOffsetI8 ...
-func GetOffsetI8(fp int, arg *CXArgument) int {
+// GetOffset_i8 ...
+func GetOffset_i8(fp int, arg *CXArgument) int {
 	return GetFinalOffset(fp, arg)
 }
 
-// GetOffsetI16 ...
-func GetOffsetI16(fp int, arg *CXArgument) int {
+// GetOffset_i16 ...
+func GetOffset_i16(fp int, arg *CXArgument) int {
 	return GetFinalOffset(fp, arg)
 }
 
-// GetOffsetI32 ...
-func GetOffsetI32(fp int, arg *CXArgument) int {
+// GetOffset_i32 ...
+func GetOffset_i32(fp int, arg *CXArgument) int {
 	return GetFinalOffset(fp, arg)
 }
 
-// GetOffsetI64 ...
-func GetOffsetI64(fp int, arg *CXArgument) int {
+// GetOffset_i64 ...
+func GetOffset_i64(fp int, arg *CXArgument) int {
 	return GetFinalOffset(fp, arg)
 }
 
-// GetOffsetUI8 ...
-func GetOffsetUI8(fp int, arg *CXArgument) int {
+// GetOffset_ui8 ...
+func GetOffset_ui8(fp int, arg *CXArgument) int {
 	return GetFinalOffset(fp, arg)
 }
 
-// GetOffsetUI16 ...
-func GetOffsetUI16(fp int, arg *CXArgument) int {
+// GetOffset_ui16 ...
+func GetOffset_ui16(fp int, arg *CXArgument) int {
 	return GetFinalOffset(fp, arg)
 }
 
-// GetOffsetUI32 ...
-func GetOffsetUI32(fp int, arg *CXArgument) int {
+// GetOffset_ui32 ...
+func GetOffset_ui32(fp int, arg *CXArgument) int {
 	return GetFinalOffset(fp, arg)
 }
 
-// GetOffsetUI64 ...
-func GetOffsetUI64(fp int, arg *CXArgument) int {
+// GetOffset_ui64 ...
+func GetOffset_ui64(fp int, arg *CXArgument) int {
 	return GetFinalOffset(fp, arg)
 }
 
-// GetOffsetBool ...
-func GetOffsetBool(fp int, arg *CXArgument) int {
+// GetOffset_bool ...
+func GetOffset_bool(fp int, arg *CXArgument) int {
 	return GetFinalOffset(fp, arg)
 }
 
-// GetOffsetStr ...
-func GetOffsetStr(fp int, arg *CXArgument) int {
+// GetOffset_str ...
+func GetOffset_str(fp int, arg *CXArgument) int {
 	return GetFinalOffset(fp, arg)
 }

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -82,6 +82,16 @@ func GetOffset_ui64(fp int, arg *CXArgument) int {
 	return GetFinalOffset(fp, arg)
 }
 
+// GetOffset_f32 ...
+func GetOffset_f32(fp int, arg *CXArgument) int {
+	return GetFinalOffset(fp, arg)
+}
+
+// GetOffset_f64 ...
+func GetOffset_f64(fp int, arg *CXArgument) int {
+	return GetFinalOffset(fp, arg)
+}
+
 // GetOffset_bool ...
 func GetOffset_bool(fp int, arg *CXArgument) int {
 	return GetFinalOffset(fp, arg)

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -1,7 +1,5 @@
 package cxcore
 
-import ()
-
 //NOTE: Temp file for resolving GetFinalOffset issue
 //TODO: What should this function be called?
 
@@ -42,4 +40,24 @@ func GetFinalOffset(fp int, arg *CXArgument) int {
 	}
 
 	return finalOffset
+}
+
+// GetOffsetI8 ...
+func GetOffsetI8(fp int, arg *CXArgument) int {
+	return GetFinalOffset(fp, arg)
+}
+
+// GetOffsetI16 ...
+func GetOffsetI16(fp int, arg *CXArgument) int {
+	return GetFinalOffset(fp, arg)
+}
+
+// GetOffsetI32 ...
+func GetOffsetI32(fp int, arg *CXArgument) int {
+	return GetFinalOffset(fp, arg)
+}
+
+// GetOffsetI64 ...
+func GetOffsetI64(fp int, arg *CXArgument) int {
+	return GetFinalOffset(fp, arg)
 }

--- a/cx/op_bool.go
+++ b/cx/op_bool.go
@@ -10,25 +10,25 @@ func opBoolPrint(expr *CXExpression, fp int) {
 
 func opBoolEqual(expr *CXExpression, fp int) {
 	outV0 := ReadBool(fp, expr.Inputs[0]) == ReadBool(fp, expr.Inputs[1])
-	WriteBool(GetOffsetBool(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_bool(fp, expr.Outputs[0]), outV0)
 }
 
 func opBoolUnequal(expr *CXExpression, fp int) {
 	outV0 := ReadBool(fp, expr.Inputs[0]) != ReadBool(fp, expr.Inputs[1])
-	WriteBool(GetOffsetBool(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_bool(fp, expr.Outputs[0]), outV0)
 }
 
 func opBoolNot(expr *CXExpression, fp int) {
 	outV0 := !ReadBool(fp, expr.Inputs[0])
-	WriteBool(GetOffsetBool(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_bool(fp, expr.Outputs[0]), outV0)
 }
 
 func opBoolAnd(expr *CXExpression, fp int) {
 	outV0 := ReadBool(fp, expr.Inputs[0]) && ReadBool(fp, expr.Inputs[1])
-	WriteBool(GetOffsetBool(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_bool(fp, expr.Outputs[0]), outV0)
 }
 
 func opBoolOr(expr *CXExpression, fp int) {
 	outV0 := ReadBool(fp, expr.Inputs[0]) || ReadBool(fp, expr.Inputs[1])
-	WriteBool(GetOffsetBool(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_bool(fp, expr.Outputs[0]), outV0)
 }

--- a/cx/op_bool.go
+++ b/cx/op_bool.go
@@ -10,25 +10,25 @@ func opBoolPrint(expr *CXExpression, fp int) {
 
 func opBoolEqual(expr *CXExpression, fp int) {
 	outV0 := ReadBool(fp, expr.Inputs[0]) == ReadBool(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetBool(fp, expr.Outputs[0]), outV0)
 }
 
 func opBoolUnequal(expr *CXExpression, fp int) {
 	outV0 := ReadBool(fp, expr.Inputs[0]) != ReadBool(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetBool(fp, expr.Outputs[0]), outV0)
 }
 
 func opBoolNot(expr *CXExpression, fp int) {
 	outV0 := !ReadBool(fp, expr.Inputs[0])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetBool(fp, expr.Outputs[0]), outV0)
 }
 
 func opBoolAnd(expr *CXExpression, fp int) {
 	outV0 := ReadBool(fp, expr.Inputs[0]) && ReadBool(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetBool(fp, expr.Outputs[0]), outV0)
 }
 
 func opBoolOr(expr *CXExpression, fp int) {
 	outV0 := ReadBool(fp, expr.Inputs[0]) || ReadBool(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetBool(fp, expr.Outputs[0]), outV0)
 }

--- a/cx/op_f32.go
+++ b/cx/op_f32.go
@@ -10,67 +10,67 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opF32ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatFloat(float64(ReadF32(fp, expr.Inputs[0])), 'f', -1, 32))
-	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffset_f32(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type f32 to type i8.
 func opF32ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadF32(fp, expr.Inputs[0]))
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type f32 to type i16.
 func opF32ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadF32(fp, expr.Inputs[0]))
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type f32 to type i32.
 func opF32ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadF32(fp, expr.Inputs[0]))
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type f32 to type i64.
 func opF32ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadF32(fp, expr.Inputs[0]))
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type f32 to type ui8.
 func opF32ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadF32(fp, expr.Inputs[0]))
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type f32 to type ui16.
 func opF32ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadF32(fp, expr.Inputs[0]))
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type f32 to type ui32.
 func opF32ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadF32(fp, expr.Inputs[0]))
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type f32 to type ui64.
 func opF32ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadF32(fp, expr.Inputs[0]))
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type f32 to type f64.
 func opF32ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadF32(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in isnan function returns true if operand is nan value.
 func opF32Isnan(expr *CXExpression, fp int) {
 	outV0 := math.IsNaN(float64(ReadF32(fp, expr.Inputs[0])))
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -81,150 +81,150 @@ func opF32Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of the two operands.
 func opF32Add(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) + ReadF32(fp, expr.Inputs[1])
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference between the two operands.
 func opF32Sub(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) - ReadF32(fp, expr.Inputs[1])
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
 func opF32Neg(expr *CXExpression, fp int) {
 	outV0 := -ReadF32(fp, expr.Inputs[0])
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of the two operands.
 func opF32Mul(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) * ReadF32(fp, expr.Inputs[1])
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient between the two operands.
 func opF32Div(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) / ReadF32(fp, expr.Inputs[1])
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function return the floating-point remainder of operand 1 divided by operand 2.
 func opF32Mod(expr *CXExpression, fp int) {
 	outV0 := float32(math.Mod(float64(ReadF32(fp, expr.Inputs[0])), float64(ReadF32(fp, expr.Inputs[1]))))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in abs function returns the absolute value of the operand.
 func opF32Abs(expr *CXExpression, fp int) {
 	outV0 := float32(math.Abs(float64(ReadF32(fp, expr.Inputs[0]))))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in pow function returns x**n for n>0 otherwise 1.
 func opF32Pow(expr *CXExpression, fp int) {
 	outV0 := float32(math.Pow(float64(ReadF32(fp, expr.Inputs[0])), float64(ReadF32(fp, expr.Inputs[1]))))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opF32Gt(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) > ReadF32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if the operand 1 is greater than or
 // equal to operand 2.
 func opF32Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) >= ReadF32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opF32Lt(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) < ReadF32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or
 // equal to operand 2.
 func opF32Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) <= ReadF32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opF32Eq(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) == ReadF32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true operand1 is different from operand 2.
 func opF32Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadF32(fp, expr.Inputs[0]) != ReadF32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number in [0.0,1.0) from the default Source
 func opF32Rand(expr *CXExpression, fp int) {
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), rand.Float32())
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), rand.Float32())
 }
 
 // The built-in acos function returns the arc cosine of the operand.
 func opF32Acos(expr *CXExpression, fp int) {
 	outV0 := float32(math.Acos(float64(ReadF32(fp, expr.Inputs[0]))))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in cos function returns the cosine of the operand.
 func opF32Cos(expr *CXExpression, fp int) {
 	outV0 := float32(math.Cos(float64(ReadF32(fp, expr.Inputs[0]))))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in asin function returns the arc sine of the operand.
 func opF32Asin(expr *CXExpression, fp int) {
 	outV0 := float32(math.Asin(float64(ReadF32(fp, expr.Inputs[0]))))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sin function returns the sine of the operand.
 func opF32Sin(expr *CXExpression, fp int) {
 	outV0 := float32(math.Sin(float64(ReadF32(fp, expr.Inputs[0]))))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sqrt function returns the square root of the operand.
 func opF32Sqrt(expr *CXExpression, fp int) {
 	outV0 := float32(math.Sqrt(float64(ReadF32(fp, expr.Inputs[0]))))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in log function returns the natural logarithm of the operand.
 func opF32Log(expr *CXExpression, fp int) {
 	outV0 := float32(math.Log(float64(ReadF32(fp, expr.Inputs[0]))))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in log2 function returns the 2-logarithm of the operand.
 func opF32Log2(expr *CXExpression, fp int) {
 	outV0 := float32(math.Log2(float64(ReadF32(fp, expr.Inputs[0]))))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in log10 function returns the 10-logarithm of the operand.
 func opF32Log10(expr *CXExpression, fp int) {
 	outV0 := float32(math.Log10(float64(ReadF32(fp, expr.Inputs[0]))))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the largest value of the two operands.
 func opF32Max(expr *CXExpression, fp int) {
 	outV0 := float32(math.Max(float64(ReadF32(fp, expr.Inputs[0])), float64(ReadF32(fp, expr.Inputs[1]))))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in min function returns the smallest value of the two operands.
 func opF32Min(expr *CXExpression, fp int) {
 	outV0 := float32(math.Min(float64(ReadF32(fp, expr.Inputs[0])), float64(ReadF32(fp, expr.Inputs[1]))))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f32(fp, expr.Outputs[0]), outV0)
 }

--- a/cx/op_f64.go
+++ b/cx/op_f64.go
@@ -10,67 +10,67 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opF64ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatFloat(ReadF64(fp, expr.Inputs[0]), 'f', -1, 64))
-	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffset_f64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type f64 to type i8.
 func opF64ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadF64(fp, expr.Inputs[0]))
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type f64 to type i16.
 func opF64ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadF64(fp, expr.Inputs[0]))
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type f64 to type i32.
 func opF64ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadF64(fp, expr.Inputs[0]))
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type f64 to type i64.
 func opF64ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadF64(fp, expr.Inputs[0]))
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type f64 to type ui8.
 func opF64ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadF64(fp, expr.Inputs[0]))
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type f64 to type ui16.
 func opF64ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadF64(fp, expr.Inputs[0]))
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type f64 to type ui32.
 func opF64ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadF64(fp, expr.Inputs[0]))
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type f64 to type ui64.
 func opF64ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadF64(fp, expr.Inputs[0]))
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type f64 to type f32.
 func opF64ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadF64(fp, expr.Inputs[0]))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in isnan function returns true if operand is nan value.
 func opF64Isnan(expr *CXExpression, fp int) {
 	outV0 := math.IsNaN(ReadF64(fp, expr.Inputs[0]))
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -81,150 +81,150 @@ func opF64Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of the two operands.
 func opF64Add(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) + ReadF64(fp, expr.Inputs[1])
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference between the two operands.
 func opF64Sub(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) - ReadF64(fp, expr.Inputs[1])
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
 func opF64Neg(expr *CXExpression, fp int) {
 	outV0 := -ReadF64(fp, expr.Inputs[0])
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of the two operands.
 func opF64Mul(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) * ReadF64(fp, expr.Inputs[1])
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient between the two operands.
 func opF64Div(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) / ReadF64(fp, expr.Inputs[1])
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function return the floating-point remainder of operand 1 divided by operand 2.
 func opF64Mod(expr *CXExpression, fp int) {
 	outV0 := math.Mod(ReadF64(fp, expr.Inputs[0]), ReadF64(fp, expr.Inputs[1]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in abs function returns the absolute value of the operand.
 func opF64Abs(expr *CXExpression, fp int) {
 	outV0 := math.Abs(ReadF64(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in pow function returns x**n for n>0 otherwise 1.
 func opF64Pow(expr *CXExpression, fp int) {
 	outV0 := math.Pow(ReadF64(fp, expr.Inputs[0]), ReadF64(fp, expr.Inputs[1]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is larger than operand 2.
 func opF64Gt(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) > ReadF64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opF64Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) >= ReadF64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opF64Lt(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) < ReadF64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 2.
 func opF64Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) <= ReadF64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opF64Eq(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) == ReadF64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opF64Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadF64(fp, expr.Inputs[0]) != ReadF64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number in [0.0,1.0) from the default Source.
 func opF64Rand(expr *CXExpression, fp int) {
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), rand.Float64())
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), rand.Float64())
 }
 
 // The built-in acos function returns the arc cosine of the operand.
 func opF64Acos(expr *CXExpression, fp int) {
 	outV0 := math.Acos(ReadF64(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in cos function returns the cosine of the operand.
 func opF64Cos(expr *CXExpression, fp int) {
 	outV0 := math.Cos(ReadF64(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in asin function returns the arc sine of the operand.
 func opF64Asin(expr *CXExpression, fp int) {
 	outV0 := math.Asin(ReadF64(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sin function returns the sine of the operand.
 func opF64Sin(expr *CXExpression, fp int) {
 	outV0 := math.Sin(ReadF64(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sqrt function returns the square root of the operand.
 func opF64Sqrt(expr *CXExpression, fp int) {
 	outV0 := math.Sqrt(ReadF64(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in log function returns the natural logarithm of the operand.
 func opF64Log(expr *CXExpression, fp int) {
 	outV0 := math.Log(ReadF64(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in log2 function returns the 2-logarithm of the operand.
 func opF64Log2(expr *CXExpression, fp int) {
 	outV0 := math.Log2(ReadF64(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in log10 function returns the 10-logarithm of the operand.
 func opF64Log10(expr *CXExpression, fp int) {
 	outV0 := math.Log10(ReadF64(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the largest value of the two operands.
 func opF64Max(expr *CXExpression, fp int) {
 	outV0 := math.Max(ReadF64(fp, expr.Inputs[0]), ReadF64(fp, expr.Inputs[1]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in min function returns the smallest value of the two operands.
 func opF64Min(expr *CXExpression, fp int) {
 	outV0 := math.Min(ReadF64(fp, expr.Inputs[0]), ReadF64(fp, expr.Inputs[1]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_f64(fp, expr.Outputs[0]), outV0)
 }

--- a/cx/op_i16.go
+++ b/cx/op_i16.go
@@ -9,61 +9,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opI16ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatInt(int64(ReadI16(fp, expr.Inputs[0])), 10))
-	WriteObject(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type i16 to type i8.
 func opI16ToI8(expr *CXExpression, fp int) {
 	outB0 := int8(ReadI16(fp, expr.Inputs[0]))
-	WriteI8(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI8(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i32 function returns operand 1 casted from type i16 to type i32.
 func opI16ToI32(expr *CXExpression, fp int) {
 	outB0 := int32(ReadI16(fp, expr.Inputs[0]))
-	WriteI32(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI32(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i64 function returns operand 1 casted from type i16 to type i64.
 func opI16ToI64(expr *CXExpression, fp int) {
 	outB0 := int64(ReadI16(fp, expr.Inputs[0]))
-	WriteI64(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i16 to type ui8.
 func opI16ToUI8(expr *CXExpression, fp int) {
 	outB0 := uint8(ReadI16(fp, expr.Inputs[0]))
-	WriteUI8(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteUI8(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i16 to type ui16.
 func opI16ToUI16(expr *CXExpression, fp int) {
 	outB0 := uint16(ReadI16(fp, expr.Inputs[0]))
-	WriteUI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteUI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i16 to type ui32.
 func opI16ToUI32(expr *CXExpression, fp int) {
 	outB0 := uint32(ReadI16(fp, expr.Inputs[0]))
-	WriteUI32(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteUI32(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type i16 to type ui64.
 func opI16ToUI64(expr *CXExpression, fp int) {
 	outB0 := uint64(ReadI16(fp, expr.Inputs[0]))
-	WriteUI64(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteUI64(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i16 to type f32.
 func opI16ToF32(expr *CXExpression, fp int) {
 	outB0 := float32(ReadI16(fp, expr.Inputs[0]))
-	WriteF32(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteF32(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i16 to type f64.
 func opI16ToF64(expr *CXExpression, fp int) {
 	outB0 := float64(ReadI16(fp, expr.Inputs[0]))
-	WriteF64(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteF64(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -74,31 +74,31 @@ func opI16Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two i16 numbers.
 func opI16Add(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) + ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in sub function returns the difference of two i16 numbers.
 func opI16Sub(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) - ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
 func opI16Neg(expr *CXExpression, fp int) {
 	outB0 := -ReadI16(fp, expr.Inputs[0])
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in mul function returns the product of two i16 numbers.
 func opI16Mul(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) * ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in div function returns the quotient of two i16 numbers.
 func opI16Div(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) / ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in abs function returns the absolute number of the number.
@@ -106,51 +106,51 @@ func opI16Abs(expr *CXExpression, fp int) {
 	V0 := ReadI16(fp, expr.Inputs[0])
 	sign := V0 >> 15
 	outB0 := (V0 ^ sign) - sign
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opI16Gt(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) > ReadI16(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opI16Gteq(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) >= ReadI16(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opI16Lt(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) < ReadI16(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opI16Lteq(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) <= ReadI16(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opI16Eq(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) == ReadI16(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opI16Uneq(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) != ReadI16(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
 func opI16Mod(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) % ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
@@ -164,45 +164,45 @@ func opI16Rand(expr *CXExpression, fp int) {
 		outV0 = int16(rand.Intn(r) + int(minimum))
 	}
 
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opI16Bitand(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) & ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opI16Bitor(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) | ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opI16Bitxor(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) ^ ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opI16Bitclear(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) &^ ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opI16Bitshl(expr *CXExpression, fp int) {
 	outB0 := int16(ReadI16(fp, expr.Inputs[0]) << uint16(ReadI16(fp, expr.Inputs[1])))
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opI16Bitshr(expr *CXExpression, fp int) {
 	outB0 := int16(ReadI16(fp, expr.Inputs[0]) >> uint16(ReadI16(fp, expr.Inputs[1])))
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -212,7 +212,7 @@ func opI16Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), inpV0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
@@ -222,5 +222,5 @@ func opI16Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), inpV0)
+	WriteI16(GetOffset_i16(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_i16.go
+++ b/cx/op_i16.go
@@ -9,61 +9,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opI16ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatInt(int64(ReadI16(fp, expr.Inputs[0])), 10))
-	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type i16 to type i8.
 func opI16ToI8(expr *CXExpression, fp int) {
 	outB0 := int8(ReadI16(fp, expr.Inputs[0]))
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI8(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i32 function returns operand 1 casted from type i16 to type i32.
 func opI16ToI32(expr *CXExpression, fp int) {
 	outB0 := int32(ReadI16(fp, expr.Inputs[0]))
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI32(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i64 function returns operand 1 casted from type i16 to type i64.
 func opI16ToI64(expr *CXExpression, fp int) {
 	outB0 := int64(ReadI16(fp, expr.Inputs[0]))
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i16 to type ui8.
 func opI16ToUI8(expr *CXExpression, fp int) {
 	outB0 := uint8(ReadI16(fp, expr.Inputs[0]))
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteUI8(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i16 to type ui16.
 func opI16ToUI16(expr *CXExpression, fp int) {
 	outB0 := uint16(ReadI16(fp, expr.Inputs[0]))
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteUI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i16 to type ui32.
 func opI16ToUI32(expr *CXExpression, fp int) {
 	outB0 := uint32(ReadI16(fp, expr.Inputs[0]))
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteUI32(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type i16 to type ui64.
 func opI16ToUI64(expr *CXExpression, fp int) {
 	outB0 := uint64(ReadI16(fp, expr.Inputs[0]))
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteUI64(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i16 to type f32.
 func opI16ToF32(expr *CXExpression, fp int) {
 	outB0 := float32(ReadI16(fp, expr.Inputs[0]))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteF32(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i16 to type f64.
 func opI16ToF64(expr *CXExpression, fp int) {
 	outB0 := float64(ReadI16(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteF64(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -74,31 +74,31 @@ func opI16Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two i16 numbers.
 func opI16Add(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) + ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in sub function returns the difference of two i16 numbers.
 func opI16Sub(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) - ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
 func opI16Neg(expr *CXExpression, fp int) {
 	outB0 := -ReadI16(fp, expr.Inputs[0])
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in mul function returns the product of two i16 numbers.
 func opI16Mul(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) * ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in div function returns the quotient of two i16 numbers.
 func opI16Div(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) / ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in abs function returns the absolute number of the number.
@@ -106,51 +106,51 @@ func opI16Abs(expr *CXExpression, fp int) {
 	V0 := ReadI16(fp, expr.Inputs[0])
 	sign := V0 >> 15
 	outB0 := (V0 ^ sign) - sign
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opI16Gt(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) > ReadI16(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opI16Gteq(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) >= ReadI16(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opI16Lt(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) < ReadI16(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opI16Lteq(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) <= ReadI16(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opI16Eq(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) == ReadI16(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opI16Uneq(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) != ReadI16(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
 func opI16Mod(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) % ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
@@ -164,45 +164,45 @@ func opI16Rand(expr *CXExpression, fp int) {
 		outV0 = int16(rand.Intn(r) + int(minimum))
 	}
 
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opI16Bitand(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) & ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opI16Bitor(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) | ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opI16Bitxor(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) ^ ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opI16Bitclear(expr *CXExpression, fp int) {
 	outB0 := ReadI16(fp, expr.Inputs[0]) &^ ReadI16(fp, expr.Inputs[1])
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opI16Bitshl(expr *CXExpression, fp int) {
 	outB0 := int16(ReadI16(fp, expr.Inputs[0]) << uint16(ReadI16(fp, expr.Inputs[1])))
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opI16Bitshr(expr *CXExpression, fp int) {
 	outB0 := int16(ReadI16(fp, expr.Inputs[0]) >> uint16(ReadI16(fp, expr.Inputs[1])))
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -212,7 +212,7 @@ func opI16Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
@@ -222,5 +222,5 @@ func opI16Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteI16(GetOffsetI16(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_i32.go
+++ b/cx/op_i32.go
@@ -9,61 +9,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opI32ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatInt(int64(ReadI32(fp, expr.Inputs[0])), 10))
-	WriteObject(GetOffsetI32(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffset_i32(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type i32 to type i8.
 func opI32ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadI32(fp, expr.Inputs[0]))
-	WriteI8(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type i32 to type i16.
 func opI32ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadI32(fp, expr.Inputs[0]))
-	WriteI16(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type i32 to type i64.
 func opI32ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadI32(fp, expr.Inputs[0]))
-	WriteI64(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i32 to type ui8.
 func opI32ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadI32(fp, expr.Inputs[0]))
-	WriteUI8(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i32 to type ui16.
 func opI32ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadI32(fp, expr.Inputs[0]))
-	WriteUI16(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type i32 to type ui32.
 func opI32ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadI32(fp, expr.Inputs[0]))
-	WriteUI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type i32 to type ui64.
 func opI32ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadI32(fp, expr.Inputs[0]))
-	WriteUI64(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i32 to type f32.
 func opI32ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadI32(fp, expr.Inputs[0]))
-	WriteF32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i32 to type f64.
 func opI32ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadI32(fp, expr.Inputs[0]))
-	WriteF64(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -74,31 +74,31 @@ func opI32Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two i32 numbers.
 func opI32Add(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) + ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two i32 numbers.
 func opI32Sub(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) - ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
 func opI32Neg(expr *CXExpression, fp int) {
 	outV0 := -ReadI32(fp, expr.Inputs[0])
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two i32 numbers.
 func opI32Mul(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) * ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two i32 numbers.
 func opI32Div(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) / ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in abs function returns the absolute number of the number.
@@ -106,51 +106,51 @@ func opI32Abs(expr *CXExpression, fp int) {
 	inpV0 := ReadI32(fp, expr.Inputs[0])
 	sign := inpV0 >> 31
 	outV0 := (inpV0 ^ sign) - sign
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opI32Gt(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) > ReadI32(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opI32Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) >= ReadI32(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opI32Lt(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) < ReadI32(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opI32Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) <= ReadI32(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opI32Eq(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) == ReadI32(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opI32Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) != ReadI32(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 divided by operand 2.
 func opI32Mod(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) % ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
@@ -164,45 +164,45 @@ func opI32Rand(expr *CXExpression, fp int) {
 		outV0 = int32(rand.Intn(r) + int(minimum))
 	}
 
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opI32Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) & ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opI32Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) | ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opI32Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) ^ ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opI32Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) &^ ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opI32Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) << uint32(ReadI32(fp, expr.Inputs[1]))
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opI32Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) >> uint32(ReadI32(fp, expr.Inputs[1]))
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -212,7 +212,7 @@ func opI32Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), inpV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
@@ -222,5 +222,5 @@ func opI32Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), inpV0)
+	WriteI32(GetOffset_i32(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_i32.go
+++ b/cx/op_i32.go
@@ -9,61 +9,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opI32ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatInt(int64(ReadI32(fp, expr.Inputs[0])), 10))
-	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffsetI32(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type i32 to type i8.
 func opI32ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadI32(fp, expr.Inputs[0]))
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type i32 to type i16.
 func opI32ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadI32(fp, expr.Inputs[0]))
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type i32 to type i64.
 func opI32ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadI32(fp, expr.Inputs[0]))
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i32 to type ui8.
 func opI32ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadI32(fp, expr.Inputs[0]))
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i32 to type ui16.
 func opI32ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadI32(fp, expr.Inputs[0]))
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type i32 to type ui32.
 func opI32ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadI32(fp, expr.Inputs[0]))
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type i32 to type ui64.
 func opI32ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadI32(fp, expr.Inputs[0]))
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i32 to type f32.
 func opI32ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadI32(fp, expr.Inputs[0]))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i32 to type f64.
 func opI32ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadI32(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -74,31 +74,31 @@ func opI32Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two i32 numbers.
 func opI32Add(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) + ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two i32 numbers.
 func opI32Sub(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) - ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
 func opI32Neg(expr *CXExpression, fp int) {
 	outV0 := -ReadI32(fp, expr.Inputs[0])
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two i32 numbers.
 func opI32Mul(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) * ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two i32 numbers.
 func opI32Div(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) / ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in abs function returns the absolute number of the number.
@@ -106,51 +106,51 @@ func opI32Abs(expr *CXExpression, fp int) {
 	inpV0 := ReadI32(fp, expr.Inputs[0])
 	sign := inpV0 >> 31
 	outV0 := (inpV0 ^ sign) - sign
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opI32Gt(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) > ReadI32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opI32Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) >= ReadI32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opI32Lt(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) < ReadI32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opI32Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) <= ReadI32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opI32Eq(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) == ReadI32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opI32Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) != ReadI32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 divided by operand 2.
 func opI32Mod(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) % ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
@@ -164,45 +164,45 @@ func opI32Rand(expr *CXExpression, fp int) {
 		outV0 = int32(rand.Intn(r) + int(minimum))
 	}
 
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opI32Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) & ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opI32Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) | ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opI32Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) ^ ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opI32Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) &^ ReadI32(fp, expr.Inputs[1])
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opI32Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) << uint32(ReadI32(fp, expr.Inputs[1]))
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opI32Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadI32(fp, expr.Inputs[0]) >> uint32(ReadI32(fp, expr.Inputs[1]))
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -212,7 +212,7 @@ func opI32Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
@@ -222,5 +222,5 @@ func opI32Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteI32(GetOffsetI32(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_i64.go
+++ b/cx/op_i64.go
@@ -9,61 +9,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opI64ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatInt(ReadI64(fp, expr.Inputs[0]), 10))
-	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type i64 to type i8.
 func opI64ToI8(expr *CXExpression, fp int) {
 	outB0 := int8(ReadI64(fp, expr.Inputs[0]))
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI8(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i16 function returns operand 1 casted from type i64 to type i16.
 func opI64ToI16(expr *CXExpression, fp int) {
 	outB0 := int16(ReadI64(fp, expr.Inputs[0]))
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i32 function returns operand 1 casted from type i64 to type i32.
 func opI64ToI32(expr *CXExpression, fp int) {
 	outB0 := int32(ReadI64(fp, expr.Inputs[0]))
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI32(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i64 to type ui8.
 func opI64ToUI8(expr *CXExpression, fp int) {
 	outB0 := uint8(ReadI64(fp, expr.Inputs[0]))
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteUI8(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i64 to type ui16.
 func opI64ToUI16(expr *CXExpression, fp int) {
 	outB0 := uint16(ReadI64(fp, expr.Inputs[0]))
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteUI16(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type i64 to type ui32.
 func opI64ToUI32(expr *CXExpression, fp int) {
 	outB0 := uint32(ReadI64(fp, expr.Inputs[0]))
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteUI32(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type i64 to type ui64.
 func opI64ToUI64(expr *CXExpression, fp int) {
 	outB0 := uint64(ReadI64(fp, expr.Inputs[0]))
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteUI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i64 to type f32.
 func opI64ToF32(expr *CXExpression, fp int) {
 	outB0 := float32(ReadI64(fp, expr.Inputs[0]))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteF32(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i64 to type f64.
 func opI64ToF64(expr *CXExpression, fp int) {
 	outB0 := float64(ReadI64(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteF64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -74,31 +74,31 @@ func opI64Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of the two operands.
 func opI64Add(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) + ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in sub function returns the difference between the two operands.
 func opI64Sub(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) - ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in neg function returns the opposit of operand 1.
 func opI64Neg(expr *CXExpression, fp int) {
 	outB0 := -ReadI64(fp, expr.Inputs[0])
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in mul function returns the product of the two operands.
 func opI64Mul(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) * ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in div function returns the quotient of the two operands.
 func opI64Div(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) / ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in abs function returns the absolute value of the operand.
@@ -106,51 +106,51 @@ func opI64Abs(expr *CXExpression, fp int) {
 	inpV0 := ReadI64(fp, expr.Inputs[0])
 	sign := inpV0 >> 63
 	outB0 := (inpV0 ^ sign) - sign
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opI64Gt(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) > ReadI64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opI64Gteq(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) >= ReadI64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in lt function returns true if operand 1 is less than oeprand 2.
 func opI64Lt(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) < ReadI64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or
 // equal to operand 2.
 func opI64Lteq(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) <= ReadI64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opI64Eq(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) == ReadI64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opI64Uneq(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) != ReadI64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in mod function returns the remainder of operand 1 divided by operand 2.
 func opI64Mod(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) % ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
@@ -164,45 +164,45 @@ func opI64Rand(expr *CXExpression, fp int) {
 		outV0 = int64(rand.Intn(r) + int(minimum))
 	}
 
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opI64Bitand(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) & ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opI64Bitor(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) | ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opI64Bitxor(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) ^ ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opI64Bitclear(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) &^ ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opI64Bitshl(expr *CXExpression, fp int) {
 	outB0 := int64(ReadI64(fp, expr.Inputs[0]) << uint64(ReadI64(fp, expr.Inputs[1])))
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opI64Bitshr(expr *CXExpression, fp int) {
 	outB0 := int64(ReadI64(fp, expr.Inputs[0]) >> uint64(ReadI64(fp, expr.Inputs[1])))
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in max function returns the greatest value of the two operands.
@@ -212,7 +212,7 @@ func opI64Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest value of the two operands.
@@ -222,5 +222,5 @@ func opI64Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_i64.go
+++ b/cx/op_i64.go
@@ -9,61 +9,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opI64ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatInt(ReadI64(fp, expr.Inputs[0]), 10))
-	WriteObject(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type i64 to type i8.
 func opI64ToI8(expr *CXExpression, fp int) {
 	outB0 := int8(ReadI64(fp, expr.Inputs[0]))
-	WriteI8(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI8(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i16 function returns operand 1 casted from type i64 to type i16.
 func opI64ToI16(expr *CXExpression, fp int) {
 	outB0 := int16(ReadI64(fp, expr.Inputs[0]))
-	WriteI16(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI16(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i32 function returns operand 1 casted from type i64 to type i32.
 func opI64ToI32(expr *CXExpression, fp int) {
 	outB0 := int32(ReadI64(fp, expr.Inputs[0]))
-	WriteI32(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI32(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i64 to type ui8.
 func opI64ToUI8(expr *CXExpression, fp int) {
 	outB0 := uint8(ReadI64(fp, expr.Inputs[0]))
-	WriteUI8(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteUI8(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i64 to type ui16.
 func opI64ToUI16(expr *CXExpression, fp int) {
 	outB0 := uint16(ReadI64(fp, expr.Inputs[0]))
-	WriteUI16(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteUI16(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type i64 to type ui32.
 func opI64ToUI32(expr *CXExpression, fp int) {
 	outB0 := uint32(ReadI64(fp, expr.Inputs[0]))
-	WriteUI32(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteUI32(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type i64 to type ui64.
 func opI64ToUI64(expr *CXExpression, fp int) {
 	outB0 := uint64(ReadI64(fp, expr.Inputs[0]))
-	WriteUI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteUI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i64 to type f32.
 func opI64ToF32(expr *CXExpression, fp int) {
 	outB0 := float32(ReadI64(fp, expr.Inputs[0]))
-	WriteF32(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteF32(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i64 to type f64.
 func opI64ToF64(expr *CXExpression, fp int) {
 	outB0 := float64(ReadI64(fp, expr.Inputs[0]))
-	WriteF64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteF64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -74,31 +74,31 @@ func opI64Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of the two operands.
 func opI64Add(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) + ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in sub function returns the difference between the two operands.
 func opI64Sub(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) - ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in neg function returns the opposit of operand 1.
 func opI64Neg(expr *CXExpression, fp int) {
 	outB0 := -ReadI64(fp, expr.Inputs[0])
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in mul function returns the product of the two operands.
 func opI64Mul(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) * ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in div function returns the quotient of the two operands.
 func opI64Div(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) / ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in abs function returns the absolute value of the operand.
@@ -106,51 +106,51 @@ func opI64Abs(expr *CXExpression, fp int) {
 	inpV0 := ReadI64(fp, expr.Inputs[0])
 	sign := inpV0 >> 63
 	outB0 := (inpV0 ^ sign) - sign
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opI64Gt(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) > ReadI64(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opI64Gteq(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) >= ReadI64(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in lt function returns true if operand 1 is less than oeprand 2.
 func opI64Lt(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) < ReadI64(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or
 // equal to operand 2.
 func opI64Lteq(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) <= ReadI64(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opI64Eq(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) == ReadI64(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opI64Uneq(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) != ReadI64(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in mod function returns the remainder of operand 1 divided by operand 2.
 func opI64Mod(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) % ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
@@ -164,45 +164,45 @@ func opI64Rand(expr *CXExpression, fp int) {
 		outV0 = int64(rand.Intn(r) + int(minimum))
 	}
 
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opI64Bitand(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) & ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opI64Bitor(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) | ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opI64Bitxor(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) ^ ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opI64Bitclear(expr *CXExpression, fp int) {
 	outB0 := ReadI64(fp, expr.Inputs[0]) &^ ReadI64(fp, expr.Inputs[1])
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opI64Bitshl(expr *CXExpression, fp int) {
 	outB0 := int64(ReadI64(fp, expr.Inputs[0]) << uint64(ReadI64(fp, expr.Inputs[1])))
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opI64Bitshr(expr *CXExpression, fp int) {
 	outB0 := int64(ReadI64(fp, expr.Inputs[0]) >> uint64(ReadI64(fp, expr.Inputs[1])))
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), outB0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in max function returns the greatest value of the two operands.
@@ -212,7 +212,7 @@ func opI64Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), inpV0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest value of the two operands.
@@ -222,5 +222,5 @@ func opI64Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI64(GetOffsetI64(fp, expr.Outputs[0]), inpV0)
+	WriteI64(GetOffset_i64(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_i8.go
+++ b/cx/op_i8.go
@@ -9,61 +9,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opI8ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatInt(int64(ReadI8(fp, expr.Inputs[0])), 10))
-	WriteObject(GetOffsetI8(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffset_i8(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i16 function returns operand 1 casted from type i8 to type i16.
 func opI8ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadI8(fp, expr.Inputs[0]))
-	WriteI16(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function returns operand 1 casted from type i8 to type i32.
 func opI8ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadI8(fp, expr.Inputs[0]))
-	WriteI32(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type i8 to type i64.
 func opI8ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadI8(fp, expr.Inputs[0]))
-	WriteI64(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i8 to type ui8.
 func opI8ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadI8(fp, expr.Inputs[0]))
-	WriteUI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns operand 1 casted from type i8 to type ui16.
 func opI8ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadI8(fp, expr.Inputs[0]))
-	WriteUI16(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns operand 1 casted from type i8 to type ui32.
 func opI8ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadI8(fp, expr.Inputs[0]))
-	WriteUI32(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns operand 1 casted from type i8 to type ui64.
 func opI8ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadI8(fp, expr.Inputs[0]))
-	WriteUI64(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i8 to type f32.
 func opI8ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadI8(fp, expr.Inputs[0]))
-	WriteF32(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i8 to type uf64.
 func opI8ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadI8(fp, expr.Inputs[0]))
-	WriteF64(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -74,31 +74,31 @@ func opI8Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two i8 numbers.
 func opI8Add(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) + ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two i8 numbers.
 func opI8Sub(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) - ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
 func opI8Neg(expr *CXExpression, fp int) {
 	outV0 := -ReadI8(fp, expr.Inputs[0])
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two i8 numbers.
 func opI8Mul(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) * ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two i8 numbers.
 func opI8Div(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) / ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in abs function returns the absolute number of the number.
@@ -106,51 +106,51 @@ func opI8Abs(expr *CXExpression, fp int) {
 	inpV0 := ReadI8(fp, expr.Inputs[0])
 	sign := inpV0 >> 7
 	outV0 := (inpV0 ^ sign) - sign
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opI8Gt(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) > ReadI8(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opI8Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) >= ReadI8(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opI8Lt(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) < ReadI8(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opI8Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) <= ReadI8(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opI8Eq(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) == ReadI8(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opI8Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) != ReadI8(fp, expr.Inputs[1])
-	WriteBool(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
 func opI8Mod(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) % ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
@@ -164,45 +164,45 @@ func opI8Rand(expr *CXExpression, fp int) {
 		outV0 = int8(rand.Intn(r) + int(minimum))
 	}
 
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opI8Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) & ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opI8Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) | ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opI8Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) ^ ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opI8Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) &^ ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opI8Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) << uint8(ReadI8(fp, expr.Inputs[1]))
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opI8Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) >> uint8(ReadI8(fp, expr.Inputs[1]))
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -212,7 +212,7 @@ func opI8Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), inpV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
@@ -222,5 +222,5 @@ func opI8Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), inpV0)
+	WriteI8(GetOffset_i8(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_i8.go
+++ b/cx/op_i8.go
@@ -9,61 +9,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opI8ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatInt(int64(ReadI8(fp, expr.Inputs[0])), 10))
-	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffsetI8(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i16 function returns operand 1 casted from type i8 to type i16.
 func opI8ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadI8(fp, expr.Inputs[0]))
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function returns operand 1 casted from type i8 to type i32.
 func opI8ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadI8(fp, expr.Inputs[0]))
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type i8 to type i64.
 func opI8ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadI8(fp, expr.Inputs[0]))
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i8 to type ui8.
 func opI8ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadI8(fp, expr.Inputs[0]))
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns operand 1 casted from type i8 to type ui16.
 func opI8ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadI8(fp, expr.Inputs[0]))
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns operand 1 casted from type i8 to type ui32.
 func opI8ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadI8(fp, expr.Inputs[0]))
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns operand 1 casted from type i8 to type ui64.
 func opI8ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadI8(fp, expr.Inputs[0]))
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i8 to type f32.
 func opI8ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadI8(fp, expr.Inputs[0]))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i8 to type uf64.
 func opI8ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadI8(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -74,31 +74,31 @@ func opI8Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two i8 numbers.
 func opI8Add(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) + ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two i8 numbers.
 func opI8Sub(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) - ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
 func opI8Neg(expr *CXExpression, fp int) {
 	outV0 := -ReadI8(fp, expr.Inputs[0])
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two i8 numbers.
 func opI8Mul(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) * ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two i8 numbers.
 func opI8Div(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) / ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in abs function returns the absolute number of the number.
@@ -106,51 +106,51 @@ func opI8Abs(expr *CXExpression, fp int) {
 	inpV0 := ReadI8(fp, expr.Inputs[0])
 	sign := inpV0 >> 7
 	outV0 := (inpV0 ^ sign) - sign
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opI8Gt(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) > ReadI8(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opI8Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) >= ReadI8(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opI8Lt(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) < ReadI8(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opI8Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) <= ReadI8(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opI8Eq(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) == ReadI8(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opI8Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) != ReadI8(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
 func opI8Mod(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) % ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
@@ -164,45 +164,45 @@ func opI8Rand(expr *CXExpression, fp int) {
 		outV0 = int8(rand.Intn(r) + int(minimum))
 	}
 
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opI8Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) & ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opI8Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) | ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opI8Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) ^ ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opI8Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) &^ ReadI8(fp, expr.Inputs[1])
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opI8Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) << uint8(ReadI8(fp, expr.Inputs[1]))
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opI8Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadI8(fp, expr.Inputs[0]) >> uint8(ReadI8(fp, expr.Inputs[1]))
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -212,7 +212,7 @@ func opI8Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
@@ -222,5 +222,5 @@ func opI8Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteI8(GetOffsetI8(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_str.go
+++ b/cx/op_str.go
@@ -13,7 +13,7 @@ func opStrToI8(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteI8(GetOffsetStr(fp, expr.Outputs[0]), int8(outV0))
+	WriteI8(GetOffset_str(fp, expr.Outputs[0]), int8(outV0))
 }
 
 func opStrToI16(expr *CXExpression, fp int) {
@@ -21,7 +21,7 @@ func opStrToI16(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteI16(GetOffsetStr(fp, expr.Outputs[0]), int16(outV0))
+	WriteI16(GetOffset_str(fp, expr.Outputs[0]), int16(outV0))
 }
 
 func opStrToI32(expr *CXExpression, fp int) {
@@ -29,7 +29,7 @@ func opStrToI32(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteI32(GetOffsetStr(fp, expr.Outputs[0]), int32(outV0))
+	WriteI32(GetOffset_str(fp, expr.Outputs[0]), int32(outV0))
 }
 
 func opStrToI64(expr *CXExpression, fp int) {
@@ -37,7 +37,7 @@ func opStrToI64(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteI64(GetOffsetStr(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffset_str(fp, expr.Outputs[0]), outV0)
 }
 
 func opStrToUI8(expr *CXExpression, fp int) {
@@ -45,7 +45,7 @@ func opStrToUI8(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteUI8(GetOffsetStr(fp, expr.Outputs[0]), uint8(outV0))
+	WriteUI8(GetOffset_str(fp, expr.Outputs[0]), uint8(outV0))
 }
 
 func opStrToUI16(expr *CXExpression, fp int) {
@@ -53,7 +53,7 @@ func opStrToUI16(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteUI16(GetOffsetStr(fp, expr.Outputs[0]), uint16(outV0))
+	WriteUI16(GetOffset_str(fp, expr.Outputs[0]), uint16(outV0))
 }
 
 func opStrToUI32(expr *CXExpression, fp int) {
@@ -61,7 +61,7 @@ func opStrToUI32(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteUI32(GetOffsetStr(fp, expr.Outputs[0]), uint32(outV0))
+	WriteUI32(GetOffset_str(fp, expr.Outputs[0]), uint32(outV0))
 }
 
 func opStrToUI64(expr *CXExpression, fp int) {
@@ -69,7 +69,7 @@ func opStrToUI64(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteUI64(GetOffsetStr(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_str(fp, expr.Outputs[0]), outV0)
 }
 
 func opStrToF32(expr *CXExpression, fp int) {
@@ -77,7 +77,7 @@ func opStrToF32(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteF32(GetOffsetStr(fp, expr.Outputs[0]), float32(outV0))
+	WriteF32(GetOffset_str(fp, expr.Outputs[0]), float32(outV0))
 }
 
 func opStrToF64(expr *CXExpression, fp int) {
@@ -85,7 +85,7 @@ func opStrToF64(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteF64(GetOffsetStr(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_str(fp, expr.Outputs[0]), outV0)
 }
 
 func opStrPrint(expr *CXExpression, fp int) {
@@ -95,32 +95,32 @@ func opStrPrint(expr *CXExpression, fp int) {
 
 func opStrEq(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) == ReadStr(fp, expr.Inputs[1])
-	WriteBool(GetOffsetStr(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_str(fp, expr.Outputs[0]), outB0)
 }
 
 func opStrUneq(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) != ReadStr(fp, expr.Inputs[1])
-	WriteBool(GetOffsetStr(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_str(fp, expr.Outputs[0]), outB0)
 }
 
 func opStrLt(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) < ReadStr(fp, expr.Inputs[1])
-	WriteBool(GetOffsetStr(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_str(fp, expr.Outputs[0]), outB0)
 }
 
 func opStrLteq(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) <= ReadStr(fp, expr.Inputs[1])
-	WriteBool(GetOffsetStr(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_str(fp, expr.Outputs[0]), outB0)
 }
 
 func opStrGt(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) >= ReadStr(fp, expr.Inputs[1])
-	WriteBool(GetOffsetStr(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_str(fp, expr.Outputs[0]), outB0)
 }
 
 func opStrGteq(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) >= ReadStr(fp, expr.Inputs[1])
-	WriteBool(GetOffsetStr(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffset_str(fp, expr.Outputs[0]), outB0)
 }
 
 // WriteString writes the string `str` on memory, starting at byte number `fp`.
@@ -135,7 +135,7 @@ func WriteString(fp int, str string, out *CXArgument) {
 	obj := append(header, byts...)
 
 	WriteMemory(heapOffset, obj)
-	WriteI32(GetOffsetStr(fp, out), int32(heapOffset))
+	WriteI32(GetOffset_str(fp, out), int32(heapOffset))
 }
 
 func opStrConcat(expr *CXExpression, fp int) {
@@ -153,11 +153,11 @@ func opStrSubstr(expr *CXExpression, fp int) {
 func opStrIndex(expr *CXExpression, fp int) {
 	str := ReadStr(fp, expr.Inputs[0])
 	substr := ReadStr(fp, expr.Inputs[1])
-	WriteI32(GetOffsetStr(fp, expr.Outputs[0]), int32(strings.Index(str, substr)))
+	WriteI32(GetOffset_str(fp, expr.Outputs[0]), int32(strings.Index(str, substr)))
 }
 
 func opStrLastIndex(expr *CXExpression, fp int) {
-	WriteI32(GetOffsetStr(fp, expr.Outputs[0]), int32(strings.LastIndex(ReadStr(fp, expr.Inputs[0]), ReadStr(fp, expr.Inputs[1]))))
+	WriteI32(GetOffset_str(fp, expr.Outputs[0]), int32(strings.LastIndex(ReadStr(fp, expr.Inputs[0]), ReadStr(fp, expr.Inputs[1]))))
 }
 
 func opStrTrimSpace(expr *CXExpression, fp int) {

--- a/cx/op_str.go
+++ b/cx/op_str.go
@@ -13,7 +13,7 @@ func opStrToI8(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), int8(outV0))
+	WriteI8(GetOffsetStr(fp, expr.Outputs[0]), int8(outV0))
 }
 
 func opStrToI16(expr *CXExpression, fp int) {
@@ -21,7 +21,7 @@ func opStrToI16(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), int16(outV0))
+	WriteI16(GetOffsetStr(fp, expr.Outputs[0]), int16(outV0))
 }
 
 func opStrToI32(expr *CXExpression, fp int) {
@@ -29,7 +29,7 @@ func opStrToI32(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(outV0))
+	WriteI32(GetOffsetStr(fp, expr.Outputs[0]), int32(outV0))
 }
 
 func opStrToI64(expr *CXExpression, fp int) {
@@ -37,7 +37,7 @@ func opStrToI64(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffsetStr(fp, expr.Outputs[0]), outV0)
 }
 
 func opStrToUI8(expr *CXExpression, fp int) {
@@ -45,7 +45,7 @@ func opStrToUI8(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), uint8(outV0))
+	WriteUI8(GetOffsetStr(fp, expr.Outputs[0]), uint8(outV0))
 }
 
 func opStrToUI16(expr *CXExpression, fp int) {
@@ -53,7 +53,7 @@ func opStrToUI16(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), uint16(outV0))
+	WriteUI16(GetOffsetStr(fp, expr.Outputs[0]), uint16(outV0))
 }
 
 func opStrToUI32(expr *CXExpression, fp int) {
@@ -61,7 +61,7 @@ func opStrToUI32(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), uint32(outV0))
+	WriteUI32(GetOffsetStr(fp, expr.Outputs[0]), uint32(outV0))
 }
 
 func opStrToUI64(expr *CXExpression, fp int) {
@@ -69,7 +69,7 @@ func opStrToUI64(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetStr(fp, expr.Outputs[0]), outV0)
 }
 
 func opStrToF32(expr *CXExpression, fp int) {
@@ -77,7 +77,7 @@ func opStrToF32(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), float32(outV0))
+	WriteF32(GetOffsetStr(fp, expr.Outputs[0]), float32(outV0))
 }
 
 func opStrToF64(expr *CXExpression, fp int) {
@@ -85,7 +85,7 @@ func opStrToF64(expr *CXExpression, fp int) {
 	if err != nil {
 		panic(CX_RUNTIME_ERROR)
 	}
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffsetStr(fp, expr.Outputs[0]), outV0)
 }
 
 func opStrPrint(expr *CXExpression, fp int) {
@@ -95,32 +95,32 @@ func opStrPrint(expr *CXExpression, fp int) {
 
 func opStrEq(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) == ReadStr(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetStr(fp, expr.Outputs[0]), outB0)
 }
 
 func opStrUneq(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) != ReadStr(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetStr(fp, expr.Outputs[0]), outB0)
 }
 
 func opStrLt(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) < ReadStr(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetStr(fp, expr.Outputs[0]), outB0)
 }
 
 func opStrLteq(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) <= ReadStr(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetStr(fp, expr.Outputs[0]), outB0)
 }
 
 func opStrGt(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) >= ReadStr(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetStr(fp, expr.Outputs[0]), outB0)
 }
 
 func opStrGteq(expr *CXExpression, fp int) {
 	outB0 := ReadStr(fp, expr.Inputs[0]) >= ReadStr(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteBool(GetOffsetStr(fp, expr.Outputs[0]), outB0)
 }
 
 // WriteString writes the string `str` on memory, starting at byte number `fp`.
@@ -135,7 +135,7 @@ func WriteString(fp int, str string, out *CXArgument) {
 	obj := append(header, byts...)
 
 	WriteMemory(heapOffset, obj)
-	WriteI32(GetFinalOffset(fp, out), int32(heapOffset))
+	WriteI32(GetOffsetStr(fp, out), int32(heapOffset))
 }
 
 func opStrConcat(expr *CXExpression, fp int) {
@@ -153,11 +153,11 @@ func opStrSubstr(expr *CXExpression, fp int) {
 func opStrIndex(expr *CXExpression, fp int) {
 	str := ReadStr(fp, expr.Inputs[0])
 	substr := ReadStr(fp, expr.Inputs[1])
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(strings.Index(str, substr)))
+	WriteI32(GetOffsetStr(fp, expr.Outputs[0]), int32(strings.Index(str, substr)))
 }
 
 func opStrLastIndex(expr *CXExpression, fp int) {
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), int32(strings.LastIndex(ReadStr(fp, expr.Inputs[0]), ReadStr(fp, expr.Inputs[1]))))
+	WriteI32(GetOffsetStr(fp, expr.Outputs[0]), int32(strings.LastIndex(ReadStr(fp, expr.Inputs[0]), ReadStr(fp, expr.Inputs[1]))))
 }
 
 func opStrTrimSpace(expr *CXExpression, fp int) {

--- a/cx/op_ui16.go
+++ b/cx/op_ui16.go
@@ -10,61 +10,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opUI16ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatUint(uint64(ReadUI16(fp, expr.Inputs[0])), 10))
-	WriteObject(GetOffsetUI16(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffset_ui16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui16 to type i8.
 func opUI16ToI8(expr *CXExpression, fp int) {
 	outV0 := int16(ReadUI16(fp, expr.Inputs[0]))
-	WriteI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type ui16 to type i16.
 func opUI16ToI16(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0])
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui16 to type i32.
 func opUI16ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadUI16(fp, expr.Inputs[0]))
-	WriteI32(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type ui16 to type i64.
 func opUI16ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadUI16(fp, expr.Inputs[0]))
-	WriteI64(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type ui16 to type ui8.
 func opUI16ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadUI16(fp, expr.Inputs[0]))
-	WriteUI8(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type ui16 to type ui32.
 func opUI16ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadUI16(fp, expr.Inputs[0]))
-	WriteUI32(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type ui16 to type ui64.
 func opUI16ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadUI16(fp, expr.Inputs[0]))
-	WriteUI64(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui16 to type f32.
 func opUI16ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadUI16(fp, expr.Inputs[0]))
-	WriteF32(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui16 to type f64.
 func opUI16ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadUI16(fp, expr.Inputs[0]))
-	WriteF64(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -75,113 +75,113 @@ func opUI16Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two ui16 numbers.
 func opUI16Add(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) + ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two ui16 numbers.
 func opUI16Sub(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) - ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two ui16 numbers.
 func opUI16Mul(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) * ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two ui16 numbers.
 func opUI16Div(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) / ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opUI16Gt(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) > ReadUI16(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opUI16Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) >= ReadUI16(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opUI16Lt(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) < ReadUI16(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opUI16Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) <= ReadUI16(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opUI16Eq(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) == ReadUI16(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opUI16Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) != ReadUI16(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
 func opUI16Mod(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) % ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
 func opUI16Rand(expr *CXExpression, fp int) {
 	outV0 := uint16(rand.Int31n(int32(math.MaxUint16)))
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opUI16Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) & ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opUI16Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) | ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opUI16Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) ^ ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opUI16Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) &^ ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opUI16Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) << ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opUI16Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) >> ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands..
@@ -191,7 +191,7 @@ func opUI16Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), inpV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -201,5 +201,5 @@ func opUI16Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), inpV0)
+	WriteUI16(GetOffset_ui16(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_ui16.go
+++ b/cx/op_ui16.go
@@ -10,61 +10,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opUI16ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatUint(uint64(ReadUI16(fp, expr.Inputs[0])), 10))
-	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffsetUI16(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui16 to type i8.
 func opUI16ToI8(expr *CXExpression, fp int) {
 	outV0 := int16(ReadUI16(fp, expr.Inputs[0]))
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type ui16 to type i16.
 func opUI16ToI16(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0])
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui16 to type i32.
 func opUI16ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadUI16(fp, expr.Inputs[0]))
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type ui16 to type i64.
 func opUI16ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadUI16(fp, expr.Inputs[0]))
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type ui16 to type ui8.
 func opUI16ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadUI16(fp, expr.Inputs[0]))
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type ui16 to type ui32.
 func opUI16ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadUI16(fp, expr.Inputs[0]))
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type ui16 to type ui64.
 func opUI16ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadUI16(fp, expr.Inputs[0]))
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui16 to type f32.
 func opUI16ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadUI16(fp, expr.Inputs[0]))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui16 to type f64.
 func opUI16ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadUI16(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -75,113 +75,113 @@ func opUI16Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two ui16 numbers.
 func opUI16Add(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) + ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two ui16 numbers.
 func opUI16Sub(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) - ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two ui16 numbers.
 func opUI16Mul(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) * ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two ui16 numbers.
 func opUI16Div(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) / ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opUI16Gt(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) > ReadUI16(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opUI16Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) >= ReadUI16(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opUI16Lt(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) < ReadUI16(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opUI16Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) <= ReadUI16(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opUI16Eq(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) == ReadUI16(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opUI16Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) != ReadUI16(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
 func opUI16Mod(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) % ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
 func opUI16Rand(expr *CXExpression, fp int) {
 	outV0 := uint16(rand.Int31n(int32(math.MaxUint16)))
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opUI16Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) & ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opUI16Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) | ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opUI16Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) ^ ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opUI16Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) &^ ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opUI16Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) << ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opUI16Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadUI16(fp, expr.Inputs[0]) >> ReadUI16(fp, expr.Inputs[1])
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands..
@@ -191,7 +191,7 @@ func opUI16Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -201,5 +201,5 @@ func opUI16Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteUI16(GetOffsetUI16(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_ui32.go
+++ b/cx/op_ui32.go
@@ -9,61 +9,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opUI32ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatUint(uint64(ReadUI32(fp, expr.Inputs[0])), 10))
-	WriteObject(GetOffsetUI32(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffset_ui32(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui32 to type i8.
 func opUI32ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadUI32(fp, expr.Inputs[0]))
-	WriteI8(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type ui32 to type i16.
 func opUI32ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadUI32(fp, expr.Inputs[0]))
-	WriteI16(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui32 to type i32.
 func opUI32ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadUI32(fp, expr.Inputs[0]))
-	WriteI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type ui32 to type i64.
 func opUI32ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadUI32(fp, expr.Inputs[0]))
-	WriteI64(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type ui32 to type ui8.
 func opUI32ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadUI32(fp, expr.Inputs[0]))
-	WriteUI8(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type ui32 to type ui16.
 func opUI32ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadUI32(fp, expr.Inputs[0]))
-	WriteUI16(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type ui32 to type ui64.
 func opUI32ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadUI32(fp, expr.Inputs[0]))
-	WriteUI64(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui32 to type f32.
 func opUI32ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadUI32(fp, expr.Inputs[0]))
-	WriteF32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui32 to type f64.
 func opUI32ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadUI32(fp, expr.Inputs[0]))
-	WriteF64(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -74,113 +74,113 @@ func opUI32Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two ui32 numbers.
 func opUI32Add(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) + ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two ui32 numbers.
 func opUI32Sub(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) - ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two ui32 numbers.
 func opUI32Mul(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) * ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two ui32 numbers.
 func opUI32Div(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) / ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opUI32Gt(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) > ReadUI32(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opUI32Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) >= ReadUI32(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opUI32Lt(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) < ReadUI32(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opUI32Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) <= ReadUI32(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opUI32Eq(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) == ReadUI32(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opUI32Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) != ReadUI32(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
 func opUI32Mod(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) % ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
 func opUI32Rand(expr *CXExpression, fp int) {
 	outV0 := rand.Uint32()
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opUI32Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) & ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opUI32Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) | ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opUI32Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) ^ ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opUI32Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) &^ ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opUI32Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) << ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opUI32Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) >> ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -190,7 +190,7 @@ func opUI32Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), inpV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
@@ -200,5 +200,5 @@ func opUI32Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), inpV0)
+	WriteUI32(GetOffset_ui32(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_ui32.go
+++ b/cx/op_ui32.go
@@ -9,61 +9,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opUI32ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatUint(uint64(ReadUI32(fp, expr.Inputs[0])), 10))
-	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffsetUI32(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui32 to type i8.
 func opUI32ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadUI32(fp, expr.Inputs[0]))
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type ui32 to type i16.
 func opUI32ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadUI32(fp, expr.Inputs[0]))
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui32 to type i32.
 func opUI32ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadUI32(fp, expr.Inputs[0]))
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type ui32 to type i64.
 func opUI32ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadUI32(fp, expr.Inputs[0]))
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type ui32 to type ui8.
 func opUI32ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadUI32(fp, expr.Inputs[0]))
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type ui32 to type ui16.
 func opUI32ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadUI32(fp, expr.Inputs[0]))
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type ui32 to type ui64.
 func opUI32ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadUI32(fp, expr.Inputs[0]))
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui32 to type f32.
 func opUI32ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadUI32(fp, expr.Inputs[0]))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui32 to type f64.
 func opUI32ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadUI32(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -74,113 +74,113 @@ func opUI32Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two ui32 numbers.
 func opUI32Add(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) + ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two ui32 numbers.
 func opUI32Sub(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) - ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two ui32 numbers.
 func opUI32Mul(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) * ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two ui32 numbers.
 func opUI32Div(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) / ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opUI32Gt(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) > ReadUI32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opUI32Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) >= ReadUI32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opUI32Lt(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) < ReadUI32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opUI32Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) <= ReadUI32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opUI32Eq(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) == ReadUI32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opUI32Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) != ReadUI32(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
 func opUI32Mod(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) % ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
 func opUI32Rand(expr *CXExpression, fp int) {
 	outV0 := rand.Uint32()
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opUI32Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) & ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opUI32Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) | ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opUI32Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) ^ ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opUI32Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) &^ ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opUI32Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) << ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opUI32Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadUI32(fp, expr.Inputs[0]) >> ReadUI32(fp, expr.Inputs[1])
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -190,7 +190,7 @@ func opUI32Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
@@ -200,5 +200,5 @@ func opUI32Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteUI32(GetOffsetUI32(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_ui64.go
+++ b/cx/op_ui64.go
@@ -9,61 +9,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opUI64ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatUint(ReadUI64(fp, expr.Inputs[0]), 10))
-	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffsetUI64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui64 to type i8.
 func opUI64ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadUI64(fp, expr.Outputs[0]))
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function retruns operand 1 casted from type ui64 to i16.
 func opUI64ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadUI64(fp, expr.Outputs[0]))
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui64 to type i32.
 func opUI64ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadUI64(fp, expr.Inputs[0]))
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function return operand 1 casted from type ui64 to type i64.
 func opUI64ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadUI64(fp, expr.Inputs[0]))
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type ui64 to type ui8.
 func opUI64ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadUI64(fp, expr.Inputs[0]))
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type ui64 to type ui16.
 func opUI64ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadUI64(fp, expr.Inputs[0]))
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type ui64 to type ui32.
 func opUI64ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadUI64(fp, expr.Inputs[0]))
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui64 to type f32.
 func opUI64ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadUI64(fp, expr.Inputs[0]))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui64 to type f64.
 func opUI64ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadUI64(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -74,113 +74,113 @@ func opUI64Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two ui64 numbers.
 func opUI64Add(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) + ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two ui64 numbers.
 func opUI64Sub(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) - ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two ui64 numbers.
 func opUI64Mul(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) * ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two ui64 numbers.
 func opUI64Div(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) / ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opUI64Gt(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) > ReadUI64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opUI64Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) >= ReadUI64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opUI64Lt(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) < ReadUI64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opUI64Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) <= ReadUI64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opUI64Eq(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) == ReadUI64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opUI64Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) != ReadUI64(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
 func opUI64Mod(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) % ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
 func opUI64Rand(expr *CXExpression, fp int) {
 	outV0 := rand.Uint64()
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opUI64Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) & ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opUI64Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) | ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opUI64Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) ^ ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opUI64Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) &^ ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opUI64Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) << ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opUI64Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) >> ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -190,7 +190,7 @@ func opUI64Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
@@ -200,5 +200,5 @@ func opUI64Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_ui64.go
+++ b/cx/op_ui64.go
@@ -9,61 +9,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opUI64ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatUint(ReadUI64(fp, expr.Inputs[0]), 10))
-	WriteObject(GetOffsetUI64(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffset_ui64(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui64 to type i8.
 func opUI64ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadUI64(fp, expr.Outputs[0]))
-	WriteI8(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function retruns operand 1 casted from type ui64 to i16.
 func opUI64ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadUI64(fp, expr.Outputs[0]))
-	WriteI16(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui64 to type i32.
 func opUI64ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadUI64(fp, expr.Inputs[0]))
-	WriteI32(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function return operand 1 casted from type ui64 to type i64.
 func opUI64ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadUI64(fp, expr.Inputs[0]))
-	WriteI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type ui64 to type ui8.
 func opUI64ToUI8(expr *CXExpression, fp int) {
 	outV0 := uint8(ReadUI64(fp, expr.Inputs[0]))
-	WriteUI8(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type ui64 to type ui16.
 func opUI64ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadUI64(fp, expr.Inputs[0]))
-	WriteUI16(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type ui64 to type ui32.
 func opUI64ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadUI64(fp, expr.Inputs[0]))
-	WriteUI32(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui64 to type f32.
 func opUI64ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadUI64(fp, expr.Inputs[0]))
-	WriteF32(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui64 to type f64.
 func opUI64ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadUI64(fp, expr.Inputs[0]))
-	WriteF64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -74,113 +74,113 @@ func opUI64Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two ui64 numbers.
 func opUI64Add(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) + ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two ui64 numbers.
 func opUI64Sub(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) - ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two ui64 numbers.
 func opUI64Mul(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) * ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two ui64 numbers.
 func opUI64Div(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) / ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opUI64Gt(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) > ReadUI64(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opUI64Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) >= ReadUI64(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opUI64Lt(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) < ReadUI64(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opUI64Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) <= ReadUI64(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opUI64Eq(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) == ReadUI64(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opUI64Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) != ReadUI64(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
 func opUI64Mod(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) % ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
 func opUI64Rand(expr *CXExpression, fp int) {
 	outV0 := rand.Uint64()
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opUI64Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) & ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opUI64Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) | ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opUI64Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) ^ ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opUI64Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) &^ ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opUI64Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) << ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opUI64Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadUI64(fp, expr.Inputs[0]) >> ReadUI64(fp, expr.Inputs[1])
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -190,7 +190,7 @@ func opUI64Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), inpV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
@@ -200,5 +200,5 @@ func opUI64Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI64(GetOffsetUI64(fp, expr.Outputs[0]), inpV0)
+	WriteUI64(GetOffset_ui64(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_ui8.go
+++ b/cx/op_ui8.go
@@ -10,61 +10,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opUI8ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatUint(uint64(ReadUI8(fp, expr.Inputs[0])), 10))
-	WriteObject(GetOffsetUI8(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffset_ui8(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui8 to type i8.
 func opUI8ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadUI8(fp, expr.Inputs[0]))
-	WriteI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type ui8 to type i16.
 func opUI8ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadUI8(fp, expr.Inputs[0]))
-	WriteI16(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui8 to type i32.
 func opUI8ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadUI8(fp, expr.Inputs[0]))
-	WriteI32(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type ui8 to type i64.
 func opUI8ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadUI8(fp, expr.Inputs[0]))
-	WriteI64(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type ui8 to type ui16.
 func opUI8ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadUI8(fp, expr.Inputs[0]))
-	WriteUI16(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type ui8 to type ui32.
 func opUI8ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadUI8(fp, expr.Inputs[0]))
-	WriteUI32(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type ui8 to type ui64.
 func opUI8ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadUI8(fp, expr.Inputs[0]))
-	WriteUI64(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui8 to type f32.
 func opUI8ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadUI8(fp, expr.Inputs[0]))
-	WriteF32(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui8 to type f64.
 func opUI8ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadUI8(fp, expr.Inputs[0]))
-	WriteF64(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -75,113 +75,113 @@ func opUI8Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two ui8 numbers.
 func opUI8Add(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) + ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two ui8 numbers.
 func opUI8Sub(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) - ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two ui8 numbers.
 func opUI8Mul(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) * ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two ui8 numbers.
 func opUI8Div(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) / ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opUI8Gt(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) > ReadUI8(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opUI8Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) >= ReadUI8(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opUI8Lt(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) < ReadUI8(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opUI8Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) <= ReadUI8(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opUI8Eq(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) == ReadUI8(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opUI8Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) != ReadUI8(fp, expr.Inputs[1])
-	WriteBool(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
 func opUI8Mod(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) % ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
 func opUI8Rand(expr *CXExpression, fp int) {
 	outV0 := uint8(rand.Int31n(int32(math.MaxUint8)))
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opUI8Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) & ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opUI8Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) | ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opUI8Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) ^ ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opUI8Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) &^ ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opUI8Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) << ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opUI8Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) >> uint32(ReadUI8(fp, expr.Inputs[1]))
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -191,7 +191,7 @@ func opUI8Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), inpV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
@@ -201,5 +201,5 @@ func opUI8Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), inpV0)
+	WriteUI8(GetOffset_ui8(fp, expr.Outputs[0]), inpV0)
 }

--- a/cx/op_ui8.go
+++ b/cx/op_ui8.go
@@ -10,61 +10,61 @@ import (
 // The built-in str function returns the base 10 string representation of operand 1.
 func opUI8ToStr(expr *CXExpression, fp int) {
 	outB0 := FromStr(strconv.FormatUint(uint64(ReadUI8(fp, expr.Inputs[0])), 10))
-	WriteObject(GetFinalOffset(fp, expr.Outputs[0]), outB0)
+	WriteObject(GetOffsetUI8(fp, expr.Outputs[0]), outB0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui8 to type i8.
 func opUI8ToI8(expr *CXExpression, fp int) {
 	outV0 := int8(ReadUI8(fp, expr.Inputs[0]))
-	WriteI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type ui8 to type i16.
 func opUI8ToI16(expr *CXExpression, fp int) {
 	outV0 := int16(ReadUI8(fp, expr.Inputs[0]))
-	WriteI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI16(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui8 to type i32.
 func opUI8ToI32(expr *CXExpression, fp int) {
 	outV0 := int32(ReadUI8(fp, expr.Inputs[0]))
-	WriteI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI32(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type ui8 to type i64.
 func opUI8ToI64(expr *CXExpression, fp int) {
 	outV0 := int64(ReadUI8(fp, expr.Inputs[0]))
-	WriteI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteI64(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type ui8 to type ui16.
 func opUI8ToUI16(expr *CXExpression, fp int) {
 	outV0 := uint16(ReadUI8(fp, expr.Inputs[0]))
-	WriteUI16(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI16(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type ui8 to type ui32.
 func opUI8ToUI32(expr *CXExpression, fp int) {
 	outV0 := uint32(ReadUI8(fp, expr.Inputs[0]))
-	WriteUI32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI32(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type ui8 to type ui64.
 func opUI8ToUI64(expr *CXExpression, fp int) {
 	outV0 := uint64(ReadUI8(fp, expr.Inputs[0]))
-	WriteUI64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI64(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui8 to type f32.
 func opUI8ToF32(expr *CXExpression, fp int) {
 	outV0 := float32(ReadUI8(fp, expr.Inputs[0]))
-	WriteF32(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF32(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui8 to type f64.
 func opUI8ToF64(expr *CXExpression, fp int) {
 	outV0 := float64(ReadUI8(fp, expr.Inputs[0]))
-	WriteF64(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteF64(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
@@ -75,113 +75,113 @@ func opUI8Print(expr *CXExpression, fp int) {
 // The built-in add function returns the sum of two ui8 numbers.
 func opUI8Add(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) + ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in sub function returns the difference of two ui8 numbers.
 func opUI8Sub(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) - ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mul function returns the product of two ui8 numbers.
 func opUI8Mul(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) * ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in div function returns the quotient of two ui8 numbers.
 func opUI8Div(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) / ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
 func opUI8Gt(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) > ReadUI8(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
 func opUI8Gteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) >= ReadUI8(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
 func opUI8Lt(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) < ReadUI8(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
 func opUI8Lteq(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) <= ReadUI8(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
 func opUI8Eq(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) == ReadUI8(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
 func opUI8Uneq(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) != ReadUI8(fp, expr.Inputs[1])
-	WriteBool(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteBool(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
 func opUI8Mod(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) % ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
 func opUI8Rand(expr *CXExpression, fp int) {
 	outV0 := uint8(rand.Int31n(int32(math.MaxUint8)))
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
 func opUI8Bitand(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) & ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
 func opUI8Bitor(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) | ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
 func opUI8Bitxor(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) ^ ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
 func opUI8Bitclear(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) &^ ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
 func opUI8Bitshl(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) << ReadUI8(fp, expr.Inputs[1])
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
 func opUI8Bitshr(expr *CXExpression, fp int) {
 	outV0 := ReadUI8(fp, expr.Inputs[0]) >> uint32(ReadUI8(fp, expr.Inputs[1]))
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), outV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
@@ -191,7 +191,7 @@ func opUI8Max(expr *CXExpression, fp int) {
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
@@ -201,5 +201,5 @@ func opUI8Min(expr *CXExpression, fp int) {
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-	WriteUI8(GetFinalOffset(fp, expr.Outputs[0]), inpV0)
+	WriteUI8(GetOffsetUI8(fp, expr.Outputs[0]), inpV0)
 }


### PR DESCRIPTION
Fixes #480

Changes:
- specialized func's created for GetFinalOffset
- GetFinalOffset replaced by respective func in op_files (op_i.., op_ui.., op_str, op_bool)

Does this change need to mentioned in CHANGELOG.md?
no