### PR TITLE
Remove opcodes init, make them initialize opcode table using LoadOpCo…

### DIFF
--- a/cmd/cx/main.go
+++ b/cmd/cx/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	repl "github.com/skycoin/cx/cmd/cxrepl"
 	cxcore "github.com/skycoin/cx/cx"
 	"github.com/skycoin/cx/cx/ast"
@@ -113,6 +114,9 @@ func Run(args []string) {
 	cxgo.DebugLexer = options.debugLexer // in package cxgo
 	profiling.DebugProfileRate = options.debugProfile
 	profiling.DebugProfile = profiling.DebugProfileRate > 0
+
+	// Load op code tables
+	cxcore.LoadOpCodeTables()
 
 	if run := parseProgram(options, fileNames, sourceCode); run {
 

--- a/cx/opcodes_init.go
+++ b/cx/opcodes_init.go
@@ -9,7 +9,7 @@ import (
 //TODO: dont need opcode for non-atomic types
 //TODO: Compiler needs to substitute for types and specify earlier
 
-func init() {
+func LoadOpCodeTables() {
 	httpPkg, err := ast.PROGRAM.GetPackage("http")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
…deTables()

Fixes #

Changes:
-Change cx core op code init() to LoadOpCodeTables(), forcing it to be called instead of relying on init()

Does this change need to mentioned in CHANGELOG.md?
