### PR TITLE
reverted DeclarationSpecifiersSize and Offset back (they were actuall…

### DIFF
--- a/cx/ast/serialize.go
+++ b/cx/ast/serialize.go
@@ -101,6 +101,9 @@ func serializeArgument(arg *CXArgument, s *SerializedCXProgram) int {
 	s.Arguments[argOff].IndirectionLevels = int64(arg.IndirectionLevels)
 	s.Arguments[argOff].DereferenceLevels = int64(arg.DereferenceLevels)
 
+	s.Arguments[argOff].DeclarationSpecifiersOffset,
+		s.Arguments[argOff].DeclarationSpecifiersSize = serializeIntegers(arg.DeclarationSpecifiers, s)
+
 	s.Arguments[argOff].IsSlice = serializeBoolean(arg.IsSlice)
 	s.Arguments[argOff].IsPointer = serializeBoolean(arg.IsPointer)
 	s.Arguments[argOff].IsReference = serializeBoolean(arg.IsReference)
@@ -766,6 +769,8 @@ func deserializeArgument(sArg *serializedArgument, s *SerializedCXProgram, prgrm
 	arg.IndirectionLevels = int(sArg.IndirectionLevels)
 	arg.DereferenceLevels = int(sArg.DereferenceLevels)
 	arg.PassBy = int(sArg.PassBy)
+
+	arg.DeclarationSpecifiers = deserializeIntegers(sArg.DeclarationSpecifiersOffset, sArg.DeclarationSpecifiersSize, s)
 
 	arg.IsSlice = deserializeBool(sArg.IsSlice)
 	arg.IsPointer = deserializeBool(sArg.IsPointer)

--- a/cx/ast/serialize_structs.go
+++ b/cx/ast/serialize_structs.go
@@ -136,8 +136,10 @@ type serializedArgument struct {
 
 	Offset int64
 
-	IndirectionLevels int64
-	DereferenceLevels int64
+	IndirectionLevels           int64
+	DereferenceLevels           int64
+	DeclarationSpecifiersOffset int64
+	DeclarationSpecifiersSize   int64
 
 	IsSlice int64
 	// IsArray      int64

--- a/cx/ast/serialize_test.go
+++ b/cx/ast/serialize_test.go
@@ -7,7 +7,7 @@ import (
 	cxast "github.com/skycoin/cx/cx/ast"
 	"github.com/skycoin/cx/cx/astapi"
 	cxconstants "github.com/skycoin/cx/cx/constants"
-	cxparsingcompletor "github.com/skycoin/cx/cxparser/parsingcompletor"
+	cxparsingcompletor "github.com/skycoin/cx/cxparser/cxparsingcompletor"
 )
 
 func TestSerialize_CipherEncoder(t *testing.T) {

--- a/cx/ast/serialized_cx_program_skyencoder.go
+++ b/cx/ast/serialized_cx_program_skyencoder.go
@@ -356,11 +356,11 @@ func EncodeSizeSerializedCXProgram(obj *SerializedCXProgram) uint64 {
 		// x1.DereferenceOperationsOffset
 		i1 += 8
 
-		// // x1.DereferenceOperationsSize
-		// i1 += 8
+		// x1.DereferenceOperationsSize
+		i1 += 8
 
-		// // x1.DeclarationSpecifiersOffset
-		// i1 += 8
+		// x1.DeclarationSpecifiersOffset
+		i1 += 8
 
 		// x1.DeclarationSpecifiersSize
 		i1 += 8
@@ -920,11 +920,11 @@ func EncodeSerializedCXProgramToBuffer(buf []byte, obj *SerializedCXProgram) err
 		// // x.DereferenceOperationsSize
 		// e.Int64(x.DereferenceOperationsSize)
 
-		// // x.DeclarationSpecifiersOffset
-		// e.Int64(x.DeclarationSpecifiersOffset)
+		// x.DeclarationSpecifiersOffset
+		e.Int64(x.DeclarationSpecifiersOffset)
 
-		// // x.DeclarationSpecifiersSize
-		// e.Int64(x.DeclarationSpecifiersSize)
+		// x.DeclarationSpecifiersSize
+		e.Int64(x.DeclarationSpecifiersSize)
 
 		// x.IsSlice
 		e.Int64(x.IsSlice)
@@ -2166,23 +2166,23 @@ func DecodeSerializedCXProgram(buf []byte, obj *SerializedCXProgram) (uint64, er
 				// 	obj.Arguments[z1].DereferenceOperationsSize = i
 				// }
 
-				// {
-				// 	// obj.Arguments[z1].DeclarationSpecifiersOffset
-				// 	i, err := d.Int64()
-				// 	if err != nil {
-				// 		return 0, err
-				// 	}
-				// 	obj.Arguments[z1].DeclarationSpecifiersOffset = i
-				// }
+				{
+					// obj.Arguments[z1].DeclarationSpecifiersOffset
+					i, err := d.Int64()
+					if err != nil {
+						return 0, err
+					}
+					obj.Arguments[z1].DeclarationSpecifiersOffset = i
+				}
 
-				// {
-				// 	// obj.Arguments[z1].DeclarationSpecifiersSize
-				// 	i, err := d.Int64()
-				// 	if err != nil {
-				// 		return 0, err
-				// 	}
-				// 	obj.Arguments[z1].DeclarationSpecifiersSize = i
-				// }
+				{
+					// obj.Arguments[z1].DeclarationSpecifiersSize
+					i, err := d.Int64()
+					if err != nil {
+						return 0, err
+					}
+					obj.Arguments[z1].DeclarationSpecifiersSize = i
+				}
 
 				{
 					// obj.Arguments[z1].IsSlice


### PR DESCRIPTION
Fixes #662

Changes:
- DeclarationSpecifiers Offset and Size restored, as they are actually used.

Does this change need to mentioned in CHANGELOG.md?
