### PR TITLE
opcodes loaded on init

### DIFF
--- a/cmd/cx/main.go
+++ b/cmd/cx/main.go
@@ -103,7 +103,7 @@ func Run(args []string) {
 	profiling.DebugProfile = profiling.DebugProfileRate > 0
 
 	// Load op code tables
-	cxcore.LoadOpCodeTables()
+	cxgo.InitCXCore()
 
 	if run := parseProgram(options, fileNames, sourceCode); run {
 

--- a/cx/astapi/arguments_test.go
+++ b/cx/astapi/arguments_test.go
@@ -3,10 +3,10 @@ package astapi_test
 import (
 	"testing"
 
-	cxcore "github.com/skycoin/cx/cx"
 	cxast "github.com/skycoin/cx/cx/ast"
 	"github.com/skycoin/cx/cx/astapi"
 	cxconstants "github.com/skycoin/cx/cx/constants"
+	"github.com/skycoin/cx/cxgo/cxgo"
 )
 
 func TestASTAPI_Arguments(t *testing.T) {
@@ -14,7 +14,7 @@ func TestASTAPI_Arguments(t *testing.T) {
 
 	// Needed for AddNativeExpressionToFunction
 	// because of dependency on cxast.OpNames
-	cxcore.LoadOpCodeTables()
+	cxgo.InitCXCore()
 
 	t.Run("make program", func(t *testing.T) {
 		cxprogram = cxast.MakeProgram()

--- a/cx/astapi/expressions_test.go
+++ b/cx/astapi/expressions_test.go
@@ -3,10 +3,10 @@ package astapi_test
 import (
 	"testing"
 
-	cxcore "github.com/skycoin/cx/cx"
 	cxast "github.com/skycoin/cx/cx/ast"
 	"github.com/skycoin/cx/cx/astapi"
 	cxconstants "github.com/skycoin/cx/cx/constants"
+	"github.com/skycoin/cx/cxgo/cxgo"
 )
 
 func TestASTAPI_Expressions(t *testing.T) {
@@ -14,7 +14,7 @@ func TestASTAPI_Expressions(t *testing.T) {
 
 	// Needed for AddNativeExpressionToFunction
 	// because of dependency on cxast.OpNames
-	cxcore.LoadOpCodeTables()
+	cxgo.InitCXCore()
 
 	t.Run("make program", func(t *testing.T) {
 		cxprogram = cxast.MakeProgram()

--- a/cxgo/cxgo/init.go
+++ b/cxgo/cxgo/init.go
@@ -1,0 +1,18 @@
+package cxgo
+
+import (
+	cxcore "github.com/skycoin/cx/cx"
+)
+
+var Initialized bool
+
+func init() {
+	InitCXCore()
+}
+
+func InitCXCore() {
+	if !Initialized {
+		cxcore.LoadOpCodeTables()
+		Initialized = true
+	}
+}


### PR DESCRIPTION
Fixes #

Changes:
- op codes being loaded in cxgo init

Does this change need to mentioned in CHANGELOG.md?
No