### PR TITLE
Feature/issue 544 functions for extracting ast

### DIFF
--- a/cmd/cx/flags.go
+++ b/cmd/cx/flags.go
@@ -17,6 +17,7 @@ type cxCmdFlags struct {
 	printHelp        bool
 	printVersion     bool
 	printEnv         bool
+	printAST         bool
 	tokenizeMode     bool
 	initialHeap      string
 	maxHeap          string
@@ -32,14 +33,14 @@ type cxCmdFlags struct {
 
 func defaultCmdFlags() cxCmdFlags {
 	return cxCmdFlags{
-		baseOutput:       false,
-		compileOutput:    "",
-		replMode:         false,
-		printHelp:        false,
-		printEnv:         false,
-		printVersion:     false,
-		debugLexer:   false,
-		debugProfile: 0,
+		baseOutput:    false,
+		compileOutput: "",
+		replMode:      false,
+		printHelp:     false,
+		printEnv:      false,
+		printVersion:  false,
+		debugLexer:    false,
+		debugProfile:  0,
 	}
 }
 
@@ -51,6 +52,8 @@ func appendDash(args []string) {
 		switch v {
 		case "version":
 			args[k] = "-version"
+		case "ast":
+			args[k] = "-ast"
 		}
 	}
 }
@@ -65,6 +68,7 @@ func parseFlags(options *cxCmdFlags, args []string) {
 	commandLine.BoolVar(&options.printVersion, "version", options.printVersion, "Print CX version")
 	commandLine.BoolVar(&options.printVersion, "v", options.printVersion, "alias for -version")
 	commandLine.BoolVar(&options.printEnv, "env", options.printEnv, "Print CX environment information")
+	commandLine.BoolVar(&options.printAST, "ast", options.printAST, "Print CX Program AST")
 	commandLine.BoolVar(&options.tokenizeMode, "tokenize", options.tokenizeMode, "generate a 'out.cx.txt' text file with parsed tokens")
 	commandLine.BoolVar(&options.tokenizeMode, "t", options.tokenizeMode, "alias for -tokenize")
 	commandLine.StringVar(&options.compileOutput, "co", options.compileOutput, "alias for -compile-output")
@@ -125,6 +129,13 @@ func checkversion(args []string) bool {
 
 func checkenv(args []string) bool {
 	if strings.Contains(args[0], "env") {
+		return true
+	}
+	return false
+}
+
+func checkAST(args []string) bool {
+	if strings.Contains(args[0], "ast") {
 		return true
 	}
 	return false

--- a/cmd/cx/main.go
+++ b/cmd/cx/main.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/skycoin/cx/cx"
+	cxcore "github.com/skycoin/cx/cx"
 	"github.com/skycoin/cx/cxgo/actions"
 	"github.com/skycoin/cx/cxgo/cxgo"
 	"github.com/skycoin/cx/cxgo/cxgo0"
@@ -107,6 +107,11 @@ func Run(args []string) {
 	DebugProfile = DebugProfileRate > 0
 
 	if run, bcHeap, sPrgrm := parseProgram(options, fileNames, sourceCode); run {
+		if checkAST(args) {
+			printProgramAST(options, cxArgs, sourceCode, bcHeap, sPrgrm)
+			return
+		}
+
 		runProgram(options, cxArgs, sourceCode, bcHeap, sPrgrm)
 	}
 }
@@ -226,6 +231,24 @@ func runProgram(options cxCmdFlags, cxArgs []string, sourceCode []*os.File, bcHe
 	if err != nil {
 		panic(err)
 	}
+
+	if cxcore.AssertFailed() {
+		os.Exit(cxcore.CX_ASSERT)
+	}
+}
+
+func printProgramAST(options cxCmdFlags, cxArgs []string, sourceCode []*os.File, bcHeap []byte, sPrgrm []byte) {
+	StartProfile("run")
+	defer StopProfile("run")
+
+	if options.replMode || len(sourceCode) == 0 {
+		actions.PRGRM.SelectProgram()
+		Repl()
+		return
+	}
+
+	// Print CX program.
+	actions.PRGRM.PrintProgram()
 
 	if cxcore.AssertFailed() {
 		os.Exit(cxcore.CX_ASSERT)

--- a/cx/utilities.go
+++ b/cx/utilities.go
@@ -290,7 +290,7 @@ func getFormattedParam(params []*CXArgument, pkg *CXPackage, buf *bytes.Buffer) 
 // string representation all the imported packages of `pkg`.
 func buildStrImports(pkg *CXPackage, ast *string) {
 	if len(pkg.Imports) > 0 {
-		*ast += "\tImports"
+		*ast += "\tImports\n"
 	}
 
 	for j, imp := range pkg.Imports {
@@ -302,7 +302,7 @@ func buildStrImports(pkg *CXPackage, ast *string) {
 // string representation of all the global variables of `pkg`.
 func buildStrGlobals(pkg *CXPackage, ast *string) {
 	if len(pkg.Globals) > 0 {
-		*ast += "\tGlobals"
+		*ast += "\tGlobals\n"
 	}
 
 	for j, v := range pkg.Globals {
@@ -324,7 +324,7 @@ func SignatureStringOfStruct(s *CXStruct) string {
 // string representation of all the structures defined in `pkg`.
 func buildStrStructs(pkg *CXPackage, ast *string) {
 	if len(pkg.Structs) > 0 {
-		*ast += "\tStructs"
+		*ast += "\tStructs\n"
 	}
 
 	for j, strct := range pkg.Structs {
@@ -352,7 +352,7 @@ func SignatureStringOfFunction(pkg *CXPackage, f *CXFunction) string {
 // string representation of all the functions defined in `pkg`.
 func buildStrFunctions(pkg *CXPackage, ast *string) {
 	if len(pkg.Functions) > 0 {
-		*ast += "\tFunctions"
+		*ast += "\tFunctions\n"
 	}
 
 	// We need to declare the counter outside so we can

--- a/cx/utilities.go
+++ b/cx/utilities.go
@@ -464,7 +464,7 @@ func (prgrm *CXProgram) PrintProgram() {
 // string format.
 func (prgrm *CXProgram) ToString() string {
 	var ast string
-	ast += "Program"
+	ast += "Program\n"
 
 	var currentFunction *CXFunction
 	var currentPackage *CXPackage


### PR DESCRIPTION
Fixes #
#544 

Changes:
-Refactored cx/utilities - CXProgram.PrintProgram(), PrintProgram() outputs AST to terminal
-cx/utilities - CXProgram.ToString() returns string representation of AST
-Added ast or -ast flag
  `cx -ast sample.cx ` outputs the program's AST instead of compiling

Does this change need to be mentioned in CHANGELOG.md?
