### PR TITLE
replace hardcoded 4 with elt.Size for printf

### DIFF
--- a/cx/ast/tostring.go
+++ b/cx/ast/tostring.go
@@ -341,7 +341,7 @@ func GetPrintableValue(fp int, arg *CXArgument) string {
 				// for slices
 				sliceOffset := GetSliceOffset(fp, arg)
 
-				sliceData := GetSlice(sliceOffset, 4)
+				sliceData := GetSlice(sliceOffset, elt.Size)
 				if len(sliceData) != 0 {
 					sliceLen := int(helper.Deserialize_i32(sliceData[:4]))
 					for c := 0; c < sliceLen; c++ {


### PR DESCRIPTION
Fixes #

Changes:
- Getting printable values for slices fixed to get by elt.Size instead of fixed 4

Does this change need to mentioned in CHANGELOG.md?
