### PR TITLE
Fix/revert get offset slice

### DIFF
--- a/cmd/cxtest/main.go
+++ b/cmd/cxtest/main.go
@@ -313,6 +313,7 @@ func runTestCases(t *runner.TestRunner) {
 	t.RunEx("issue-131.cx", runner.CxSuccess, "Panic when using arithmetic operations.", runner.TestIssue, 0)
 	t.RunEx("test-ar-1.cx", runner.CxSuccess, "Panic when using string to pointer array.", runner.TestIssue, 0)
 	t.RunEx("issue-157.cx", runner.CxSuccess, "expected either 'i32' or 'i64', got 'ident'", runner.TestIssue, 0)
+	t.Run("issue-650.cx", runner.CxSuccess, "test should not fail")
 
 	// We need to fix serialization and deserialization as user-callable functions
 	// t.RunEx("issue-309.cx", CxSuccess, "Serialization is not taking into account non-default stack sizes.", TestIssue, 0)

--- a/cx/ast/mem_slice.go
+++ b/cx/ast/mem_slice.go
@@ -22,8 +22,8 @@ func IsValidSliceIndex(offset int, index int, sizeofElement int) bool {
 func GetSliceOffset(fp int, arg *CXArgument) int32 {
 	element := GetAssignmentElement(arg)
 	if element.IsSlice {
-		// return GetPointerOffset(int32(GetFinalOffset(fp, arg)))
-		return GetPointerOffset(int32(GetOffset_slice(fp, arg)))
+		return GetPointerOffset(int32(GetFinalOffset(fp, arg)))
+		// return GetPointerOffset(int32(GetOffset_slice(fp, arg)))
 	}
 
 	return -1

--- a/tests/issue-650.cx
+++ b/tests/issue-650.cx
@@ -1,0 +1,14 @@
+package main
+
+type Soo struct {
+    sliceI32 []i32
+}
+
+func main()() {
+    var sliceSoo []Soo
+
+    var soo Soo
+    sliceSoo = append(sliceSoo, soo)
+
+    sliceSoo[0].sliceI32 = append(sliceSoo[0].sliceI32, 5)
+}

--- a/tests/main.cx
+++ b/tests/main.cx
@@ -379,6 +379,7 @@ func main ()() {
 	runTestEx("issue-131.cx", cx.SUCCESS, "Panic when using arithmetic operations.", TEST_ISSUE, 0)
 	runTestEx("test-ar-1.cx", cx.SUCCESS, "Panic when using string to pointer array.", TEST_ISSUE, 0)
 	runTestEx("issue-157.cx", cx.SUCCESS, "expected either 'i32' or 'i64', got 'ident'", TEST_ISSUE, 0)
+	runTest("issue-650.cx", cx.SUCCESS, "test should not fail")
 	
 
     // We need to fix serialization and deserialization as user-callable functions


### PR DESCRIPTION
Fixes #

Changes:
- GetOffset_slice reverted to GetFinalOffset
- new test `issue-650.cx` created for testing slices
- test added to test cases

Does this change need to mentioned in CHANGELOG.md?
no