### PR TITLE
Mod/specialize read data

### DIFF
--- a/cx/base/op_os.go
+++ b/cx/base/op_os.go
@@ -632,7 +632,7 @@ func opOsReadI8Slice(expr *CXExpression, fp int) {
 func opOsWriteF64Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
-		if data := ReadData(fp, expr.Inputs[1], TYPE_F64); data != nil {
+		if data := ReadData_f64(fp, expr.Inputs[1], TYPE_F64); data != nil {
 			if err := binary.Write(file, binary.LittleEndian, data); err == nil {
 				success = true
 			}
@@ -644,7 +644,7 @@ func opOsWriteF64Slice(expr *CXExpression, fp int) {
 func opOsWriteF32Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
-		if data := ReadData(fp, expr.Inputs[1], TYPE_F32); data != nil {
+		if data := ReadData_f32(fp, expr.Inputs[1], TYPE_F32); data != nil {
 			if err := binary.Write(file, binary.LittleEndian, data); err == nil {
 				success = true
 			}
@@ -656,7 +656,7 @@ func opOsWriteF32Slice(expr *CXExpression, fp int) {
 func opOsWriteUI64Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
-		if data := ReadData(fp, expr.Inputs[1], TYPE_UI64); data != nil {
+		if data := ReadData_ui64(fp, expr.Inputs[1], TYPE_UI64); data != nil {
 			if err := binary.Write(file, binary.LittleEndian, data); err == nil {
 				success = true
 			}
@@ -668,7 +668,7 @@ func opOsWriteUI64Slice(expr *CXExpression, fp int) {
 func opOsWriteUI32Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
-		if data := ReadData(fp, expr.Inputs[1], TYPE_UI32); data != nil {
+		if data := ReadData_ui32(fp, expr.Inputs[1], TYPE_UI32); data != nil {
 			if err := binary.Write(file, binary.LittleEndian, data); err == nil {
 				success = true
 			}
@@ -680,7 +680,7 @@ func opOsWriteUI32Slice(expr *CXExpression, fp int) {
 func opOsWriteUI16Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
-		if data := ReadData(fp, expr.Inputs[1], TYPE_UI16); data != nil {
+		if data := ReadData_ui16(fp, expr.Inputs[1], TYPE_UI16); data != nil {
 			if err := binary.Write(file, binary.LittleEndian, data); err == nil {
 				success = true
 			}
@@ -692,7 +692,7 @@ func opOsWriteUI16Slice(expr *CXExpression, fp int) {
 func opOsWriteUI8Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
-		if data := ReadData(fp, expr.Inputs[1], TYPE_UI8); data != nil {
+		if data := ReadData_ui8(fp, expr.Inputs[1], TYPE_UI8); data != nil {
 			if err := binary.Write(file, binary.LittleEndian, data); err == nil {
 				success = true
 			}
@@ -704,7 +704,7 @@ func opOsWriteUI8Slice(expr *CXExpression, fp int) {
 func opOsWriteI64Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
-		if data := ReadData(fp, expr.Inputs[1], TYPE_I64); data != nil {
+		if data := ReadData_i64(fp, expr.Inputs[1], TYPE_I64); data != nil {
 			if err := binary.Write(file, binary.LittleEndian, data); err == nil {
 				success = true
 			}
@@ -716,7 +716,7 @@ func opOsWriteI64Slice(expr *CXExpression, fp int) {
 func opOsWriteI32Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
-		if data := ReadData(fp, expr.Inputs[1], TYPE_I32); data != nil {
+		if data := ReadData_i32(fp, expr.Inputs[1], TYPE_I32); data != nil {
 			if err := binary.Write(file, binary.LittleEndian, data); err == nil {
 				success = true
 			}
@@ -728,7 +728,7 @@ func opOsWriteI32Slice(expr *CXExpression, fp int) {
 func opOsWriteI16Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
-		if data := ReadData(fp, expr.Inputs[1], TYPE_I16); data != nil {
+		if data := ReadData_i16(fp, expr.Inputs[1], TYPE_I16); data != nil {
 			if err := binary.Write(file, binary.LittleEndian, data); err == nil {
 				success = true
 			}
@@ -740,7 +740,7 @@ func opOsWriteI16Slice(expr *CXExpression, fp int) {
 func opOsWriteI8Slice(expr *CXExpression, fp int) {
 	success := false
 	if file := validFileFromExpr(expr, fp); file != nil {
-		if data := ReadData(fp, expr.Inputs[1], TYPE_I8); data != nil {
+		if data := ReadData_i8(fp, expr.Inputs[1], TYPE_I8); data != nil {
 			if err := binary.Write(file, binary.LittleEndian, data); err == nil {
 				success = true
 			}

--- a/cx/fix_mem2.go
+++ b/cx/fix_mem2.go
@@ -91,9 +91,6 @@ func CalculateDereferences(arg *CXArgument, finalOffset *int, fp int) {
 	}
 }
 
-// TODO: str, bool
-// TODO: f32, f64
-
 // CalculateDereferences_i8 ...
 func CalculateDereferences_i8(arg *CXArgument, finalOffset *int, fp int) {
 	CalculateDereferences(arg, finalOffset, fp)

--- a/cx/fix_read3.go
+++ b/cx/fix_read3.go
@@ -1,7 +1,5 @@
 package cxcore
 
-import()
-
 //Why do these functions need CXArgument as imput!?
 
 func ReadData(fp int, inp *CXArgument, dataType int) interface{} {
@@ -13,6 +11,56 @@ func ReadData(fp int, inp *CXArgument, dataType int) interface{} {
 	} else {
 		return ReadObject(fp, inp, dataType)
 	}
+}
+
+// ReadData_i8 ...
+func ReadData_i8(fp int, inp *CXArgument, dataType int) interface{} {
+	return ReadData(fp, inp, dataType)
+}
+
+// ReadData_i16 ...
+func ReadData_i16(fp int, inp *CXArgument, dataType int) interface{} {
+	return ReadData(fp, inp, dataType)
+}
+
+// ReadData_i32 ...
+func ReadData_i32(fp int, inp *CXArgument, dataType int) interface{} {
+	return ReadData(fp, inp, dataType)
+}
+
+// ReadData_i64 ...
+func ReadData_i64(fp int, inp *CXArgument, dataType int) interface{} {
+	return ReadData(fp, inp, dataType)
+}
+
+// ReadData_ui8 ...
+func ReadData_ui8(fp int, inp *CXArgument, dataType int) interface{} {
+	return ReadData(fp, inp, dataType)
+}
+
+// ReadData_ui16 ...
+func ReadData_ui16(fp int, inp *CXArgument, dataType int) interface{} {
+	return ReadData(fp, inp, dataType)
+}
+
+// ReadData_ui32 ...
+func ReadData_ui32(fp int, inp *CXArgument, dataType int) interface{} {
+	return ReadData(fp, inp, dataType)
+}
+
+// ReadData_ui64 ...
+func ReadData_ui64(fp int, inp *CXArgument, dataType int) interface{} {
+	return ReadData(fp, inp, dataType)
+}
+
+// ReadData_f32 ...
+func ReadData_f32(fp int, inp *CXArgument, dataType int) interface{} {
+	return ReadData(fp, inp, dataType)
+}
+
+// ReadData_f64 ...
+func ReadData_f64(fp int, inp *CXArgument, dataType int) interface{} {
+	return ReadData(fp, inp, dataType)
 }
 
 //Note: Only called once and only by ReadData


### PR DESCRIPTION
Fixes #

Changes:
- ReadData funcs created for dtypes
- op_os, ReadData func calls replaced with respective func

Does this change need to mentioned in CHANGELOG.md?
