### PR TITLE
Feature/add compression for including memory in serialize

### DIFF
--- a/cx/ast/ast.go
+++ b/cx/ast/ast.go
@@ -15,7 +15,7 @@ import (
 type CXEXPR_TYPE int
 
 const (
-	CXEXPR_UNUSED         CXEXPR_TYPE = iota
+	CXEXPR_UNUSED CXEXPR_TYPE = iota
 	CXEXPR_METHOD_CALL
 	CXEXPR_STRUCT_LITERAL
 	CXEXPR_ARRAY_LITERAL
@@ -161,7 +161,6 @@ type CXExpression struct {
 
 	ExpressionType CXEXPR_TYPE
 }
-
 
 // IsMethodCall checks if expression type is method call
 func (cxe CXExpression) IsMethodCall() bool {

--- a/cx/ast/serialize.go
+++ b/cx/ast/serialize.go
@@ -580,6 +580,9 @@ func SerializeCXProgram(prgrm *CXProgram, includeMemory bool) (b []byte) {
 	// serializing everything
 	b = encoder.Serialize(s)
 
+	// Compress using LZ4
+	CompressBytesLZ4(&b)
+
 	return b
 }
 
@@ -935,6 +938,9 @@ func initDeserialization(prgrm *CXProgram, s *SerializedCXProgram) {
 func Deserialize(b []byte) (prgrm *CXProgram) {
 	prgrm = &CXProgram{}
 	var s SerializedCXProgram
+
+	// Uncompress using LZ4
+	UncompressBytesLZ4(&b)
 
 	helper.DeserializeRaw(b, &s)
 	initDeserialization(prgrm, &s)

--- a/cx/ast/serialize_skyencoder.go
+++ b/cx/ast/serialize_skyencoder.go
@@ -1,5 +1,9 @@
 package ast
 
+import (
+	"github.com/pierrec/lz4"
+)
+
 // SerializeCXProgramV2 is using skyencoder generated
 // encoder/decoder for serializing cx program.
 func SerializeCXProgramV2(prgrm *CXProgram, includeMemory bool) (b []byte) {
@@ -19,6 +23,9 @@ func SerializeCXProgramV2(prgrm *CXProgram, includeMemory bool) (b []byte) {
 		panic(err)
 	}
 
+	// Compress using LZ4
+	CompressBytesLZ4(&b)
+
 	return b
 }
 
@@ -26,7 +33,35 @@ func DeserializeCXProgramV2(b []byte) *CXProgram {
 	prgrm := &CXProgram{}
 	var sPrgrm SerializedCXProgram
 
+	// Uncompress using LZ4
+	UncompressBytesLZ4(&b)
+
 	DecodeSerializedCXProgram(b, &sPrgrm)
 	initDeserialization(prgrm, &sPrgrm)
 	return prgrm
+}
+
+func CompressBytesLZ4(data *[]byte) {
+	buf := make([]byte, len(*data))
+	ht := make([]int, 64<<10) // buffer for the compression table
+
+	n, err := lz4.CompressBlock(*data, buf, ht)
+	if err != nil {
+		panic(err)
+	}
+	if n >= len(*data) {
+		panic("data not compressible")
+	}
+
+	*data = buf[:n] // compressed data
+}
+
+func UncompressBytesLZ4(data *[]byte) {
+	// Allocated a very large buffer for decompression.
+	out := make([]byte, 1000*len(*data))
+	n, err := lz4.UncompressBlock(*data, out)
+	if err != nil {
+		panic(err)
+	}
+	*data = out[:n] // uncompressed data
 }

--- a/cx/ast/serialize_skyencoder.go
+++ b/cx/ast/serialize_skyencoder.go
@@ -6,9 +6,9 @@ import (
 
 // SerializeCXProgramV2 is using skyencoder generated
 // encoder/decoder for serializing cx program.
-func SerializeCXProgramV2(prgrm *CXProgram, includeMemory bool) (b []byte) {
+func SerializeCXProgramV2(prgrm *CXProgram, includeDataMemory, useCompression bool) (b []byte) {
 	s := SerializedCXProgram{}
-	initSerialization(prgrm, &s, includeMemory)
+	initSerialization(prgrm, &s, includeDataMemory, useCompression)
 
 	// serialize cx program's packages,
 	// structs, functions, etc.
@@ -23,18 +23,22 @@ func SerializeCXProgramV2(prgrm *CXProgram, includeMemory bool) (b []byte) {
 		panic(err)
 	}
 
-	// Compress using LZ4
-	CompressBytesLZ4(&b)
+	if useCompression {
+		// Compress using LZ4
+		CompressBytesLZ4(&b)
+	}
 
 	return b
 }
 
-func DeserializeCXProgramV2(b []byte) *CXProgram {
+func DeserializeCXProgramV2(b []byte, useCompression bool) *CXProgram {
 	prgrm := &CXProgram{}
 	var sPrgrm SerializedCXProgram
 
-	// Uncompress using LZ4
-	UncompressBytesLZ4(&b)
+	if useCompression {
+		// Uncompress using LZ4
+		UncompressBytesLZ4(&b)
+	}
 
 	DecodeSerializedCXProgram(b, &sPrgrm)
 	initDeserialization(prgrm, &sPrgrm)

--- a/cx/ast/serialize_structs.go
+++ b/cx/ast/serialize_structs.go
@@ -189,7 +189,8 @@ type SerializedCXProgram struct {
 	StringsMap map[string]int64
 	Integers   []int64
 
-	Memory []byte
+	Memory            []byte
+	DataSegmentMemory []byte
 }
 
 type SerializedDataSize struct {

--- a/cx/ast/serialize_test.go
+++ b/cx/ast/serialize_test.go
@@ -2,9 +2,11 @@ package ast_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	cxevolves "github.com/skycoin/cx-evolves/evolve"
+	"github.com/skycoin/cx/cx/ast"
 	cxast "github.com/skycoin/cx/cx/ast"
 	"github.com/skycoin/cx/cx/astapi"
 	cxconstants "github.com/skycoin/cx/cx/constants"
@@ -87,6 +89,41 @@ func TestSerialize_SkyEncoder_VS_CipherEncoder(t *testing.T) {
 				}
 			}
 			t.Logf("There were %v indexes that have different values. \nThese indexes are %v", diffCount, pos)
+		})
+	}
+}
+
+func TestCompression_LZ4(t *testing.T) {
+	tests := []struct {
+		scenario string
+		data     []byte
+	}{
+		{
+			scenario: "Valid data",
+			data:     []byte(strings.Repeat("HelloWorld", 100)),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.scenario, func(t *testing.T) {
+			originalLen := len(tc.data)
+			t.Logf("Original length of data: %v\n", originalLen)
+
+			ast.CompressBytesLZ4(&tc.data)
+			compressedLen := len(tc.data)
+			t.Logf("Compressed length of data: %v\n", compressedLen)
+
+			ast.UncompressBytesLZ4(&tc.data)
+			unCompressedLen := len(tc.data)
+			t.Logf("Uncompressed length of data: %v\n", unCompressedLen)
+
+			if compressedLen > originalLen {
+				t.Errorf("want compressed length to be less than original length, got %v", compressedLen)
+			}
+
+			if originalLen != unCompressedLen {
+				t.Errorf("want uncompressed length %v, got %v", originalLen, unCompressedLen)
+			}
 		})
 	}
 }

--- a/cx/astapi/arguments.go
+++ b/cx/astapi/arguments.go
@@ -3,6 +3,7 @@ package astapi
 import (
 	cxast "github.com/skycoin/cx/cx/ast"
 	cxconstants "github.com/skycoin/cx/cx/constants"
+	cxparseractions "github.com/skycoin/cx/cxparser/actions"
 )
 
 // AddNativeInputToExpression adds native input to an expression
@@ -338,4 +339,29 @@ func GetAccessibleArgsForFunctionByType(cxprogram *cxast.CXProgram, packageLocat
 	}
 
 	return argsList, nil
+}
+
+func AddLiteralInputToExpression(cxprogram *cxast.CXProgram, packageName, functionName string, bytes []byte, argType, lineNumber int) error {
+	pkg, err := FindPackage(cxprogram, packageName)
+	if err != nil {
+		return err
+	}
+	cxprogram.CurrentPackage = pkg
+	fn, err := FindFunction(cxprogram, functionName)
+	if err != nil {
+		return err
+	}
+
+	expr, err := fn.GetExpressionByLine(lineNumber)
+	if err != nil {
+		return err
+	}
+
+	cxparseractions.AST = cxprogram
+	litArg := cxparseractions.WritePrimary(argType, bytes, false)
+	arg := litArg[0].Outputs[0]
+	arg.ArgDetails.Package = pkg
+	expr.AddInput(arg)
+
+	return nil
 }

--- a/cx/astapi/arguments_test.go
+++ b/cx/astapi/arguments_test.go
@@ -1,6 +1,8 @@
 package astapi_test
 
 import (
+	"bytes"
+	"encoding/binary"
 	"testing"
 
 	cxast "github.com/skycoin/cx/cx/ast"
@@ -56,7 +58,10 @@ func TestASTAPI_Arguments(t *testing.T) {
 	})
 
 	t.Run("add first input to expression", func(t *testing.T) {
-		err := astapi.AddNativeInputToExpression(cxprogram, "main", "TestFunction", "x", cxconstants.TYPE_I16, 0)
+		buf := new(bytes.Buffer)
+		var num int32 = 5
+		binary.Write(buf, binary.LittleEndian, num)
+		err := astapi.AddLiteralInputToExpression(cxprogram, "main", "TestFunction", buf.Bytes(), cxconstants.TYPE_I16, 0)
 		if err != nil {
 			t.Errorf("want no error, got %v", err)
 		}

--- a/cx/opcodes/op_serialize.go
+++ b/cx/opcodes/op_serialize.go
@@ -8,12 +8,12 @@ import (
 
 func opSerialize(inputs []ast.CXValue, outputs []ast.CXValue) {
 	var slcOff int
-	byts := ast.SerializeCXProgram(ast.PROGRAM, true)
+	byts := ast.SerializeCXProgram(ast.PROGRAM, true, false)
 	for _, b := range byts {
 		slcOff = ast.WriteToSlice(slcOff, []byte{b})
 	}
 
-    outputs[0].Set_i32(int32(slcOff))
+	outputs[0].Set_i32(int32(slcOff))
 }
 
 func opDeserialize(inputs []ast.CXValue, outputs []ast.CXValue) {
@@ -22,5 +22,5 @@ func opDeserialize(inputs []ast.CXValue, outputs []ast.CXValue) {
 	_l := ast.PROGRAM.Memory[off+constants.OBJECT_HEADER_SIZE : off+constants.OBJECT_HEADER_SIZE+constants.SLICE_HEADER_SIZE]
 	l := helper.Deserialize_i32(_l[4:8])
 
-	ast.Deserialize(ast.PROGRAM.Memory[off+constants.OBJECT_HEADER_SIZE+constants.SLICE_HEADER_SIZE : off+constants.OBJECT_HEADER_SIZE+constants.SLICE_HEADER_SIZE+l]) // BUG : should be l * elt.TotalSize ?
+	ast.Deserialize(ast.PROGRAM.Memory[off+constants.OBJECT_HEADER_SIZE+constants.SLICE_HEADER_SIZE:off+constants.OBJECT_HEADER_SIZE+constants.SLICE_HEADER_SIZE+l], false) // BUG : should be l * elt.TotalSize ?
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/jinzhu/copier v0.2.5
 	github.com/mjibson/go-dsp v0.0.0-20180508042940-11479a337f12
+	github.com/pierrec/lz4 v2.6.0+incompatible
 	github.com/prashantv/gostub v1.0.0
 	github.com/sirupsen/logrus v1.8.0
 	github.com/skycoin/cx-evolves v0.0.0-20210422070949-64c6ff70d91e

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTm
 github.com/phpdave11/gofpdf v1.4.2 h1:KPKiIbfwbvC/wOncwhrpRdXVj2CZTCFlw4wnoyjtHfQ=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
+github.com/pierrec/lz4 v2.6.0+incompatible h1:Ix9yFKn1nSPBLFl/yZknTp8TU5G4Ps0JDmguYK6iH1A=
+github.com/pierrec/lz4 v2.6.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -118,6 +118,10 @@ github.com/marten-seemann/qtls-go1-15
 github.com/mjibson/go-dsp/wav
 # github.com/phpdave11/gofpdf v1.4.2
 github.com/phpdave11/gofpdf
+# github.com/pierrec/lz4 v2.6.0+incompatible
+## explicit
+github.com/pierrec/lz4
+github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/prashantv/gostub v1.0.0


### PR DESCRIPTION
Fixes #
#675 
Changes:
-Add lz4 compression for serialize deserialize of v1 and v2
-Add unit test for compression
-Add option to include data segment in serializing and also option to use compression or not

Does this change need to mentioned in CHANGELOG.md?
no