### PR TITLE
Replaced GetOffsetAtomic with GetOffsetAtomicSimple in cx/cx/fix_mem3.go

### DIFF
--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -91,13 +91,14 @@ func GetOffsetAtomic(fp int, arg *CXArgument) int {
 // GetOffset_i8 ...
 func GetOffset_i8(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
+	//return GetOffsetAtomic(fp,arg)
 	return GetOffsetAtomicSimple(fp,arg)
 }
 
 // GetOffset_i16 ...
 func GetOffset_i16(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	return GetOffsetAtomicSimple(fp, arg)
+	return GetOffsetAtomic(fp, arg)
 }
 
 // GetOffset_i32 ...

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -98,7 +98,8 @@ func GetOffset_i8(fp int, arg *CXArgument) int {
 // GetOffset_i16 ...
 func GetOffset_i16(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	return GetOffsetAtomic(fp, arg)
+	//return GetOffsetAtomic(fp, arg)
+	return GetOffsetAtomicSimple(fp,arg)
 }
 
 // GetOffset_i32 ...

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -91,7 +91,7 @@ func GetOffsetAtomic(fp int, arg *CXArgument) int {
 // GetOffset_i8 ...
 func GetOffset_i8(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	return GetOffsetAtomic(fp,arg)
+	return GetOffsetAtomicSimple(fp,arg)
 }
 
 // GetOffset_i16 ...

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -112,7 +112,8 @@ func GetOffset_i32(fp int, arg *CXArgument) int {
 // GetOffset_i64 ...
 func GetOffset_i64(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	return GetOffsetAtomic(fp, arg)
+	//return GetOffsetAtomic(fp, arg)
+	return GetOffsetAtomicSimple(fp,arg)
 }
 
 // GetOffset_ui8 ...

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -154,14 +154,16 @@ func GetOffset_f32(fp int, arg *CXArgument) int {
 // GetOffset_f64 ...
 func GetOffset_f64(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	return GetOffsetAtomic(fp, arg)
+	//return GetOffsetAtomic(fp, arg)
+	return GetOffsetAtomicSimple(fp,arg)
 }
 
 // GetOffset_bool ...
 //NOTE: BOOL is not ready for migration yet
 func GetOffset_bool(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	return GetOffsetAtomic(fp, arg)
+	//return GetOffsetAtomic(fp, arg)
+	return GetOffsetAtomicSimple(fp,arg)
 }
 
 // GetOffset_str ...

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -126,7 +126,8 @@ func GetOffset_ui8(fp int, arg *CXArgument) int {
 // GetOffset_ui16 ...
 func GetOffset_ui16(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	return GetOffsetAtomic(fp, arg)
+	//return GetOffsetAtomic(fp, arg)
+	return GetOffsetAtomicSimple(fp,arg)
 }
 
 // GetOffset_ui32 ...

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -147,7 +147,8 @@ func GetOffset_ui64(fp int, arg *CXArgument) int {
 // GetOffset_f32 ...
 func GetOffset_f32(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	return GetOffsetAtomic(fp, arg)
+	//return GetOffsetAtomic(fp, arg)
+	return GetOffsetAtomicSimple(fp,arg)
 }
 
 // GetOffset_f64 ...

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -97,7 +97,7 @@ func GetOffset_i8(fp int, arg *CXArgument) int {
 // GetOffset_i16 ...
 func GetOffset_i16(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	return GetOffsetAtomic(fp, arg)
+	return GetOffsetAtomicSimple(fp, arg)
 }
 
 // GetOffset_i32 ...

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -140,7 +140,8 @@ func GetOffset_ui32(fp int, arg *CXArgument) int {
 // GetOffset_ui64 ...
 func GetOffset_ui64(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	return GetOffsetAtomic(fp, arg)
+	//return GetOffsetAtomic(fp, arg)
+	return GetOffsetAtomicSimple(fp,arg)
 }
 
 // GetOffset_f32 ...

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -154,7 +154,7 @@ func GetOffset_f32(fp int, arg *CXArgument) int {
 // GetOffset_f64 ...
 func GetOffset_f64(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	//return GetOffsetAtomic(fp, arg)
+	// return GetOffsetAtomic(fp, arg)
 	return GetOffsetAtomicSimple(fp,arg)
 }
 

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -133,7 +133,8 @@ func GetOffset_ui16(fp int, arg *CXArgument) int {
 // GetOffset_ui32 ...
 func GetOffset_ui32(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	return GetOffsetAtomic(fp, arg)
+	//return GetOffsetAtomic(fp, arg)
+	return GetOffsetAtomicSimple(fp,arg)
 }
 
 // GetOffset_ui64 ...

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -105,7 +105,8 @@ func GetOffset_i16(fp int, arg *CXArgument) int {
 // GetOffset_i32 ...
 func GetOffset_i32(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	return GetOffsetAtomic(fp, arg)
+	//return GetOffsetAtomic(fp, arg)
+	return GetOffsetAtomicSimple(fp,arg)
 }
 
 // GetOffset_i64 ...

--- a/cx/fix_mem3.go
+++ b/cx/fix_mem3.go
@@ -119,7 +119,8 @@ func GetOffset_i64(fp int, arg *CXArgument) int {
 // GetOffset_ui8 ...
 func GetOffset_ui8(fp int, arg *CXArgument) int {
 	//return GetFinalOffset(fp, arg)
-	return GetOffsetAtomic(fp, arg)
+	//return GetOffsetAtomic(fp, arg)
+	return GetOffsetAtomicSimple(fp,arg)
 }
 
 // GetOffset_ui16 ...

--- a/cx/fix_read3.go
+++ b/cx/fix_read3.go
@@ -38,6 +38,8 @@ import (
 ./cx/fix_readmemory.go:8:func ReadMemory(offset int, arg *CXArgument) []byte {
 */
 
+var DEBUG_FIX_READ3_ASSERTIONS bool
+
 // ReadMemory ...
 //TODO: DELETE THIS FUNCTION
 //TODO: Avoid all read memory commands for fixed width types (i32,f32,etc)
@@ -57,6 +59,17 @@ func ReadObject(fp int, inp *CXArgument, dataType int) interface{} {
 }
 
 func ReadObjectAtomic(fp int, inp *CXArgument, dataType int) interface{} {
+
+	if DEBUG_FIX_READ3_ASSERTIONS {
+		if inp.IsArray{
+			panic("CXArgument is slice" )
+		}else if inp.IsSlice {
+			panic("CXArgument is slice" )
+		}else if inp.IsPointer {
+			panic("CXArgument is slice" )
+		}
+	}
+
 	offset := GetOffsetAtomic(fp, inp) //SHOULD NOT BE CALLED FOR ATOMICS
 	//FOR ATOMIC TYPES, CALL GetOffsetAtomic()
 	array := ReadMemory(offset, inp)


### PR DESCRIPTION
Fixes #564

Changes:
- Replaced GetOffsetAtomic with GetOffsetAtomicSimple in cx/cx/fix_mem3.go

Does this change need to mentioned in CHANGELOG.md?
No
