### PR TITLE
Modularize methods and functions

### DIFF
--- a/cx/ast/ast_cxcall.go
+++ b/cx/ast/ast_cxcall.go
@@ -13,194 +13,229 @@ type CXCall struct {
 	FramePointer types.Pointer // Where in the stack is this function call's local variables stored
 }
 
-//function is only called once and by affordances
-//is a function on CXCal, not PROGRAM
-func (call *CXCall) Ccall(prgrm *CXProgram, globalInputs *[]CXValue, globalOutputs *[]CXValue) error {
+func popStack(prgrm *CXProgram, call *CXCall) error {
+	// going back to the previous call
+	prgrm.CallCounter--
+	if !prgrm.CallCounter.IsValid() {
+		// then the program finished
+		prgrm.Terminated = true
+		return nil
+	}
+
+	// copying the outputs to the previous stack frame
+	returnAddr := &prgrm.CallStack[prgrm.CallCounter]
+	returnOp := returnAddr.Operator
+	returnLine := returnAddr.Line
+	returnFP := returnAddr.FramePointer
+	fp := call.FramePointer
+
+	expr := returnOp.Expressions[returnLine]
+
+	lenOuts := len(expr.Outputs)
+	for i, out := range call.Operator.Outputs {
+		// Continuing if there is no receiving variable available.
+		if i >= lenOuts {
+			continue
+		}
+
+		types.WriteSlice_byte(prgrm.Memory, GetFinalOffset(returnFP, expr.Outputs[i]),
+			types.GetSlice_byte(prgrm.Memory, GetFinalOffset(fp, out), GetSize(out)))
+	}
+
+	// return the stack pointer to its previous state
+	prgrm.Stack.Pointer = fp
+	// we'll now execute the next command
+	prgrm.CallStack[prgrm.CallCounter].Line++
+	// calling the actual command
+	// prgrm.CallStack[prgrm.CallCounter].Call(prgrm)
+	return nil
+}
+
+func wipeDeclarationMemory(prgrm *CXProgram, expr *CXExpression) error {
+	newCall := &prgrm.CallStack[prgrm.CallCounter]
+	newFP := newCall.FramePointer
+	size := GetSize(expr.Outputs[0])
+	for c := types.Pointer(0); c < size; c++ {
+		prgrm.Memory[newFP+expr.Outputs[0].Offset+c] = 0
+	}
+
+	return nil
+}
+
+func processBuiltInOperators(expr *CXExpression, globalInputs *[]CXValue, globalOutputs *[]CXValue, fp types.Pointer) error {
+	if IsOperator(expr.Operator.AtomicOPCode) {
+		// TODO: resolve this at compile time
+		atomicType := expr.Inputs[0].GetType()
+		expr.Operator = GetTypedOperator(atomicType, expr.Operator.AtomicOPCode)
+	}
+	inputs := expr.Inputs
+	inputCount := len(inputs)
+	if inputCount > len(*globalInputs) {
+		*globalInputs = make([]CXValue, inputCount)
+	}
+	inputValues := (*globalInputs)[:inputCount]
+
+	outputs := expr.Outputs
+	outputCount := len(outputs)
+	if outputCount > len(*globalOutputs) {
+		*globalOutputs = make([]CXValue, outputCount)
+	}
+	outputValues := (*globalOutputs)[:outputCount]
+
+	argIndex := 0
+	for inputIndex := 0; inputIndex < inputCount; inputIndex++ {
+		input := inputs[inputIndex]
+		offset := GetFinalOffset(fp, input)
+		value := &inputValues[inputIndex]
+		value.Arg = input
+		value.Offset = offset
+		value.Type = input.Type
+		if input.Type == types.POINTER {
+			value.Type = input.PointerTargetType
+		}
+		value.FramePointer = fp
+		value.Expr = expr
+		argIndex++
+	}
+
+	for outputIndex := 0; outputIndex < outputCount; outputIndex++ {
+		output := outputs[outputIndex]
+		offset := GetFinalOffset(fp, output)
+		value := &outputValues[outputIndex]
+		value.Arg = output
+		value.Offset = offset
+		value.Type = output.Type
+		if output.Type == types.POINTER {
+			value.Type = output.PointerTargetType
+		}
+		value.FramePointer = fp
+		value.Expr = expr
+		argIndex++
+	}
+
+	OpcodeHandlers[expr.Operator.AtomicOPCode](inputValues, outputValues)
+
+	return nil
+}
+
+func processNonAtomicOperators(prgrm *CXProgram, expr *CXExpression, fp types.Pointer) error {
+	//TODO: Is this only called for user defined functions?
+	/*
+	   It was not a native, so we need to create another call
+	   with the current expression's operator
+	*/
+	// we're going to use the next call in the callstack
+	prgrm.CallCounter++
+	if prgrm.CallCounter >= constants.CALLSTACK_SIZE {
+		panic(constants.STACK_OVERFLOW_ERROR)
+	}
+
+	newCall := &prgrm.CallStack[prgrm.CallCounter]
+	// setting the new call
+	newCall.Operator = expr.Operator
+	newCall.Line = 0
+	newCall.FramePointer = prgrm.Stack.Pointer
+	// the stack pointer is moved to create room for the next call
+	// prgrm.MemoryPointer += fn.Size
+	prgrm.Stack.Pointer += newCall.Operator.Size
+
+	// checking if enough memory in stack
+	if prgrm.Stack.Pointer > constants.STACK_SIZE {
+		panic(constants.STACK_OVERFLOW_ERROR)
+	}
+
+	newFP := newCall.FramePointer
+
+	// wiping next stack frame (removing garbage)
+	for c := types.Pointer(0); c < expr.Operator.Size; c++ {
+		prgrm.Memory[newFP+c] = 0
+	}
+
+	for i, inp := range expr.Inputs {
+		var byts []byte
+		// finalOffset := inp.Offset
+		finalOffset := GetFinalOffset(fp, inp)
+		// finalOffset := fp + inp.Offset
+
+		// if inp.Indexes != nil {
+		// 	finalOffset = GetFinalOffset(&prgrm.Stacks[0], fp, inp)
+		// }
+		if inp.PassBy == constants.PASSBY_REFERENCE {
+			// If we're referencing an inner element, like an element of a slice (&slc[0])
+			// or a field of a struct (&struct.fld) we no longer need to add
+			// the OBJECT_HEADER_SIZE to the offset
+			if inp.IsInnerReference {
+				finalOffset -= types.OBJECT_HEADER_SIZE
+			}
+			var finalOffsetB [types.POINTER_SIZE]byte
+			types.Write_ptr(finalOffsetB[:], 0, finalOffset)
+			byts = finalOffsetB[:]
+		} else {
+			size := GetSize(inp)
+			byts = prgrm.Memory[finalOffset : finalOffset+size]
+		}
+
+		// writing inputs to new stack frame
+		types.WriteSlice_byte(
+			prgrm.Memory,
+			GetFinalOffset(newFP, newCall.Operator.Inputs[i]),
+			// newFP + newCall.Operator.ProgramInput[i].Offset,
+			// GetFinalOffset(prgrm.Memory, newFP, newCall.Operator.ProgramInput[i], MEM_WRITE),
+			byts)
+	}
+
+	return nil
+}
+
+func (call *CXCall) Call(prgrm *CXProgram, globalInputs *[]CXValue, globalOutputs *[]CXValue) error {
 	// CX is still single-threaded, so only one stack
 	if call.Line >= call.Operator.LineCount {
 		/*
 		   popping the stack
 		*/
-		// going back to the previous call
-		prgrm.CallCounter--
-		if !prgrm.CallCounter.IsValid() {
-			// then the program finished
-			prgrm.Terminated = true
-			return nil
+		err := popStack(prgrm, call)
+		if err != nil {
+			return err
 		}
 
-		// copying the outputs to the previous stack frame
-		returnAddr := &prgrm.CallStack[prgrm.CallCounter]
-		returnOp := returnAddr.Operator
-		returnLine := returnAddr.Line
-		returnFP := returnAddr.FramePointer
-		fp := call.FramePointer
+		return nil
+	}
 
-		expr := returnOp.Expressions[returnLine]
+	/*
+	   continue with call operator's execution
+	*/
 
-		lenOuts := len(expr.Outputs)
-		for i, out := range call.Operator.Outputs {
-			// Continuing if there is no receiving variable available.
-			if i >= lenOuts {
-				continue
-			}
+	fn := call.Operator
+	expr := fn.Expressions[call.Line]
+	fp := call.FramePointer
 
-			types.WriteSlice_byte(PROGRAM.Memory, GetFinalOffset(returnFP, expr.Outputs[i]),
-				types.GetSlice_byte(PROGRAM.Memory, GetFinalOffset(fp, out), GetSize(out)))
+	// if it's a native, then we just process the arguments with execNative
+	//TODO: WHEN WOULD OPERATOR EVER BE NIL?
+	if expr.Operator == nil {
+		// then it's a declaration
+		// wiping this declaration's memory (removing garbage)
+		err := wipeDeclarationMemory(prgrm, expr)
+		if err != nil {
+			return err
 		}
 
-		// return the stack pointer to its previous state
-		prgrm.Stack.Pointer = call.FramePointer
-		// we'll now execute the next command
-		prgrm.CallStack[prgrm.CallCounter].Line++
-		// calling the actual command
-		// prgrm.CallStack[prgrm.CallCounter].Ccall(prgrm)
+		call.Line++
+	} else if expr.Operator.IsBuiltIn() {
+		//TODO: SLICES ARE NON ATOMIC
+		err := processBuiltInOperators(expr, globalInputs, globalOutputs, fp)
+		if err != nil {
+			return err
+		}
 
+		call.Line++
 	} else {
-		/*
-		   continue with call operator's execution
-		*/
-		fn := call.Operator
-		expr := fn.Expressions[call.Line]
-
-		// if it's a native, then we just process the arguments with execNative
-
-		//TODO: WHEN WOULD OPERATOR EVER BE NIL?
-		if expr.Operator == nil {
-			// then it's a declaration
-			// wiping this declaration's memory (removing garbage)
-			newCall := &prgrm.CallStack[prgrm.CallCounter]
-			newFP := newCall.FramePointer
-			size := GetSize(expr.Outputs[0])
-			for c := types.Pointer(0); c < size; c++ {
-				prgrm.Memory[newFP+expr.Outputs[0].Offset+c] = 0
-			}
-			call.Line++
-		} else if expr.Operator.IsBuiltIn() {
-			//TODO: SLICES ARE NON ATOMIC
-
-			fp := call.FramePointer
-			if IsOperator(expr.Operator.AtomicOPCode) {
-				// TODO: resolve this at compile time
-				atomicType := expr.Inputs[0].GetType()
-				expr.Operator = GetTypedOperator(atomicType, expr.Operator.AtomicOPCode)
-			}
-			inputs := expr.Inputs
-			inputCount := len(inputs)
-			if inputCount > len(*globalInputs) {
-				*globalInputs = make([]CXValue, inputCount)
-			}
-			inputValues := (*globalInputs)[:inputCount]
-
-			outputs := expr.Outputs
-			outputCount := len(outputs)
-			if outputCount > len(*globalOutputs) {
-				*globalOutputs = make([]CXValue, outputCount)
-			}
-			outputValues := (*globalOutputs)[:outputCount]
-
-			argIndex := 0
-			for inputIndex := 0; inputIndex < inputCount; inputIndex++ {
-				input := inputs[inputIndex]
-				offset := GetFinalOffset(fp, input)
-				value := &inputValues[inputIndex]
-				value.Arg = input
-				value.Offset = offset
-				value.Type = input.Type
-				if input.Type == types.POINTER {
-					value.Type = input.PointerTargetType
-				}
-				value.FramePointer = fp
-				value.Expr = expr
-				argIndex++
-			}
-
-			for outputIndex := 0; outputIndex < outputCount; outputIndex++ {
-				output := outputs[outputIndex]
-				offset := GetFinalOffset(fp, output)
-				value := &outputValues[outputIndex]
-				value.Arg = output
-				value.Offset = offset
-				value.Type = output.Type
-				if output.Type == types.POINTER {
-					value.Type = output.PointerTargetType
-				}
-				value.FramePointer = fp
-				value.Expr = expr
-				argIndex++
-			}
-
-			OpcodeHandlers[expr.Operator.AtomicOPCode](inputValues, outputValues)
-
-			call.Line++
-		} else { //NON-ATOMIC OPERATOR
-			//TODO: Is this only called for user defined functions?
-			/*
-			   It was not a native, so we need to create another call
-			   with the current expression's operator
-			*/
-			// we're going to use the next call in the callstack
-			prgrm.CallCounter++
-			if prgrm.CallCounter >= constants.CALLSTACK_SIZE {
-				panic(constants.STACK_OVERFLOW_ERROR)
-			}
-
-			newCall := &prgrm.CallStack[prgrm.CallCounter]
-			// setting the new call
-			newCall.Operator = expr.Operator
-			newCall.Line = 0
-			newCall.FramePointer = prgrm.Stack.Pointer
-			// the stack pointer is moved to create room for the next call
-			// prgrm.MemoryPointer += fn.Size
-			prgrm.Stack.Pointer += newCall.Operator.Size
-
-			// checking if enough memory in stack
-			if prgrm.Stack.Pointer > constants.STACK_SIZE {
-				panic(constants.STACK_OVERFLOW_ERROR)
-			}
-
-			fp := call.FramePointer
-			newFP := newCall.FramePointer
-
-			// wiping next stack frame (removing garbage)
-			for c := types.Pointer(0); c < expr.Operator.Size; c++ {
-				prgrm.Memory[newFP+c] = 0
-			}
-
-			for i, inp := range expr.Inputs {
-				var byts []byte
-				// finalOffset := inp.Offset
-				finalOffset := GetFinalOffset(fp, inp)
-				// finalOffset := fp + inp.Offset
-
-				// if inp.Indexes != nil {
-				// 	finalOffset = GetFinalOffset(&prgrm.Stacks[0], fp, inp)
-				// }
-				if inp.PassBy == constants.PASSBY_REFERENCE {
-					// If we're referencing an inner element, like an element of a slice (&slc[0])
-					// or a field of a struct (&struct.fld) we no longer need to add
-					// the OBJECT_HEADER_SIZE to the offset
-					if inp.IsInnerReference {
-						finalOffset -= types.OBJECT_HEADER_SIZE
-					}
-					var finalOffsetB [types.POINTER_SIZE]byte
-					types.Write_ptr(finalOffsetB[:], 0, finalOffset)
-					byts = finalOffsetB[:]
-				} else {
-					size := GetSize(inp)
-					byts = prgrm.Memory[finalOffset : finalOffset+size]
-				}
-
-				// writing inputs to new stack frame
-				types.WriteSlice_byte(
-					prgrm.Memory,
-					GetFinalOffset(newFP, newCall.Operator.Inputs[i]),
-					// newFP + newCall.Operator.ProgramInput[i].Offset,
-					// GetFinalOffset(prgrm.Memory, newFP, newCall.Operator.ProgramInput[i], MEM_WRITE),
-					byts)
-			}
+		//NON-ATOMIC OPERATOR
+		err := processNonAtomicOperators(prgrm, expr, fp)
+		if err != nil {
+			return err
 		}
 	}
+
 	return nil
 }
 

--- a/cx/ast/ast_cxcall.go
+++ b/cx/ast/ast_cxcall.go
@@ -113,7 +113,7 @@ func processBuiltInOperators(expr *CXExpression, globalInputs *[]CXValue, global
 		argIndex++
 	}
 
-	OpcodeHandlers[expr.Operator.AtomicOPCode](inputValues, outputValues)
+	OpcodeHandlers[expr.Operator.AtomicOPCode](PROGRAM, inputValues, outputValues)
 
 	return nil
 }

--- a/cx/ast/opcodes.go
+++ b/cx/ast/opcodes.go
@@ -14,12 +14,12 @@ var (
 )
 
 var (
-	OpcodeHandlers    []OpcodeHandler
+	OpcodeHandlers []OpcodeHandler
 )
 
 // OpcodeHandler ...
 //TODO: make special op-code handler for 2 input, 1 output atomics
-type OpcodeHandler func(inputs []CXValue, outputs []CXValue)
+type OpcodeHandler func(prgrm *CXProgram, inputs []CXValue, outputs []CXValue)
 
 //TODO: Do atomic opcode handlers (not slices, not arrays)
 //type AtomicOpcodeHandler func(input1 CXValue, input2 CXValue, output CXValue)
@@ -37,4 +37,3 @@ var (
 	Natives   = map[int]*CXFunction{}
 	Operators []*CXFunction
 )
-

--- a/cx/execute/callback.go
+++ b/cx/execute/callback.go
@@ -49,7 +49,7 @@ func Callback(cxprogram *ast.CXProgram, fn *ast.CXFunction, inputs [][]byte) (ou
 	for _, out := range fn.Outputs {
 		// Making a copy of the bytes, so if we modify the bytes being held by `outputs`
 		// we don't modify the program memory.
-		mem := types.GetSlice_byte(ast.PROGRAM.Memory, ast.GetFinalOffset(newFP, out), ast.GetSize(out))
+		mem := types.GetSlice_byte(cxprogram.Memory, ast.GetFinalOffset(newFP, out), ast.GetSize(out))
 		cop := make([]byte, len(mem))
 		copy(cop, mem)
 		outputs = append(outputs, cop)

--- a/cx/execute/execute.go
+++ b/cx/execute/execute.go
@@ -121,7 +121,7 @@ func runSysInitFunc(cxprogram *ast.CXProgram, mod *ast.CXPackage) error {
 }
 
 func feedOSArgs(cxprogram *ast.CXProgram, args []string) error {
-	if osPkg, err := ast.PROGRAM.SelectPackage(constants.OS_PKG); err == nil {
+	if osPkg, err := cxprogram.SelectPackage(constants.OS_PKG); err == nil {
 		argsOffset := types.Pointer(0)
 		if osGbl, err := osPkg.GetGlobal(constants.OS_ARGS); err == nil {
 			for _, arg := range args {
@@ -131,7 +131,7 @@ func feedOSArgs(cxprogram *ast.CXProgram, args []string) error {
 				types.Write_ptr(argOffsetBytes[:], 0, argOffset)
 				argsOffset = ast.WriteToSlice(argsOffset, argOffsetBytes[:])
 			}
-			types.Write_ptr(ast.PROGRAM.Memory, ast.GetFinalOffset(0, osGbl), argsOffset)
+			types.Write_ptr(cxprogram.Memory, ast.GetFinalOffset(0, osGbl), argsOffset)
 		}
 	}
 	return nil

--- a/cx/execute/execute.go
+++ b/cx/execute/execute.go
@@ -82,7 +82,7 @@ func RunCxAst(cxprogram *ast.CXProgram, untilEnd bool, maxOps int, untilCall typ
 			opCount++
 		}
 
-		err := call.Ccall(cxprogram, &inputs, &outputs)
+		err := call.Call(cxprogram, &inputs, &outputs)
 		if err != nil {
 			return err
 		}
@@ -107,7 +107,7 @@ func runSysInitFunc(cxprogram *ast.CXProgram, mod *ast.CXPackage) error {
 
 	for !cxprogram.Terminated {
 		call := &cxprogram.CallStack[cxprogram.CallCounter]
-		err = call.Ccall(cxprogram, &inputs, &outputs)
+		err = call.Call(cxprogram, &inputs, &outputs)
 		if err != nil {
 			return err
 		}

--- a/cx/opcodes/op_aff.go
+++ b/cx/opcodes/op_aff.go
@@ -81,7 +81,7 @@ func CallAffPredicate(fn *ast.CXFunction, predValue []byte) byte {
 	prevCC := ast.PROGRAM.CallCounter
 	for {
 		call := &ast.PROGRAM.CallStack[ast.PROGRAM.CallCounter]
-		err := call.Ccall(ast.PROGRAM, &inputs, &outputs)
+		err := call.Call(ast.PROGRAM, &inputs, &outputs)
 		if err != nil {
 			panic(err)
 		}

--- a/cx/opcodes/op_bool.go
+++ b/cx/opcodes/op_bool.go
@@ -2,35 +2,36 @@ package opcodes
 
 import (
 	"fmt"
+
 	"github.com/skycoin/cx/cx/ast"
 )
 
-func opBoolPrint(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opBoolPrint(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	fmt.Println(inputs[0].Get_bool())
 }
 
-func opBoolEqual(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opBoolEqual(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_bool() == inputs[1].Get_bool()
 	outputs[0].Set_bool(outV0)
 }
 
-func opBoolUnequal(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opBoolUnequal(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_bool() != inputs[1].Get_bool()
 	outputs[0].Set_bool(outV0)
 }
 
-func opBoolNot(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opBoolNot(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := !inputs[0].Get_bool()
 	outputs[0].Set_bool(outV0)
 }
 
-func opBoolAnd(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opBoolAnd(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_bool()
 	inpV1 := inputs[1].Get_bool()
 	outputs[0].Set_bool(inpV0 && inpV1)
 }
 
-func opBoolOr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opBoolOr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_bool()
 	inpV1 := inputs[1].Get_bool()
 	outputs[0].Set_bool(inpV0 || inpV1)

--- a/cx/opcodes/op_f32.go
+++ b/cx/opcodes/op_f32.go
@@ -2,230 +2,231 @@ package opcodes
 
 import (
 	"fmt"
-	"github.com/skycoin/cx/cx/ast"
 	"math"
 	"math/rand"
 	"strconv"
+
+	"github.com/skycoin/cx/cx/ast"
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opF32ToStr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32ToStr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := strconv.FormatFloat(float64(inputs[0].Get_f32()), 'f', -1, 32)
 	outputs[0].Set_str(outV0)
 }
 
 // The built-in i8 function returns operand 1 casted from type f32 to type i8.
-func opF32ToI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32ToI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int8(inputs[0].Get_f32())
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type f32 to type i16.
-func opF32ToI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32ToI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int16(inputs[0].Get_f32())
-    outputs[0].Set_i16(outV0)
+	outputs[0].Set_i16(outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type f32 to type i32.
-func opF32ToI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32ToI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int32(inputs[0].Get_f32())
-    outputs[0].Set_i32(outV0)
+	outputs[0].Set_i32(outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type f32 to type i64.
-func opF32ToI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32ToI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int64(inputs[0].Get_f32())
-    outputs[0].Set_i64(outV0)
+	outputs[0].Set_i64(outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type f32 to type ui8.
-func opF32ToUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32ToUI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint8(inputs[0].Get_f32())
-    outputs[0].Set_ui8(outV0)
+	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type f32 to type ui16.
-func opF32ToUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32ToUI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint16(inputs[0].Get_f32())
-    outputs[0].Set_ui16(outV0)
+	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type f32 to type ui32.
-func opF32ToUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32ToUI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint32(inputs[0].Get_f32())
-    outputs[0].Set_ui32(outV0)
+	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type f32 to type ui64.
-func opF32ToUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32ToUI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint64(inputs[0].Get_f32())
-    outputs[0].Set_ui64(outV0)
+	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type f32 to type f64.
-func opF32ToF64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32ToF64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float64(inputs[0].Get_f32())
-    outputs[0].Set_f64(outV0)
+	outputs[0].Set_f64(outV0)
 }
 
 // The built-in isnan function returns true if operand is nan value.
-func opF32Isnan(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Isnan(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.IsNaN(float64(inputs[0].Get_f32()))
 	outputs[0].Set_bool(outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opF32Print(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Print(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	fmt.Println(inputs[0].Get_f32())
 }
 
 // The built-in add function returns the sum of the two operands.
-func opF32Add(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Add(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f32() + inputs[1].Get_f32()
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in sub function returns the difference between the two operands.
-func opF32Sub(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Sub(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f32() - inputs[1].Get_f32()
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
-func opF32Neg(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Neg(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := -inputs[0].Get_f32()
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in mul function returns the product of the two operands.
-func opF32Mul(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Mul(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f32() * inputs[1].Get_f32()
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in div function returns the quotient between the two operands.
-func opF32Div(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Div(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f32() / inputs[1].Get_f32()
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in mod function return the floating-point remainder of operand 1 divided by operand 2.
-func opF32Mod(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Mod(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(math.Mod(float64(inputs[0].Get_f32()), float64(inputs[1].Get_f32())))
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in abs function returns the absolute value of the operand.
-func opF32Abs(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Abs(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(math.Abs(float64(inputs[0].Get_f32())))
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in pow function returns x**n for n>0 otherwise 1.
-func opF32Pow(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Pow(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(math.Pow(float64(inputs[0].Get_f32()), float64(inputs[1].Get_f32())))
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opF32Gt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Gt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f32() > inputs[1].Get_f32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in gteq function returns true if the operand 1 is greater than or
 // equal to operand 2.
-func opF32Gteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Gteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f32() >= inputs[1].Get_f32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opF32Lt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Lt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f32() < inputs[1].Get_f32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or
 // equal to operand 2.
-func opF32Lteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Lteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f32() <= inputs[1].Get_f32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opF32Eq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Eq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f32() == inputs[1].Get_f32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in uneq function returns true operand1 is different from operand 2.
-func opF32Uneq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Uneq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f32() != inputs[1].Get_f32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in rand function returns a pseudo-random number in [0.0,1.0) from the default Source
-func opF32Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
-    outputs[0].Set_f32(rand.Float32())
+func opF32Rand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	outputs[0].Set_f32(rand.Float32())
 }
 
 // The built-in acos function returns the arc cosine of the operand.
-func opF32Acos(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Acos(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(math.Acos(float64(inputs[0].Get_f32())))
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in cos function returns the cosine of the operand.
-func opF32Cos(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Cos(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(math.Cos(float64(inputs[0].Get_f32())))
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in asin function returns the arc sine of the operand.
-func opF32Asin(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Asin(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(math.Asin(float64(inputs[0].Get_f32())))
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in sin function returns the sine of the operand.
-func opF32Sin(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Sin(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(math.Sin(float64(inputs[0].Get_f32())))
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in sqrt function returns the square root of the operand.
-func opF32Sqrt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Sqrt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(math.Sqrt(float64(inputs[0].Get_f32())))
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in log function returns the natural logarithm of the operand.
-func opF32Log(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Log(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(math.Log(float64(inputs[0].Get_f32())))
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in log2 function returns the 2-logarithm of the operand.
-func opF32Log2(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Log2(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(math.Log2(float64(inputs[0].Get_f32())))
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in log10 function returns the 10-logarithm of the operand.
-func opF32Log10(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Log10(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(math.Log10(float64(inputs[0].Get_f32())))
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in max function returns the largest value of the two operands.
-func opF32Max(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Max(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(math.Max(float64(inputs[0].Get_f32()), float64(inputs[1].Get_f32())))
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in min function returns the smallest value of the two operands.
-func opF32Min(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF32Min(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(math.Min(float64(inputs[0].Get_f32()), float64(inputs[1].Get_f32())))
 	outputs[0].Set_f32(outV0)
 }

--- a/cx/opcodes/op_f64.go
+++ b/cx/opcodes/op_f64.go
@@ -2,230 +2,231 @@ package opcodes
 
 import (
 	"fmt"
-	"github.com/skycoin/cx/cx/ast"
 	"math"
 	"math/rand"
 	"strconv"
+
+	"github.com/skycoin/cx/cx/ast"
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opF64ToStr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64ToStr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := strconv.FormatFloat(inputs[0].Get_f64(), 'f', -1, 64)
 	outputs[0].Set_str(outV0)
 }
 
 // The built-in i8 function returns operand 1 casted from type f64 to type i8.
-func opF64ToI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64ToI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int8(inputs[0].Get_f64())
 	outputs[0].Set_i8(outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type f64 to type i16.
-func opF64ToI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64ToI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int16(inputs[0].Get_f64())
-    outputs[0].Set_i16(outV0)
+	outputs[0].Set_i16(outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type f64 to type i32.
-func opF64ToI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64ToI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int32(inputs[0].Get_f64())
-    outputs[0].Set_i32(outV0)
+	outputs[0].Set_i32(outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type f64 to type i64.
-func opF64ToI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64ToI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int64(inputs[0].Get_f64())
-    outputs[0].Set_i64(outV0)
+	outputs[0].Set_i64(outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type f64 to type ui8.
-func opF64ToUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64ToUI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint8(inputs[0].Get_f64())
-    outputs[0].Set_ui8(outV0)
+	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type f64 to type ui16.
-func opF64ToUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64ToUI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint16(inputs[0].Get_f64())
-    outputs[0].Set_ui16(outV0)
+	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type f64 to type ui32.
-func opF64ToUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64ToUI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint32(inputs[0].Get_f64())
-    outputs[0].Set_ui32(outV0)
+	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type f64 to type ui64.
-func opF64ToUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64ToUI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint64(inputs[0].Get_f64())
-    outputs[0].Set_ui64(outV0)
+	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type f64 to type f32.
-func opF64ToF32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64ToF32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(inputs[0].Get_f64())
-    outputs[0].Set_f32(outV0)
+	outputs[0].Set_f32(outV0)
 }
 
 // The built-in isnan function returns true if operand is nan value.
-func opF64Isnan(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Isnan(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.IsNaN(inputs[0].Get_f64())
 	outputs[0].Set_bool(outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opF64Print(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Print(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	fmt.Println(inputs[0].Get_f64())
 }
 
 // The built-in add function returns the sum of the two operands.
-func opF64Add(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Add(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f64() + inputs[1].Get_f64()
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in sub function returns the difference between the two operands.
-func opF64Sub(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Sub(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f64() - inputs[1].Get_f64()
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
-func opF64Neg(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Neg(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := -inputs[0].Get_f64()
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in mul function returns the product of the two operands.
-func opF64Mul(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Mul(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f64() * inputs[1].Get_f64()
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in div function returns the quotient between the two operands.
-func opF64Div(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Div(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f64() / inputs[1].Get_f64()
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in mod function return the floating-point remainder of operand 1 divided by operand 2.
-func opF64Mod(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Mod(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.Mod(inputs[0].Get_f64(), inputs[1].Get_f64())
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in abs function returns the absolute value of the operand.
-func opF64Abs(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Abs(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.Abs(inputs[0].Get_f64())
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in pow function returns x**n for n>0 otherwise 1.
-func opF64Pow(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Pow(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.Pow(inputs[0].Get_f64(), inputs[1].Get_f64())
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in gt function returns true if operand 1 is larger than operand 2.
-func opF64Gt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Gt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f64() > inputs[1].Get_f64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opF64Gteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Gteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f64() >= inputs[1].Get_f64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opF64Lt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Lt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f64() < inputs[1].Get_f64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 2.
-func opF64Lteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Lteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f64() <= inputs[1].Get_f64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opF64Eq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Eq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f64() == inputs[1].Get_f64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opF64Uneq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Uneq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_f64() != inputs[1].Get_f64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in rand function returns a pseudo-random number in [0.0,1.0) from the default Source.
-func opF64Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Rand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_f64(rand.Float64())
 }
 
 // The built-in acos function returns the arc cosine of the operand.
-func opF64Acos(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Acos(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.Acos(inputs[0].Get_f64())
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in cos function returns the cosine of the operand.
-func opF64Cos(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Cos(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.Cos(inputs[0].Get_f64())
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in asin function returns the arc sine of the operand.
-func opF64Asin(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Asin(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.Asin(inputs[0].Get_f64())
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in sin function returns the sine of the operand.
-func opF64Sin(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Sin(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.Sin(inputs[0].Get_f64())
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in sqrt function returns the square root of the operand.
-func opF64Sqrt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Sqrt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.Sqrt(inputs[0].Get_f64())
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in log function returns the natural logarithm of the operand.
-func opF64Log(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Log(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.Log(inputs[0].Get_f64())
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in log2 function returns the 2-logarithm of the operand.
-func opF64Log2(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Log2(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.Log2(inputs[0].Get_f64())
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in log10 function returns the 10-logarithm of the operand.
-func opF64Log10(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Log10(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.Log10(inputs[0].Get_f64())
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in max function returns the largest value of the two operands.
-func opF64Max(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Max(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.Max(inputs[0].Get_f64(), inputs[1].Get_f64())
 	outputs[0].Set_f64(outV0)
 }
 
 // The built-in min function returns the smallest value of the two operands.
-func opF64Min(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opF64Min(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := math.Min(inputs[0].Get_f64(), inputs[1].Get_f64())
 	outputs[0].Set_f64(outV0)
 }

--- a/cx/opcodes/op_fmt.go
+++ b/cx/opcodes/op_fmt.go
@@ -8,7 +8,7 @@ import (
 	"github.com/skycoin/cx/cx/types"
 )
 
-func buildString(inputs []ast.CXValue, outputs []ast.CXValue) []byte {
+func buildString(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) []byte {
 	fmtStr := inputs[0].Get_str()
 
 	var res []byte
@@ -119,12 +119,12 @@ func buildString(inputs []ast.CXValue, outputs []ast.CXValue) []byte {
 	return res
 }
 
-func opSprintf(inputs []ast.CXValue, outputs []ast.CXValue) {
-	outputs[0].Set_str(string(buildString(inputs, outputs)))
+func opSprintf(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	outputs[0].Set_str(string(buildString(prgrm, inputs, outputs)))
 }
 
-func opPrintf(inputs []ast.CXValue, outputs []ast.CXValue) {
-	fmt.Print(string(buildString(inputs, outputs)))
+func opPrintf(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	fmt.Print(string(buildString(prgrm, inputs, outputs)))
 }
 
 //Only used in op_fmt.go, once

--- a/cx/opcodes/op_i16.go
+++ b/cx/opcodes/op_i16.go
@@ -2,108 +2,109 @@ package opcodes
 
 import (
 	"fmt"
-	"github.com/skycoin/cx/cx/ast"
 	"math/rand"
 	"strconv"
+
+	"github.com/skycoin/cx/cx/ast"
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opI16ToStr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16ToStr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := strconv.FormatInt(int64(inputs[0].Get_i16()), 10)
 	outputs[0].Set_str(outV0)
 }
 
 // The built-in i8 function returns operand 1 casted from type i16 to type i8.
-func opI16ToI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16ToI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int8(inputs[0].Get_i16())
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in i32 function returns operand 1 casted from type i16 to type i32.
-func opI16ToI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16ToI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int32(inputs[0].Get_i16())
-    outputs[0].Set_i32(outV0)
+	outputs[0].Set_i32(outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type i16 to type i64.
-func opI16ToI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16ToI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int64(inputs[0].Get_i16())
-    outputs[0].Set_i64(outV0)
+	outputs[0].Set_i64(outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i16 to type ui8.
-func opI16ToUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16ToUI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint8(inputs[0].Get_i16())
-    outputs[0].Set_ui8(outV0)
+	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i16 to type ui16.
-func opI16ToUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16ToUI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint16(inputs[0].Get_i16())
-    outputs[0].Set_ui16(outV0)
+	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i16 to type ui32.
-func opI16ToUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16ToUI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint32(inputs[0].Get_i16())
-    outputs[0].Set_ui32(outV0)
+	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type i16 to type ui64.
-func opI16ToUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16ToUI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint64(inputs[0].Get_i16())
-    outputs[0].Set_ui64(outV0)
+	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i16 to type f32.
-func opI16ToF32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16ToF32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(inputs[0].Get_i16())
-    outputs[0].Set_f32(outV0)
+	outputs[0].Set_f32(outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i16 to type f64.
-func opI16ToF64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16ToF64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float64(inputs[0].Get_i16())
-    outputs[0].Set_f64(outV0)
+	outputs[0].Set_f64(outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opI16Print(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Print(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	fmt.Println(inputs[0].Get_i16())
 }
 
 // The built-in add function returns the sum of two i16 numbers.
-func opI16Add(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Add(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() + inputs[1].Get_i16()
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in sub function returns the difference of two i16 numbers.
-func opI16Sub(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Sub(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() - inputs[1].Get_i16()
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
-func opI16Neg(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Neg(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := -inputs[0].Get_i16()
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in mul function returns the product of two i16 numbers.
-func opI16Mul(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Mul(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() * inputs[1].Get_i16()
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in div function returns the quotient of two i16 numbers.
-func opI16Div(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Div(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() / inputs[1].Get_i16()
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in abs function returns the absolute number of the number.
-func opI16Abs(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Abs(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	V0 := inputs[0].Get_i16()
 	sign := V0 >> 15
 	outV0 := (V0 ^ sign) - sign
@@ -111,51 +112,51 @@ func opI16Abs(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opI16Gt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Gt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() > inputs[1].Get_i16()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opI16Gteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Gteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() >= inputs[1].Get_i16()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opI16Lt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Lt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() < inputs[1].Get_i16()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opI16Lteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Lteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() <= inputs[1].Get_i16()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opI16Eq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Eq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() == inputs[1].Get_i16()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opI16Uneq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Uneq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() != inputs[1].Get_i16()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
-func opI16Mod(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Mod(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() % inputs[1].Get_i16()
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
-func opI16Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Rand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	minimum := inputs[0].Get_i16()
 	maximum := inputs[1].Get_i16()
 
@@ -169,59 +170,59 @@ func opI16Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opI16Bitand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Bitand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() & inputs[1].Get_i16()
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opI16Bitor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Bitor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() | inputs[1].Get_i16()
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opI16Bitxor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Bitxor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() ^ inputs[1].Get_i16()
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opI16Bitclear(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Bitclear(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i16() &^ inputs[1].Get_i16()
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opI16Bitshl(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Bitshl(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int16(inputs[0].Get_i16() << uint16(inputs[1].Get_i16()))
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opI16Bitshr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Bitshr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int16(inputs[0].Get_i16() >> uint16(inputs[1].Get_i16()))
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opI16Max(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Max(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_i16()
 	inpV1 := inputs[1].Get_i16()
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_i16(inpV0)
+	outputs[0].Set_i16(inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
-func opI16Min(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI16Min(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_i16()
 	inpV1 := inputs[1].Get_i16()
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_i16(inpV0)
+	outputs[0].Set_i16(inpV0)
 }

--- a/cx/opcodes/op_i32.go
+++ b/cx/opcodes/op_i32.go
@@ -9,102 +9,102 @@ import (
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opI32ToStr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32ToStr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := strconv.FormatInt(int64(inputs[0].Get_i32()), 10)
 	outputs[0].Set_str(outV0)
 }
 
 // The built-in i8 function returns operand 1 casted from type i32 to type i8.
-func opI32ToI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32ToI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int8(inputs[0].Get_i32())
 	outputs[0].Set_i8(outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type i32 to type i16.
-func opI32ToI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32ToI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int16(inputs[0].Get_i32())
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type i32 to type i64.
-func opI32ToI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32ToI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int64(inputs[0].Get_i32())
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i32 to type ui8.
-func opI32ToUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32ToUI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint8(inputs[0].Get_i32())
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i32 to type ui16.
-func opI32ToUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32ToUI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint16(inputs[0].Get_i32())
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type i32 to type ui32.
-func opI32ToUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32ToUI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint32(inputs[0].Get_i32())
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type i32 to type ui64.
-func opI32ToUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32ToUI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint64(inputs[0].Get_i32())
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i32 to type f32.
-func opI32ToF32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32ToF32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(inputs[0].Get_i32())
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i32 to type f64.
-func opI32ToF64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32ToF64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float64(inputs[0].Get_i32())
 	outputs[0].Set_f64(outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opI32Print(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Print(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	fmt.Println(inputs[0].Get_i32())
 }
 
 // The built-in add function returns the sum of two i32 numbers.
-func opI32Add(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Add(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() + inputs[1].Get_i32()
 	outputs[0].Set_i32(outV0)
 }
 
 // The built-in sub function returns the difference of two i32 numbers.
-func opI32Sub(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Sub(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() - inputs[1].Get_i32()
 	outputs[0].Set_i32(outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
-func opI32Neg(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Neg(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := -inputs[0].Get_i32()
 	outputs[0].Set_i32(outV0)
 }
 
 // The built-in mul function returns the product of two i32 numbers.
-func opI32Mul(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Mul(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() * inputs[1].Get_i32()
 	outputs[0].Set_i32(outV0)
 }
 
 // The built-in div function returns the quotient of two i32 numbers.
-func opI32Div(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Div(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() / inputs[1].Get_i32()
 	outputs[0].Set_i32(outV0)
 }
 
 // The built-in abs function returns the absolute number of the number.
-func opI32Abs(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Abs(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_i32()
 	sign := inpV0 >> 31
 	outV0 := (inpV0 ^ sign) - sign
@@ -112,51 +112,51 @@ func opI32Abs(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opI32Gt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Gt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() > inputs[1].Get_i32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opI32Gteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Gteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() >= inputs[1].Get_i32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opI32Lt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Lt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() < inputs[1].Get_i32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opI32Lteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Lteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() <= inputs[1].Get_i32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opI32Eq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Eq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() == inputs[1].Get_i32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opI32Uneq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Uneq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() != inputs[1].Get_i32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 divided by operand 2.
-func opI32Mod(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Mod(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() % inputs[1].Get_i32()
 	outputs[0].Set_i32(outV0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
-func opI32Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Rand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	minimum := inputs[0].Get_i32()
 	maximum := inputs[1].Get_i32()
 
@@ -170,45 +170,45 @@ func opI32Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opI32Bitand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Bitand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() & inputs[1].Get_i32()
 	outputs[0].Set_i32(outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opI32Bitor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Bitor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() | inputs[1].Get_i32()
 	outputs[0].Set_i32(outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opI32Bitxor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Bitxor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() ^ inputs[1].Get_i32()
 	outputs[0].Set_i32(outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opI32Bitclear(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Bitclear(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() &^ inputs[1].Get_i32()
 	outputs[0].Set_i32(outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opI32Bitshl(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Bitshl(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() << uint32(inputs[1].Get_i32())
 	outputs[0].Set_i32(outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opI32Bitshr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Bitshr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i32() >> uint32(inputs[1].Get_i32())
 	outputs[0].Set_i32(outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opI32Max(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Max(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_i32()
 	inpV1 := inputs[1].Get_i32()
 	if inpV1 > inpV0 {
@@ -218,7 +218,7 @@ func opI32Max(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // The built-in min function returns the smallest of the two operands.
-func opI32Min(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI32Min(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_i32()
 	inpV1 := inputs[1].Get_i32()
 	if inpV1 < inpV0 {
@@ -227,8 +227,8 @@ func opI32Min(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_i32(inpV0)
 }
 
-func opI32JmpEq(inputs []ast.CXValue, outputs []ast.CXValue) {
-	call := ast.PROGRAM.GetCurrentCall()
+func opI32JmpEq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	call := prgrm.GetCurrentCall()
 	expr := inputs[0].Expr
 
 	res := inputs[0].Get_i32() == inputs[1].Get_i32()
@@ -239,8 +239,8 @@ func opI32JmpEq(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 }
 
-func opI32JmpUnEq(inputs []ast.CXValue, outputs []ast.CXValue) {
-	call := ast.PROGRAM.GetCurrentCall()
+func opI32JmpUnEq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	call := prgrm.GetCurrentCall()
 	expr := inputs[0].Expr
 
 	res := inputs[0].Get_i32() != inputs[1].Get_i32()
@@ -251,8 +251,8 @@ func opI32JmpUnEq(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 }
 
-func opI32JmpGt(inputs []ast.CXValue, outputs []ast.CXValue) {
-	call := ast.PROGRAM.GetCurrentCall()
+func opI32JmpGt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	call := prgrm.GetCurrentCall()
 	expr := inputs[0].Expr
 
 	res := inputs[0].Get_i32() > inputs[1].Get_i32()
@@ -263,8 +263,8 @@ func opI32JmpGt(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 }
 
-func opI32JmpGtEq(inputs []ast.CXValue, outputs []ast.CXValue) {
-	call := ast.PROGRAM.GetCurrentCall()
+func opI32JmpGtEq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	call := prgrm.GetCurrentCall()
 	expr := inputs[0].Expr
 
 	res := inputs[0].Get_i32() >= inputs[1].Get_i32()
@@ -275,8 +275,8 @@ func opI32JmpGtEq(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 }
 
-func opI32JmpLt(inputs []ast.CXValue, outputs []ast.CXValue) {
-	call := ast.PROGRAM.GetCurrentCall()
+func opI32JmpLt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	call := prgrm.GetCurrentCall()
 	expr := inputs[0].Expr
 
 	res := inputs[0].Get_i32() < inputs[1].Get_i32()
@@ -287,8 +287,8 @@ func opI32JmpLt(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 }
 
-func opI32JmpLtEq(inputs []ast.CXValue, outputs []ast.CXValue) {
-	call := ast.PROGRAM.GetCurrentCall()
+func opI32JmpLtEq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	call := prgrm.GetCurrentCall()
 	expr := inputs[0].Expr
 
 	res := inputs[0].Get_i32() <= inputs[1].Get_i32()
@@ -299,8 +299,8 @@ func opI32JmpLtEq(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 }
 
-func opI32JmpZero(inputs []ast.CXValue, outputs []ast.CXValue) {
-	call := ast.PROGRAM.GetCurrentCall()
+func opI32JmpZero(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	call := prgrm.GetCurrentCall()
 	expr := inputs[0].Expr
 
 	res := inputs[0].Get_i32() == 0
@@ -311,8 +311,8 @@ func opI32JmpZero(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 }
 
-func opI32JmpNotZero(inputs []ast.CXValue, outputs []ast.CXValue) {
-	call := ast.PROGRAM.GetCurrentCall()
+func opI32JmpNotZero(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	call := prgrm.GetCurrentCall()
 	expr := inputs[0].Expr
 
 	res := inputs[0].Get_i32() != 0

--- a/cx/opcodes/op_i64.go
+++ b/cx/opcodes/op_i64.go
@@ -2,108 +2,109 @@ package opcodes
 
 import (
 	"fmt"
-	"github.com/skycoin/cx/cx/ast"
 	"math/rand"
 	"strconv"
+
+	"github.com/skycoin/cx/cx/ast"
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opI64ToStr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64ToStr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := strconv.FormatInt(inputs[0].Get_i64(), 10)
 	outputs[0].Set_str(outV0)
 }
 
 // The built-in i8 function returns operand 1 casted from type i64 to type i8.
-func opI64ToI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64ToI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int8(inputs[0].Get_i64())
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type i64 to type i16.
-func opI64ToI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64ToI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int16(inputs[0].Get_i64())
-    outputs[0].Set_i16(outV0)
+	outputs[0].Set_i16(outV0)
 }
 
 // The built-in i32 function returns operand 1 casted from type i64 to type i32.
-func opI64ToI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64ToI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int32(inputs[0].Get_i64())
-    outputs[0].Set_i32(outV0)
+	outputs[0].Set_i32(outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i64 to type ui8.
-func opI64ToUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64ToUI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint8(inputs[0].Get_i64())
-    outputs[0].Set_ui8(outV0)
+	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type i64 to type ui16.
-func opI64ToUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64ToUI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint16(inputs[0].Get_i64())
-    outputs[0].Set_ui16(outV0)
+	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type i64 to type ui32.
-func opI64ToUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64ToUI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint32(inputs[0].Get_i64())
-    outputs[0].Set_ui32(outV0)
+	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type i64 to type ui64.
-func opI64ToUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64ToUI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint64(inputs[0].Get_i64())
-    outputs[0].Set_ui64(outV0)
+	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i64 to type f32.
-func opI64ToF32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64ToF32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(inputs[0].Get_i64())
-    outputs[0].Set_f32(outV0)
+	outputs[0].Set_f32(outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i64 to type f64.
-func opI64ToF64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64ToF64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float64(inputs[0].Get_i64())
-    outputs[0].Set_f64(outV0)
+	outputs[0].Set_f64(outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opI64Print(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Print(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	fmt.Println(inputs[0].Get_i64())
 }
 
 // The built-in add function returns the sum of the two operands.
-func opI64Add(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Add(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() + inputs[1].Get_i64()
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in sub function returns the difference between the two operands.
-func opI64Sub(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Sub(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() - inputs[1].Get_i64()
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in neg function returns the opposit of operand 1.
-func opI64Neg(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Neg(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := -inputs[0].Get_i64()
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in mul function returns the product of the two operands.
-func opI64Mul(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Mul(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() * inputs[1].Get_i64()
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in div function returns the quotient of the two operands.
-func opI64Div(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Div(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() / inputs[1].Get_i64()
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in abs function returns the absolute value of the operand.
-func opI64Abs(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Abs(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_i64()
 	sign := inpV0 >> 63
 	outV0 := (inpV0 ^ sign) - sign
@@ -111,51 +112,51 @@ func opI64Abs(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opI64Gt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Gt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() > inputs[1].Get_i64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opI64Gteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Gteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() >= inputs[1].Get_i64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than oeprand 2.
-func opI64Lt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Lt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() < inputs[1].Get_i64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or
 // equal to operand 2.
-func opI64Lteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Lteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() <= inputs[1].Get_i64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opI64Eq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Eq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() == inputs[1].Get_i64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opI64Uneq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Uneq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() != inputs[1].Get_i64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 divided by operand 2.
-func opI64Mod(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Mod(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() % inputs[1].Get_i64()
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
-func opI64Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Rand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	minimum := inputs[0].Get_i64()
 	maximum := inputs[1].Get_i64()
 
@@ -169,59 +170,59 @@ func opI64Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opI64Bitand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Bitand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() & inputs[1].Get_i64()
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opI64Bitor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Bitor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() | inputs[1].Get_i64()
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opI64Bitxor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Bitxor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() ^ inputs[1].Get_i64()
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opI64Bitclear(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Bitclear(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i64() &^ inputs[1].Get_i64()
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opI64Bitshl(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Bitshl(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int64(inputs[0].Get_i64() << uint64(inputs[1].Get_i64()))
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opI64Bitshr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Bitshr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int64(inputs[0].Get_i64() >> uint64(inputs[1].Get_i64()))
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in max function returns the greatest value of the two operands.
-func opI64Max(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Max(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_i64()
 	inpV1 := inputs[1].Get_i64()
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_i64(inpV0)
+	outputs[0].Set_i64(inpV0)
 }
 
 // The built-in min function returns the smallest value of the two operands.
-func opI64Min(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI64Min(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_i64()
 	inpV1 := inputs[1].Get_i64()
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_i64(inpV0)
+	outputs[0].Set_i64(inpV0)
 }

--- a/cx/opcodes/op_i8.go
+++ b/cx/opcodes/op_i8.go
@@ -2,160 +2,161 @@ package opcodes
 
 import (
 	"fmt"
-	"github.com/skycoin/cx/cx/ast"
 	"math/rand"
 	"strconv"
+
+	"github.com/skycoin/cx/cx/ast"
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opI8ToStr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8ToStr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := strconv.FormatInt(int64(inputs[0].Get_i8()), 10)
 	outputs[0].Set_str(outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type i8 to type i16.
-func opI8ToI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8ToI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int16(inputs[0].Get_i8())
 	outputs[0].Set_i16(outV0)
 }
 
 // The built-in i32 function returns operand 1 casted from type i8 to type i32.
-func opI8ToI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8ToI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int32(inputs[0].Get_i8())
 	outputs[0].Set_i32(outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type i8 to type i64.
-func opI8ToI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8ToI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int64(inputs[0].Get_i8())
 	outputs[0].Set_i64(outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type i8 to type ui8.
-func opI8ToUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8ToUI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint8(inputs[0].Get_i8())
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in ui16 function returns operand 1 casted from type i8 to type ui16.
-func opI8ToUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8ToUI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint16(inputs[0].Get_i8())
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in ui32 function returns operand 1 casted from type i8 to type ui32.
-func opI8ToUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8ToUI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint32(inputs[0].Get_i8())
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in ui64 function returns operand 1 casted from type i8 to type ui64.
-func opI8ToUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8ToUI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint64(inputs[0].Get_i8())
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type i8 to type f32.
-func opI8ToF32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8ToF32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(inputs[0].Get_i8())
 	outputs[0].Set_f32(outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type i8 to type uf64.
-func opI8ToF64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8ToF64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float64(inputs[0].Get_i8())
-    outputs[0].Set_f64(outV0)
+	outputs[0].Set_f64(outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opI8Print(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Print(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	fmt.Println(inputs[0].Get_i8())
 }
 
 // The built-in add function returns the sum of two i8 numbers.
-func opI8Add(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Add(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() + inputs[1].Get_i8()
 	outputs[0].Set_i8(outV0)
 }
 
 // The built-in sub function returns the difference of two i8 numbers.
-func opI8Sub(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Sub(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() - inputs[1].Get_i8()
 	outputs[0].Set_i8(outV0)
 }
 
 // The built-in neg function returns the opposite of operand 1.
-func opI8Neg(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Neg(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := -inputs[0].Get_i8()
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in mul function returns the product of two i8 numbers.
-func opI8Mul(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Mul(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() * inputs[1].Get_i8()
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in div function returns the quotient of two i8 numbers.
-func opI8Div(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Div(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() / inputs[1].Get_i8()
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in abs function returns the absolute number of the number.
-func opI8Abs(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Abs(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_i8()
 	sign := inpV0 >> 7
 	outV0 := (inpV0 ^ sign) - sign
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opI8Gt(inputs []ast.CXValue, outputs []ast.CXValue) {
-    outV0 := inputs[0].Get_i8() > inputs[1].Get_i8()
-    outputs[0].Set_bool(outV0)
+func opI8Gt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	outV0 := inputs[0].Get_i8() > inputs[1].Get_i8()
+	outputs[0].Set_bool(outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opI8Gteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Gteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() >= inputs[1].Get_i8()
-    outputs[0].Set_bool(outV0)
+	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opI8Lt(inputs []ast.CXValue, outputs []ast.CXValue) {
-    outV0 := inputs[0].Get_i8() < inputs[1].Get_i8()
-    outputs[0].Set_bool(outV0)
+func opI8Lt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	outV0 := inputs[0].Get_i8() < inputs[1].Get_i8()
+	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opI8Lteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Lteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() <= inputs[1].Get_i8()
-    outputs[0].Set_bool(outV0)
+	outputs[0].Set_bool(outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opI8Eq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Eq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() == inputs[1].Get_i8()
-    outputs[0].Set_bool(outV0)
+	outputs[0].Set_bool(outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opI8Uneq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Uneq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() != inputs[1].Get_i8()
-    outputs[0].Set_bool(outV0)
+	outputs[0].Set_bool(outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
-func opI8Mod(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Mod(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() % inputs[1].Get_i8()
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in rand function returns a pseudo random number in [operand 1, operand 2).
-func opI8Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Rand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	minimum := inputs[0].Get_i8()
 	maximum := inputs[1].Get_i8()
 
@@ -165,63 +166,63 @@ func opI8Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
 		outV0 = int8(rand.Intn(r) + int(minimum))
 	}
 
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opI8Bitand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Bitand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() & inputs[1].Get_i8()
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opI8Bitor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Bitor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() | inputs[1].Get_i8()
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opI8Bitxor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Bitxor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() ^ inputs[1].Get_i8()
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opI8Bitclear(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Bitclear(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() &^ inputs[1].Get_i8()
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opI8Bitshl(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Bitshl(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() << uint8(inputs[1].Get_i8())
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opI8Bitshr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Bitshr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_i8() >> uint8(inputs[1].Get_i8())
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opI8Max(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Max(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_i8()
 	inpV1 := inputs[1].Get_i8()
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_i8(inpV0)
+	outputs[0].Set_i8(inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
-func opI8Min(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opI8Min(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_i8()
 	inpV1 := inputs[1].Get_i8()
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_i8(inpV0)
+	outputs[0].Set_i8(inpV0)
 }

--- a/cx/opcodes/op_misc.go
+++ b/cx/opcodes/op_misc.go
@@ -6,7 +6,7 @@ import (
 	"github.com/skycoin/cx/cx/types"
 )
 
-func opIdentity(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opIdentity(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	out1 := outputs[0].Arg
 	var elt *ast.CXArgument
 	if len(out1.Fields) > 0 {
@@ -17,7 +17,7 @@ func opIdentity(inputs []ast.CXValue, outputs []ast.CXValue) {
 
 	//TODO: Delete
 	if elt.DoesEscape {
-		outputs[0].Set_ptr(types.AllocWrite_obj_data(ast.PROGRAM.Memory, inputs[0].Get_bytes()))
+		outputs[0].Set_ptr(types.AllocWrite_obj_data(prgrm.Memory, inputs[0].Get_bytes()))
 	} else {
 		switch elt.PassBy {
 		case constants.PASSBY_VALUE:
@@ -28,14 +28,14 @@ func opIdentity(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 }
 
-func opGoto(inputs []ast.CXValue, outputs []ast.CXValue) {
-	call := ast.PROGRAM.GetCurrentCall()
+func opGoto(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	call := prgrm.GetCurrentCall()
 	expr := call.Operator.Expressions[call.Line]
 	call.Line = call.Line + expr.ThenLines
 }
 
-func opJmp(inputs []ast.CXValue, outputs []ast.CXValue) {
-	call := ast.PROGRAM.GetCurrentCall()
+func opJmp(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	call := prgrm.GetCurrentCall()
 	expr := inputs[0].Expr
 
 	if inputs[0].Get_bool() {
@@ -45,8 +45,8 @@ func opJmp(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 }
 
-func opAbsJmp(inputs []ast.CXValue, outputs []ast.CXValue) {
-	call := ast.PROGRAM.GetCurrentCall()
+func opAbsJmp(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	call := prgrm.GetCurrentCall()
 	expr := inputs[0].Expr
 
 	if inputs[0].Get_bool() {
@@ -56,19 +56,19 @@ func opAbsJmp(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 }
 
-func opBreak(inputs []ast.CXValue, outputs []ast.CXValue) {
-	call := ast.PROGRAM.GetCurrentCall()
+func opBreak(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	call := prgrm.GetCurrentCall()
 	expr := call.Operator.Expressions[call.Line]
 	call.Line = call.Line + expr.ThenLines
 }
 
-func opContinue(inputs []ast.CXValue, outputs []ast.CXValue) {
-	call := ast.PROGRAM.GetCurrentCall()
+func opContinue(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	call := prgrm.GetCurrentCall()
 	expr := call.Operator.Expressions[call.Line]
 	call.Line = call.Line + expr.ThenLines
 }
 
-func opNop(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opNop(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	// No Operation
 	// Do Nothing
 }

--- a/cx/opcodes/op_serialize.go
+++ b/cx/opcodes/op_serialize.go
@@ -6,9 +6,9 @@ import (
 	"github.com/skycoin/cx/cx/types"
 )
 
-func opSerialize(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opSerialize(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var slcOff types.Pointer
-	byts := ast.SerializeCXProgram(ast.PROGRAM, true, false)
+	byts := ast.SerializeCXProgram(prgrm, true, false)
 	for _, b := range byts {
 		slcOff = ast.WriteToSlice(slcOff, []byte{b})
 	}
@@ -16,11 +16,11 @@ func opSerialize(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_ptr(slcOff)
 }
 
-func opDeserialize(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opDeserialize(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	off := inputs[0].Get_ptr()
 
-	_l := ast.PROGRAM.Memory[off+types.OBJECT_HEADER_SIZE : off+types.OBJECT_HEADER_SIZE+constants.SLICE_HEADER_SIZE]
+	_l := prgrm.Memory[off+types.OBJECT_HEADER_SIZE : off+types.OBJECT_HEADER_SIZE+constants.SLICE_HEADER_SIZE]
 	l := types.Read_ptr(_l, 4) // TODO:PTR remove hardcode 4
 
-	ast.Deserialize(ast.PROGRAM.Memory[off+types.OBJECT_HEADER_SIZE+constants.SLICE_HEADER_SIZE:off+types.OBJECT_HEADER_SIZE+constants.SLICE_HEADER_SIZE+l], false) // BUG : should be l * elt.TotalSize ?
+	ast.Deserialize(prgrm.Memory[off+types.OBJECT_HEADER_SIZE+constants.SLICE_HEADER_SIZE:off+types.OBJECT_HEADER_SIZE+constants.SLICE_HEADER_SIZE+l], false) // BUG : should be l * elt.TotalSize ?
 }

--- a/cx/opcodes/op_slice.go
+++ b/cx/opcodes/op_slice.go
@@ -7,12 +7,12 @@ import (
 )
 
 //TODO: Rework
-func opSliceLen(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opSliceLen(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	elt := inputs[0].Arg.GetAssignmentElement()
 
 	var sliceLen types.Pointer
 	if elt.IsSlice || elt.Type == types.AFF { //TODO: FIX
-		sliceOffset := types.Read_ptr(ast.PROGRAM.Memory, inputs[0].Offset)
+		sliceOffset := types.Read_ptr(prgrm.Memory, inputs[0].Offset)
 		if sliceOffset > 0 && sliceOffset.IsValid() {
 			sliceLen = ast.GetSliceLen(sliceOffset)
 		} else if sliceOffset < 0 {
@@ -20,7 +20,7 @@ func opSliceLen(inputs []ast.CXValue, outputs []ast.CXValue) {
 		}
 		// TODO: Had to add elt.Lengths to avoid doing this for arrays, but not entirely sure why
 	} else if (elt.PointerTargetType == types.STR || elt.Type == types.STR) && elt.Lengths == nil {
-		sliceLen = types.Read_str_size(ast.PROGRAM.Memory, inputs[0].Offset)
+		sliceLen = types.Read_str_size(prgrm.Memory, inputs[0].Offset)
 	} else {
 		sliceLen = elt.Lengths[len(elt.Indexes)]
 	}
@@ -29,7 +29,7 @@ func opSliceLen(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 //TODO: Rework
-func opSliceAppend(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opSliceAppend(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inp0, inp1, out0 := inputs[0].Arg, inputs[1].Arg, outputs[0].Arg
 	sliceInputs := inputs[1:]
 	sliceInputsLen := types.Cast_int_to_ptr(len(sliceInputs))
@@ -57,7 +57,7 @@ func opSliceAppend(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 
 	var inputSliceLen types.Pointer
-	inputSliceOffset := types.Read_ptr(ast.PROGRAM.Memory, inputs[0].Offset)
+	inputSliceOffset := types.Read_ptr(prgrm.Memory, inputs[0].Offset)
 	if inputSliceOffset != 0 && inputSliceOffset.IsValid() {
 		inputSliceLen = ast.GetSliceLen(inputSliceOffset)
 	}
@@ -80,7 +80,7 @@ func opSliceAppend(inputs []ast.CXValue, outputs []ast.CXValue) {
 		}
 		if inpType == types.STR || inpType == types.AFF {
 			var obj [types.POINTER_SIZE]byte
-			types.Write_ptr(obj[:], 0, types.Read_ptr(ast.PROGRAM.Memory, input.Offset))
+			types.Write_ptr(obj[:], 0, types.Read_ptr(prgrm.Memory, input.Offset))
 			ast.SliceAppendWrite(outputSliceOffset, obj[:], inputSliceLen+types.Cast_int_to_ptr(i))
 		} else {
 			obj := inputs[1].Get_bytes()
@@ -91,7 +91,7 @@ func opSliceAppend(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 //TODO: Rework
-func opSliceResize(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opSliceResize(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inp0, out0 := inputs[0].Arg, outputs[0].Arg
 	fp := inputs[0].FramePointer
 
@@ -107,7 +107,7 @@ func opSliceResize(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 //TODO: Rework
-func opSliceInsertElement(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opSliceInsertElement(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inp0, inp2, out0 := inputs[0].Arg, inputs[2].Arg, outputs[0].Arg
 	fp := inputs[0].FramePointer
 
@@ -135,7 +135,7 @@ func opSliceInsertElement(inputs []ast.CXValue, outputs []ast.CXValue) {
 	var outputSliceOffset types.Pointer
 	if inp2Type == types.STR || inp2Type == types.AFF {
 		var obj [types.POINTER_SIZE]byte
-		types.Write_ptr(obj[:], 0, types.Read_ptr(ast.PROGRAM.Memory, inputs[2].Offset))
+		types.Write_ptr(obj[:], 0, types.Read_ptr(prgrm.Memory, inputs[2].Offset))
 		outputSliceOffset = ast.SliceInsert(fp, out0, inp0, index, obj[:])
 	} else {
 		obj := inputs[2].Get_bytes()
@@ -146,7 +146,7 @@ func opSliceInsertElement(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 //TODO: Rework
-func opSliceRemoveElement(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opSliceRemoveElement(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inp0, out0 := inputs[0].Arg, outputs[0].Arg
 	fp := inputs[0].FramePointer
 
@@ -159,7 +159,7 @@ func opSliceRemoveElement(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_ptr(outputSliceOffset)
 }
 
-func opSliceCopy(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opSliceCopy(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	dstInput := inputs[0].Arg
 	srcInput := inputs[1].Arg
 	fp := inputs[0].FramePointer

--- a/cx/opcodes/op_stdin.go
+++ b/cx/opcodes/op_stdin.go
@@ -2,22 +2,23 @@ package opcodes
 
 import (
 	"bufio"
-	"github.com/skycoin/cx/cx/ast"
-	"github.com/skycoin/cx/cx/constants"
 	"os"
 	"strings"
+
+	"github.com/skycoin/cx/cx/ast"
+	"github.com/skycoin/cx/cx/constants"
 )
 
 //Reads input from Standard Inpuit
-func OpReadStdin(inputs []ast.CXValue, outputs []ast.CXValue) {
+func OpReadStdin(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	reader := bufio.NewReader(os.Stdin)
 	text, err := reader.ReadString('\n')
-    if err != nil {
+	if err != nil {
 		panic(constants.CX_INTERNAL_ERROR)
 	}
 
 	// text = strings.Trim(text, " \n")
 	text = strings.Replace(text, "\n", "", -1)
 	text = strings.Replace(text, "\r", "", -1)
-    outputs[0].Set_str(text)
+	outputs[0].Set_str(text)
 }

--- a/cx/opcodes/op_str.go
+++ b/cx/opcodes/op_str.go
@@ -2,149 +2,150 @@ package opcodes
 
 import (
 	"fmt"
-	"github.com/skycoin/cx/cx/ast"
-	"github.com/skycoin/cx/cx/constants"
 	"strconv"
 	"strings"
+
+	"github.com/skycoin/cx/cx/ast"
+	"github.com/skycoin/cx/cx/constants"
 )
 
-func opStrToI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrToI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0, err := strconv.ParseInt(inputs[0].Get_str(), 10, 8)
 	if err != nil {
 		panic(constants.CX_RUNTIME_ERROR)
 	}
-    outputs[0].Set_i8(int8(outV0))
+	outputs[0].Set_i8(int8(outV0))
 }
 
-func opStrToI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrToI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0, err := strconv.ParseInt(inputs[0].Get_str(), 10, 16)
 	if err != nil {
 		panic(constants.CX_RUNTIME_ERROR)
 	}
-    outputs[0].Set_i16(int16(outV0))
+	outputs[0].Set_i16(int16(outV0))
 }
 
-func opStrToI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrToI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0, err := strconv.ParseInt(inputs[0].Get_str(), 10, 32)
 	if err != nil {
 		panic(constants.CX_RUNTIME_ERROR)
 	}
-    outputs[0].Set_i32(int32(outV0))
+	outputs[0].Set_i32(int32(outV0))
 }
 
-func opStrToI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrToI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0, err := strconv.ParseInt(inputs[0].Get_str(), 10, 64)
 	if err != nil {
 		panic(constants.CX_RUNTIME_ERROR)
 	}
-    outputs[0].Set_i64(int64(outV0))
+	outputs[0].Set_i64(int64(outV0))
 }
 
-func opStrToUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrToUI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0, err := strconv.ParseUint(inputs[0].Get_str(), 10, 8)
 	if err != nil {
 		panic(constants.CX_RUNTIME_ERROR)
 	}
-    outputs[0].Set_ui8(uint8(outV0))
+	outputs[0].Set_ui8(uint8(outV0))
 }
 
-func opStrToUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrToUI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0, err := strconv.ParseUint(inputs[0].Get_str(), 10, 16)
 	if err != nil {
 		panic(constants.CX_RUNTIME_ERROR)
 	}
-    outputs[0].Set_ui16(uint16(outV0))
+	outputs[0].Set_ui16(uint16(outV0))
 }
 
-func opStrToUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrToUI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0, err := strconv.ParseUint(inputs[0].Get_str(), 10, 32)
 	if err != nil {
 		panic(constants.CX_RUNTIME_ERROR)
 	}
-    outputs[0].Set_ui32(uint32(outV0))
+	outputs[0].Set_ui32(uint32(outV0))
 }
 
-func opStrToUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrToUI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0, err := strconv.ParseUint(inputs[0].Get_str(), 10, 64)
 	if err != nil {
 		panic(constants.CX_RUNTIME_ERROR)
 	}
-    outputs[0].Set_ui64(uint64(outV0))
+	outputs[0].Set_ui64(uint64(outV0))
 }
 
-func opStrToF32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrToF32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0, err := strconv.ParseFloat(inputs[0].Get_str(), 32)
 	if err != nil {
 		panic(constants.CX_RUNTIME_ERROR)
 	}
-    outputs[0].Set_f32(float32(outV0))
+	outputs[0].Set_f32(float32(outV0))
 }
 
-func opStrToF64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrToF64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0, err := strconv.ParseFloat(inputs[0].Get_str(), 64)
 	if err != nil {
 		panic(constants.CX_RUNTIME_ERROR)
 	}
-    outputs[0].Set_f64(float64(outV0))
+	outputs[0].Set_f64(float64(outV0))
 }
 
-func opStrEq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrEq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_str() == inputs[1].Get_str()
 	outputs[0].Set_bool(outV0)
 }
 
-func opStrUneq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrUneq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_str() != inputs[1].Get_str()
 	outputs[0].Set_bool(outV0)
 }
 
-func opStrLt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrLt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_str() < inputs[1].Get_str()
 	outputs[0].Set_bool(outV0)
 }
 
-func opStrLteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrLteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_str() <= inputs[1].Get_str()
 	outputs[0].Set_bool(outV0)
 }
 
-func opStrGt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrGt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_str() >= inputs[1].Get_str()
 	outputs[0].Set_bool(outV0)
 }
 
-func opStrGteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrGteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_str() >= inputs[1].Get_str()
 	outputs[0].Set_bool(outV0)
 }
 
-func opStrPrint(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrPrint(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	fmt.Println(inputs[0].Get_str())
 }
 
-func opStrConcat(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrConcat(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_str(inputs[0].Get_str() + inputs[1].Get_str())
 }
 
-func opStrSubstr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrSubstr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	str := inputs[0].Get_str()
 	begin := inputs[1].Get_i32()
 	end := inputs[2].Get_i32()
 	outputs[0].Set_str(str[begin:end])
 }
 
-func opStrIndex(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrIndex(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	str := inputs[0].Get_str()
 	substr := inputs[1].Get_str()
 	outputs[0].Set_i32(int32(strings.Index(str, substr)))
 }
 
-func opStrLastIndex(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrLastIndex(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	str := inputs[0].Get_str()
 	substr := inputs[1].Get_str()
 	outputs[0].Set_i32(int32(strings.LastIndex(str, substr)))
 }
 
-func opStrTrimSpace(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrTrimSpace(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_str(strings.TrimSpace(inputs[0].Get_str()))
 }

--- a/cx/opcodes/op_tcp.go
+++ b/cx/opcodes/op_tcp.go
@@ -2,12 +2,13 @@ package opcodes
 
 import (
 	"context"
-	"github.com/skycoin/cx/cx/ast"
-	"github.com/skycoin/cx/cx/types"
 	"log"
 	"net"
 	"net/rpc"
 	"time"
+
+	"github.com/skycoin/cx/cx/ast"
+	"github.com/skycoin/cx/cx/types"
 )
 
 //todo need to find a way to support Listener and connection interface
@@ -29,9 +30,9 @@ func init() {
 	ast.PROGRAM.AddPackage(netPkg)
 }
 
-func opTCPDial(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opTCPDial(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	network, address, errorstring := inputs[0].Arg, inputs[1].Arg, outputs[0].Arg
-    fp := inputs[0].FramePointer
+	fp := inputs[0].FramePointer
 
 	log.Println("network", network)
 	log.Println("address", address)
@@ -40,24 +41,24 @@ func opTCPDial(inputs []ast.CXValue, outputs []ast.CXValue) {
 	conn, err = net.Dial("tcp", "localhost:9000")
 
 	if err != nil {
-		types.Write_str(ast.PROGRAM.Memory, ast.GetFinalOffset(fp, errorstring), err.Error())
+		types.Write_str(prgrm.Memory, ast.GetFinalOffset(fp, errorstring), err.Error())
 	}
 
 	conn.Close()
 }
 
-func opTCPClose(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opTCPClose(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	ln.Close()
 }
 
-func opTCPAccept(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opTCPAccept(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	conn, _ = ln.Accept()
 	conn.Close()
 }
 
-func opTCPListen(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opTCPListen(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	network, address, errorstring := inputs[0].Arg, inputs[1].Arg, outputs[0].Arg
-    fp := inputs[0].FramePointer
+	fp := inputs[0].FramePointer
 
 	log.Println("network", network)
 	log.Println("address", address)
@@ -73,6 +74,6 @@ func opTCPListen(inputs []ast.CXValue, outputs []ast.CXValue) {
 	ln.Close()
 
 	if err != nil {
-		types.Write_str(ast.PROGRAM.Memory, ast.GetFinalOffset(fp, errorstring), err.Error())
+		types.Write_str(prgrm.Memory, ast.GetFinalOffset(fp, errorstring), err.Error())
 	}
 }

--- a/cx/opcodes/op_testing.go
+++ b/cx/opcodes/op_testing.go
@@ -16,7 +16,7 @@ func AssertFailed() bool {
 }
 
 //TODO: Rework
-func assert(inputs []ast.CXValue, outputs []ast.CXValue) (same bool) {
+func assert(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) (same bool) {
 	var byts1, byts2 []byte
 	if inputs[0].Arg.Type == types.STR || inputs[0].Arg.PointerTargetType == types.STR {
 		byts1 = []byte(inputs[0].Get_str())
@@ -48,7 +48,7 @@ func assert(inputs []ast.CXValue, outputs []ast.CXValue) (same bool) {
 	message := inputs[2].Get_str()
 
 	if !same {
-		call := ast.PROGRAM.GetCurrentCall()
+		call := prgrm.GetCurrentCall()
 		expr := call.Operator.Expressions[call.Line]
 		if message != "" {
 			fmt.Printf("%s: %d: result was not equal to the expected value; %s\n", expr.FileName, expr.FileLine, message)
@@ -61,26 +61,26 @@ func assert(inputs []ast.CXValue, outputs []ast.CXValue) (same bool) {
 	return same
 }
 
-func opAssertValue(inputs []ast.CXValue, outputs []ast.CXValue) {
-	same := assert(inputs, outputs)
+func opAssertValue(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	same := assert(prgrm, inputs, outputs)
 	outputs[0].Set_bool(same)
 }
 
-func opTest(inputs []ast.CXValue, outputs []ast.CXValue) {
-	assert(inputs, outputs)
+func opTest(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	assert(prgrm, inputs, outputs)
 }
 
-func opPanic(inputs []ast.CXValue, outputs []ast.CXValue) {
-	if !assert(inputs, outputs) {
+func opPanic(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	if !assert(prgrm, inputs, outputs) {
 		panic(constants.CX_ASSERT)
 	}
 }
 
 // panicIf/panicIfNot implementation
-func panicIf(inputs []ast.CXValue, outputs []ast.CXValue, condition bool) {
+func panicIf(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue, condition bool) {
 	str := inputs[1].Get_str()
 	if inputs[0].Get_bool() == condition {
-		call := ast.PROGRAM.GetCurrentCall()
+		call := prgrm.GetCurrentCall()
 		expr := call.Operator.Expressions[call.Line]
 		fmt.Printf("%s : %d, %s\n", expr.FileName, expr.FileLine, str)
 		panic(constants.CX_ASSERT)
@@ -88,15 +88,15 @@ func panicIf(inputs []ast.CXValue, outputs []ast.CXValue, condition bool) {
 }
 
 // panic with CX_ASSERT exit code if condition is true
-func opPanicIf(inputs []ast.CXValue, outputs []ast.CXValue) {
-	panicIf(inputs, outputs, true)
+func opPanicIf(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	panicIf(prgrm, inputs, outputs, true)
 }
 
 // panic with CX_ASSERT exit code if condition is false
-func opPanicIfNot(inputs []ast.CXValue, outputs []ast.CXValue) {
-	panicIf(inputs, outputs, false)
+func opPanicIfNot(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	panicIf(prgrm, inputs, outputs, false)
 }
 
-func opStrError(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStrError(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_str(ast.ErrorString(int(inputs[0].Get_i32())))
 }

--- a/cx/opcodes/op_ui16.go
+++ b/cx/opcodes/op_ui16.go
@@ -2,205 +2,206 @@ package opcodes
 
 import (
 	"fmt"
-	"github.com/skycoin/cx/cx/ast"
 	"math"
 	"math/rand"
 	"strconv"
+
+	"github.com/skycoin/cx/cx/ast"
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opUI16ToStr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16ToStr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := strconv.FormatUint(uint64(inputs[0].Get_ui16()), 10)
 	outputs[0].Set_str(outV0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui16 to type i8.
-func opUI16ToI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16ToI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int8(inputs[0].Get_ui16())
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type ui16 to type i16.
-func opUI16ToI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16ToI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int16(inputs[0].Get_ui16())
-    outputs[0].Set_i16(outV0)
+	outputs[0].Set_i16(outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui16 to type i32.
-func opUI16ToI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16ToI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int32(inputs[0].Get_ui16())
-    outputs[0].Set_i32(outV0)
+	outputs[0].Set_i32(outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type ui16 to type i64.
-func opUI16ToI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16ToI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int64(inputs[0].Get_ui16())
-    outputs[0].Set_i64(outV0)
+	outputs[0].Set_i64(outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type ui16 to type ui8.
-func opUI16ToUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16ToUI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint8(inputs[0].Get_ui16())
-    outputs[0].Set_ui8(outV0)
+	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type ui16 to type ui32.
-func opUI16ToUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16ToUI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint32(inputs[0].Get_ui16())
-    outputs[0].Set_ui32(outV0)
+	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type ui16 to type ui64.
-func opUI16ToUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16ToUI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint64(inputs[0].Get_ui16())
-    outputs[0].Set_ui64(outV0)
+	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui16 to type f32.
-func opUI16ToF32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16ToF32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(inputs[0].Get_ui16())
-    outputs[0].Set_f32(outV0)
+	outputs[0].Set_f32(outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui16 to type f64.
-func opUI16ToF64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16ToF64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float64(inputs[0].Get_ui16())
-    outputs[0].Set_f64(outV0)
+	outputs[0].Set_f64(outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opUI16Print(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Print(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	fmt.Println(inputs[0].Get_ui16())
 }
 
 // The built-in add function returns the sum of two ui16 numbers.
-func opUI16Add(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Add(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() + inputs[1].Get_ui16()
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in sub function returns the difference of two ui16 numbers.
-func opUI16Sub(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Sub(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() - inputs[1].Get_ui16()
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in mul function returns the product of two ui16 numbers.
-func opUI16Mul(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Mul(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() * inputs[1].Get_ui16()
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in div function returns the quotient of two ui16 numbers.
-func opUI16Div(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Div(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() / inputs[1].Get_ui16()
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opUI16Gt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Gt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() > inputs[1].Get_ui16()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opUI16Gteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Gteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() >= inputs[1].Get_ui16()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opUI16Lt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Lt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() < inputs[1].Get_ui16()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opUI16Lteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Lteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() <= inputs[1].Get_ui16()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opUI16Eq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Eq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() == inputs[1].Get_ui16()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opUI16Uneq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Uneq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() != inputs[1].Get_ui16()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
-func opUI16Mod(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Mod(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() % inputs[1].Get_ui16()
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
-func opUI16Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Rand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint16(rand.Int31n(int32(math.MaxUint16)))
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opUI16Bitand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Bitand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() & inputs[1].Get_ui16()
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opUI16Bitor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Bitor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() | inputs[1].Get_ui16()
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opUI16Bitxor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Bitxor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() ^ inputs[1].Get_ui16()
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opUI16Bitclear(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Bitclear(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() &^ inputs[1].Get_ui16()
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opUI16Bitshl(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Bitshl(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() << inputs[1].Get_ui16()
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opUI16Bitshr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Bitshr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui16() >> inputs[1].Get_ui16()
 	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in max function returns the biggest of the two operands..
-func opUI16Max(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Max(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_ui16()
 	inpV1 := inputs[1].Get_ui16()
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_ui16(inpV0)
+	outputs[0].Set_ui16(inpV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opUI16Min(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI16Min(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_ui16()
 	inpV1 := inputs[1].Get_ui16()
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_ui16(inpV0)
+	outputs[0].Set_ui16(inpV0)
 }

--- a/cx/opcodes/op_ui32.go
+++ b/cx/opcodes/op_ui32.go
@@ -2,204 +2,205 @@ package opcodes
 
 import (
 	"fmt"
-	"github.com/skycoin/cx/cx/ast"
 	"math/rand"
 	"strconv"
+
+	"github.com/skycoin/cx/cx/ast"
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opUI32ToStr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32ToStr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := strconv.FormatUint(uint64(inputs[0].Get_ui32()), 10)
 	outputs[0].Set_str(outV0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui32 to type i8.
-func opUI32ToI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32ToI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int8(inputs[0].Get_ui32())
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type ui32 to type i16.
-func opUI32ToI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32ToI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int16(inputs[0].Get_ui32())
-    outputs[0].Set_i16(outV0)
+	outputs[0].Set_i16(outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui32 to type i32.
-func opUI32ToI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32ToI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int32(inputs[0].Get_ui32())
-    outputs[0].Set_i32(outV0)
+	outputs[0].Set_i32(outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type ui32 to type i64.
-func opUI32ToI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32ToI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int64(inputs[0].Get_ui32())
-    outputs[0].Set_i64(outV0)
+	outputs[0].Set_i64(outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type ui32 to type ui8.
-func opUI32ToUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32ToUI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint8(inputs[0].Get_ui32())
-    outputs[0].Set_ui8(outV0)
+	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type ui32 to type ui16.
-func opUI32ToUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32ToUI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint16(inputs[0].Get_ui32())
-    outputs[0].Set_ui16(outV0)
+	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type ui32 to type ui64.
-func opUI32ToUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32ToUI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint64(inputs[0].Get_ui32())
-    outputs[0].Set_ui64(outV0)
+	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui32 to type f32.
-func opUI32ToF32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32ToF32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(inputs[0].Get_ui32())
-    outputs[0].Set_f32(outV0)
+	outputs[0].Set_f32(outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui32 to type f64.
-func opUI32ToF64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32ToF64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float64(inputs[0].Get_ui32())
-    outputs[0].Set_f64(outV0)
+	outputs[0].Set_f64(outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opUI32Print(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Print(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	fmt.Println(inputs[0].Get_ui32())
 }
 
 // The built-in add function returns the sum of two ui32 numbers.
-func opUI32Add(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Add(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() + inputs[1].Get_ui32()
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in sub function returns the difference of two ui32 numbers.
-func opUI32Sub(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Sub(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() - inputs[1].Get_ui32()
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in mul function returns the product of two ui32 numbers.
-func opUI32Mul(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Mul(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() * inputs[1].Get_ui32()
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in div function returns the quotient of two ui32 numbers.
-func opUI32Div(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Div(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() / inputs[1].Get_ui32()
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opUI32Gt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Gt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() > inputs[1].Get_ui32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opUI32Gteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Gteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() >= inputs[1].Get_ui32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opUI32Lt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Lt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() < inputs[1].Get_ui32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opUI32Lteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Lteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() <= inputs[1].Get_ui32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opUI32Eq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Eq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() == inputs[1].Get_ui32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opUI32Uneq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Uneq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() != inputs[1].Get_ui32()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
-func opUI32Mod(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Mod(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() % inputs[1].Get_ui32()
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
-func opUI32Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Rand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := rand.Uint32()
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opUI32Bitand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Bitand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() & inputs[1].Get_ui32()
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opUI32Bitor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Bitor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() | inputs[1].Get_ui32()
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opUI32Bitxor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Bitxor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() ^ inputs[1].Get_ui32()
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opUI32Bitclear(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Bitclear(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() &^ inputs[1].Get_ui32()
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opUI32Bitshl(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Bitshl(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() << inputs[1].Get_ui32()
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opUI32Bitshr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Bitshr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui32() >> inputs[1].Get_ui32()
 	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opUI32Max(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Max(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_ui32()
 	inpV1 := inputs[1].Get_ui32()
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_ui32(inpV0)
+	outputs[0].Set_ui32(inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
-func opUI32Min(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI32Min(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_ui32()
 	inpV1 := inputs[1].Get_ui32()
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_ui32(inpV0)
+	outputs[0].Set_ui32(inpV0)
 }

--- a/cx/opcodes/op_ui64.go
+++ b/cx/opcodes/op_ui64.go
@@ -2,204 +2,205 @@ package opcodes
 
 import (
 	"fmt"
-	"github.com/skycoin/cx/cx/ast"
 	"math/rand"
 	"strconv"
+
+	"github.com/skycoin/cx/cx/ast"
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opUI64ToStr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64ToStr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := strconv.FormatUint(inputs[0].Get_ui64(), 10)
 	outputs[0].Set_str(outV0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui64 to type i8.
-func opUI64ToI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64ToI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int8(inputs[0].Get_ui64())
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in i16 function retruns operand 1 casted from type ui64 to i16.
-func opUI64ToI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64ToI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int16(inputs[0].Get_ui64())
-    outputs[0].Set_i16(outV0)
+	outputs[0].Set_i16(outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui64 to type i32.
-func opUI64ToI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64ToI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int32(inputs[0].Get_ui64())
-    outputs[0].Set_i32(outV0)
+	outputs[0].Set_i32(outV0)
 }
 
 // The built-in i64 function return operand 1 casted from type ui64 to type i64.
-func opUI64ToI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64ToI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int64(inputs[0].Get_ui64())
-    outputs[0].Set_i64(outV0)
+	outputs[0].Set_i64(outV0)
 }
 
 // The built-in ui8 function returns operand 1 casted from type ui64 to type ui8.
-func opUI64ToUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64ToUI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint8(inputs[0].Get_ui64())
-    outputs[0].Set_ui8(outV0)
+	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type ui64 to type ui16.
-func opUI64ToUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64ToUI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint16(inputs[0].Get_ui64())
-    outputs[0].Set_ui16(outV0)
+	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type ui64 to type ui32.
-func opUI64ToUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64ToUI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint32(inputs[0].Get_ui64())
-    outputs[0].Set_ui32(outV0)
+	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui64 to type f32.
-func opUI64ToF32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64ToF32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(inputs[0].Get_ui64())
-    outputs[0].Set_f32(outV0)
+	outputs[0].Set_f32(outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui64 to type f64.
-func opUI64ToF64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64ToF64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float64(inputs[0].Get_ui64())
-    outputs[0].Set_f64(outV0)
+	outputs[0].Set_f64(outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opUI64Print(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Print(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	fmt.Println(inputs[0].Get_ui64())
 }
 
 // The built-in add function returns the sum of two ui64 numbers.
-func opUI64Add(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Add(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() + inputs[1].Get_ui64()
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in sub function returns the difference of two ui64 numbers.
-func opUI64Sub(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Sub(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() - inputs[1].Get_ui64()
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in mul function returns the product of two ui64 numbers.
-func opUI64Mul(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Mul(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() * inputs[1].Get_ui64()
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in div function returns the quotient of two ui64 numbers.
-func opUI64Div(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Div(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() / inputs[1].Get_ui64()
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opUI64Gt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Gt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() > inputs[1].Get_ui64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opUI64Gteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Gteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() >= inputs[1].Get_ui64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opUI64Lt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Lt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() < inputs[1].Get_ui64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opUI64Lteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Lteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() <= inputs[1].Get_ui64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opUI64Eq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Eq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() == inputs[1].Get_ui64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opUI64Uneq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Uneq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() != inputs[1].Get_ui64()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
-func opUI64Mod(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Mod(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() % inputs[1].Get_ui64()
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
-func opUI64Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Rand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := rand.Uint64()
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opUI64Bitand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Bitand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() & inputs[1].Get_ui64()
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opUI64Bitor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Bitor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() | inputs[1].Get_ui64()
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opUI64Bitxor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Bitxor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() ^ inputs[1].Get_ui64()
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opUI64Bitclear(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Bitclear(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() &^ inputs[1].Get_ui64()
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opUI64Bitshl(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Bitshl(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() << inputs[1].Get_ui64()
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opUI64Bitshr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Bitshr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui64() >> inputs[1].Get_ui64()
 	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opUI64Max(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Max(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_ui64()
 	inpV1 := inputs[1].Get_ui64()
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_ui64(inpV0)
+	outputs[0].Set_ui64(inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
-func opUI64Min(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI64Min(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_ui64()
 	inpV1 := inputs[1].Get_ui64()
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_ui64(inpV0)
+	outputs[0].Set_ui64(inpV0)
 }

--- a/cx/opcodes/op_ui8.go
+++ b/cx/opcodes/op_ui8.go
@@ -2,205 +2,206 @@ package opcodes
 
 import (
 	"fmt"
-	"github.com/skycoin/cx/cx/ast"
 	"math"
 	"math/rand"
 	"strconv"
+
+	"github.com/skycoin/cx/cx/ast"
 )
 
 // The built-in str function returns the base 10 string representation of operand 1.
-func opUI8ToStr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8ToStr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := strconv.FormatUint(uint64(inputs[0].Get_ui8()), 10)
 	outputs[0].Set_str(outV0)
 }
 
 // The built-in i8 function returns operand 1 casted from type ui8 to type i8.
-func opUI8ToI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8ToI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int8(inputs[0].Get_ui8())
-    outputs[0].Set_i8(outV0)
+	outputs[0].Set_i8(outV0)
 }
 
 // The built-in i16 function returns operand 1 casted from type ui8 to type i16.
-func opUI8ToI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8ToI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int16(inputs[0].Get_ui8())
-    outputs[0].Set_i16(outV0)
+	outputs[0].Set_i16(outV0)
 }
 
 // The built-in i32 function return operand 1 casted from type ui8 to type i32.
-func opUI8ToI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8ToI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int32(inputs[0].Get_ui8())
-    outputs[0].Set_i32(outV0)
+	outputs[0].Set_i32(outV0)
 }
 
 // The built-in i64 function returns operand 1 casted from type ui8 to type i64.
-func opUI8ToI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8ToI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int64(inputs[0].Get_ui8())
-    outputs[0].Set_i64(outV0)
+	outputs[0].Set_i64(outV0)
 }
 
 // The built-in ui16 function returns the operand 1 casted from type ui8 to type ui16.
-func opUI8ToUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8ToUI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint16(inputs[0].Get_ui8())
-    outputs[0].Set_ui16(outV0)
+	outputs[0].Set_ui16(outV0)
 }
 
 // The built-in ui32 function returns the operand 1 casted from type ui8 to type ui32.
-func opUI8ToUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8ToUI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint32(inputs[0].Get_ui8())
-    outputs[0].Set_ui32(outV0)
+	outputs[0].Set_ui32(outV0)
 }
 
 // The built-in ui64 function returns the operand 1 casted from type ui8 to type ui64.
-func opUI8ToUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8ToUI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint64(inputs[0].Get_ui8())
-    outputs[0].Set_ui64(outV0)
+	outputs[0].Set_ui64(outV0)
 }
 
 // The built-in f32 function returns operand 1 casted from type ui8 to type f32.
-func opUI8ToF32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8ToF32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float32(inputs[0].Get_ui8())
-    outputs[0].Set_f32(outV0)
+	outputs[0].Set_f32(outV0)
 }
 
 // The built-in f64 function returns operand 1 casted from type ui8 to type f64.
-func opUI8ToF64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8ToF64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := float64(inputs[0].Get_ui8())
-    outputs[0].Set_f64(outV0)
+	outputs[0].Set_f64(outV0)
 }
 
 // The print built-in function formats its arguments and prints them.
-func opUI8Print(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Print(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	fmt.Println(inputs[0].Get_ui8())
 }
 
 // The built-in add function returns the sum of two ui8 numbers.
-func opUI8Add(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Add(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() + inputs[1].Get_ui8()
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in sub function returns the difference of two ui8 numbers.
-func opUI8Sub(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Sub(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() - inputs[1].Get_ui8()
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in mul function returns the product of two ui8 numbers.
-func opUI8Mul(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Mul(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() * inputs[1].Get_ui8()
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in div function returns the quotient of two ui8 numbers.
-func opUI8Div(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Div(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() / inputs[1].Get_ui8()
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in gt function returns true if operand 1 is greater than operand 2.
-func opUI8Gt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Gt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() > inputs[1].Get_ui8()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in gteq function returns true if operand 1 is greater than or
 // equal to operand 2.
-func opUI8Gteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Gteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() >= inputs[1].Get_ui8()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lt function returns true if operand 1 is less than operand 2.
-func opUI8Lt(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Lt(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() < inputs[1].Get_ui8()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in lteq function returns true if operand 1 is less than or equal
 // to operand 1.
-func opUI8Lteq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Lteq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() <= inputs[1].Get_ui8()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in eq function returns true if operand 1 is equal to operand 2.
-func opUI8Eq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Eq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() == inputs[1].Get_ui8()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in uneq function returns true if operand 1 is different from operand 2.
-func opUI8Uneq(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Uneq(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() != inputs[1].Get_ui8()
 	outputs[0].Set_bool(outV0)
 }
 
 // The built-in mod function returns the remainder of operand 1 / operand 2.
-func opUI8Mod(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Mod(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() % inputs[1].Get_ui8()
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in rand function returns a pseudo-random number.
-func opUI8Rand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Rand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := uint8(rand.Int31n(int32(math.MaxUint8)))
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in bitand function returns the bitwise AND of 2 operands.
-func opUI8Bitand(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Bitand(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() & inputs[1].Get_ui8()
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in bitor function returns the bitwise OR of 2 operands.
-func opUI8Bitor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Bitor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() | inputs[1].Get_ui8()
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in bitxor function returns the bitwise XOR of 2 operands.
-func opUI8Bitxor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Bitxor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() ^ inputs[1].Get_ui8()
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in bitclear function returns the bitwise AND NOT of 2 operands.
-func opUI8Bitclear(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Bitclear(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() &^ inputs[1].Get_ui8()
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in bitshl function returns bits of operand 1 shifted to the left
 // by number of positions specified in operand 2.
-func opUI8Bitshl(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Bitshl(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() << inputs[1].Get_ui8()
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in bitshr function returns bits of operand 1 shifted to the right
 // by number of positions specified in operand 2.
-func opUI8Bitshr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Bitshr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := inputs[0].Get_ui8() >> uint32(inputs[1].Get_ui8())
 	outputs[0].Set_ui8(outV0)
 }
 
 // The built-in max function returns the biggest of the two operands.
-func opUI8Max(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Max(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_ui8()
 	inpV1 := inputs[1].Get_ui8()
 	if inpV1 > inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_ui8(inpV0)
+	outputs[0].Set_ui8(inpV0)
 }
 
 // The built-in min function returns the smallest of the two operands.
-func opUI8Min(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opUI8Min(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_ui8()
 	inpV1 := inputs[1].Get_ui8()
 	if inpV1 < inpV0 {
 		inpV0 = inpV1
 	}
-    outputs[0].Set_ui8(inpV0)
+	outputs[0].Set_ui8(inpV0)
 }

--- a/cx/opcodes/opcodes.go
+++ b/cx/opcodes/opcodes.go
@@ -79,6 +79,6 @@ func MakeNativeFunction(opCode int, inputs []*ast.CXArgument, outputs []*ast.CXA
 	return fn
 }
 
-func opDebugPrintStack([]ast.CXValue, []ast.CXValue) {
-	ast.PROGRAM.PrintStack()
+func opDebugPrintStack(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	prgrm.PrintStack()
 }

--- a/cx/packages/cipher/init.go
+++ b/cx/packages/cipher/init.go
@@ -19,14 +19,14 @@ func RegisterPackage() {
 	pubkeyFld.DeclarationSpecifiers = append(pubkeyFld.DeclarationSpecifiers, constants.DECL_ARRAY)
 	// pubkeyFld.IsArray = true
 	pubkeyFld.Lengths = []types.Pointer{33} // Yes, PubKey is 33 bytes long.
-	pubkeyFld.TotalSize = 33      // 33 * 1 byte (ui8)
+	pubkeyFld.TotalSize = 33                // 33 * 1 byte (ui8)
 
 	// SecKey
 	seckeyFld := ast.MakeArgument("SecKey", "", -1).AddType(types.UI8).AddPackage(cipherPkg)
 	seckeyFld.DeclarationSpecifiers = append(seckeyFld.DeclarationSpecifiers, constants.DECL_ARRAY)
 	// seckeyFld.IsArray = true
 	seckeyFld.Lengths = []types.Pointer{32} // Yes, SecKey is 32 bytes long.
-	seckeyFld.TotalSize = 33      // 33 * 1 byte (ui8)
+	seckeyFld.TotalSize = 33                // 33 * 1 byte (ui8)
 
 	pubkeyStrct.AddField(pubkeyFld)
 	seckeyStrct.AddField(seckeyFld)

--- a/cx/packages/cipher/op_cipher.go
+++ b/cx/packages/cipher/op_cipher.go
@@ -8,7 +8,7 @@ import (
 )
 
 // opCipherGenerateKeyPair generates a PubKey and a SecKey.
-func opCipherGenerateKeyPair(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opCipherGenerateKeyPair(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	pubKey, secKey := cipher.GenerateKeyPair()
 
 	bPubKey := make([]byte, len(pubKey))
@@ -22,6 +22,6 @@ func opCipherGenerateKeyPair(inputs []ast.CXValue, outputs []ast.CXValue) {
 		bSecKey[i] = byt
 	}
 
-    outputs[0].Set_bytes(bPubKey)
-    outputs[1].Set_bytes(bSecKey)
+	outputs[0].Set_bytes(bPubKey)
+	outputs[1].Set_bytes(bSecKey)
 }

--- a/cx/packages/cxfx/cxgl_desktop.go
+++ b/cx/packages/cxfx/cxgl_desktop.go
@@ -47,21 +47,21 @@ func freeCString(key string) {
 }
 
 // gogl
-func opGlInit(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlInit(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.Init()
 }
 
-func opGlDestroy(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDestroy(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	for k, _ := range cSources {
 		freeCString(k)
 	}
 }
 
-func opGlStrs(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlStrs(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	getCString(inputs[0].Get_str(), inputs[1].Get_str())
 }
 
-func opGlFree(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlFree(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	freeCString(inputs[0].Get_str())
 }
 
@@ -508,87 +508,87 @@ func cxglGenVertexArrays(n int32, arrays *uint32) {
 }
 
 // gl_0_0
-func opGlMatrixMode(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlMatrixMode(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.MatrixMode(uint32(inputs[0].Get_i32()))
 }
 
-func opGlRotatef(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlRotatef(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.Rotatef(inputs[0].Get_f32(), inputs[1].Get_f32(), inputs[2].Get_f32(), inputs[3].Get_f32())
 }
 
-func opGlTranslatef(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlTranslatef(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.Translatef(inputs[0].Get_f32(), inputs[1].Get_f32(), inputs[2].Get_f32())
 }
 
-func opGlLoadIdentity(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlLoadIdentity(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.LoadIdentity()
 }
 
-func opGlPushMatrix(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlPushMatrix(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.PushMatrix()
 }
 
-func opGlPopMatrix(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlPopMatrix(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.PopMatrix()
 }
 
-func opGlEnableClientState(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlEnableClientState(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.EnableClientState(uint32(inputs[0].Get_i32()))
 }
 
-func opGlColor3f(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlColor3f(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.Color3f(inputs[0].Get_f32(), inputs[1].Get_f32(), inputs[2].Get_f32())
 }
 
-func opGlColor4f(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlColor4f(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.Color4f(inputs[0].Get_f32(), inputs[1].Get_f32(), inputs[2].Get_f32(), inputs[3].Get_f32())
 }
 
-func opGlBegin(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlBegin(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.Begin(uint32(inputs[0].Get_i32()))
 }
 
-func opGlEnd(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlEnd(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.End()
 }
 
-func opGlNormal3f(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlNormal3f(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.Normal3f(inputs[0].Get_f32(), inputs[1].Get_f32(), inputs[2].Get_f32())
 }
 
-func opGlVertex2f(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlVertex2f(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.Vertex2f(inputs[0].Get_f32(), inputs[1].Get_f32())
 }
 
-func opGlVertex3f(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlVertex3f(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.Vertex3f(inputs[0].Get_f32(), inputs[1].Get_f32(), inputs[2].Get_f32())
 }
 
-func opGlLightfv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlLightfv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	// pointers
 	panic("gl.Lightfv")
 }
 
-func opGlFrustum(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlFrustum(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.Frustum(inputs[0].Get_f64(), inputs[1].Get_f64(), inputs[2].Get_f64(), inputs[3].Get_f64(), inputs[4].Get_f64(), inputs[5].Get_f64())
 }
 
-func opGlTexEnvi(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlTexEnvi(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.TexEnvi(uint32(inputs[0].Get_i32()), uint32(inputs[1].Get_i32()), inputs[2].Get_i32())
 }
 
-func opGlOrtho(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlOrtho(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.Ortho(inputs[0].Get_f64(), inputs[1].Get_f64(), inputs[2].Get_f64(), inputs[3].Get_f64(), inputs[4].Get_f64(), inputs[5].Get_f64())
 }
 
-func opGlScalef(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlScalef(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.Scalef(inputs[0].Get_f32(), inputs[1].Get_f32(), inputs[2].Get_f32())
 }
 
-func opGlTexCoord2d(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlTexCoord2d(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.TexCoord2d(inputs[0].Get_f64(), inputs[1].Get_f64())
 }
 
-func opGlTexCoord2f(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlTexCoord2f(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gl.TexCoord2f(inputs[0].Get_f32(), inputs[1].Get_f32())
 }

--- a/cx/packages/cxfx/event.go
+++ b/cx/packages/cxfx/event.go
@@ -53,9 +53,9 @@ type CXCallback struct {
 	functionName    string
 }
 
-func (cb *CXCallback) init(inputs []ast.CXValue, outputs []ast.CXValue, packageName string) {
+func (cb *CXCallback) init(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue, packageName string) {
 	cb.windowName = inputs[0].Get_str()
-	var windowHeapPtr = types.AllocWrite_obj_data(ast.PROGRAM.Memory, []byte(cb.windowName))
+	var windowHeapPtr = types.AllocWrite_obj_data(prgrm.Memory, []byte(cb.windowName))
 	var windowName [types.POINTER_SIZE]byte
 	types.Write_ptr(windowName[:], 0, windowHeapPtr)
 	cb.windowNameBytes = windowName[:]
@@ -63,12 +63,12 @@ func (cb *CXCallback) init(inputs []ast.CXValue, outputs []ast.CXValue, packageN
 	cb.packageName = packageName
 }
 
-func (cb *CXCallback) Init(inputs []ast.CXValue, outputs []ast.CXValue) {
-	cb.init(inputs, outputs, inputs[0].Expr.Package.Name)
+func (cb *CXCallback) Init(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	cb.init(prgrm, inputs, outputs, inputs[0].Expr.Package.Name)
 }
 
-func (cb *CXCallback) InitEx(inputs []ast.CXValue, outputs []ast.CXValue) {
-	cb.init(inputs, outputs, inputs[2].Get_str())
+func (cb *CXCallback) InitEx(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	cb.init(prgrm, inputs, outputs, inputs[2].Get_str())
 }
 
 func (cb *CXCallback) Call(inputs [][]byte) {

--- a/cx/packages/cxfx/op_glfw_desktop.go
+++ b/cx/packages/cxfx/op_glfw_desktop.go
@@ -10,7 +10,7 @@ import (
 
 var windows map[string]*glfw.Window = make(map[string]*glfw.Window, 0)
 
-func opGlfwFullscreen(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwFullscreen(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	window := windows[inputs[0].Get_str()]
 	fullscreen := inputs[1].Get_bool()
 	x := inputs[2].Get_i32()
@@ -31,41 +31,41 @@ func opGlfwFullscreen(inputs []ast.CXValue, outputs []ast.CXValue) {
 
 var initialized bool
 
-func opGlfwInit(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwInit(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	glfw.Init()
 	initialized = true
 }
 
-func opGlfwSwapBuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwSwapBuffers(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	windows[inputs[0].Get_str()].SwapBuffers()
 }
 
-func opGlfwMakeContextCurrent(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwMakeContextCurrent(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	windows[inputs[0].Get_str()].MakeContextCurrent()
 }
 
-func opGlfwWindowHint(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwWindowHint(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	glfw.WindowHint(glfw.Hint(inputs[0].Get_i32()), int(inputs[1].Get_i32()))
 }
 
-func opGlfwSetInputMode(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwSetInputMode(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	windows[inputs[0].Get_str()].SetInputMode(
 		glfw.InputMode(inputs[1].Get_i32()),
 		int(inputs[2].Get_i32()))
 }
 
-func opGlfwGetCursorPos(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwGetCursorPos(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	x, y := windows[inputs[0].Get_str()].GetCursorPos()
 	outputs[0].Set_f64(x)
 	outputs[1].Set_f64(y)
 }
 
-func opGlfwGetKey(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwGetKey(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	act := int32(windows[inputs[0].Get_str()].GetKey(glfw.Key(inputs[1].Get_i32())))
 	outputs[0].Set_i32(act)
 }
 
-func opGlfwCreateWindow(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwCreateWindow(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	if win, err := glfw.CreateWindow(
 		int(inputs[1].Get_i32()),
 		int(inputs[2].Get_i32()),
@@ -76,62 +76,62 @@ func opGlfwCreateWindow(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 }
 
-func opGlfwGetWindowContentScale(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwGetWindowContentScale(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	xscale, yscale := windows[inputs[0].Get_str()].GetContentScale()
 	outputs[0].Set_f32(xscale)
 	outputs[1].Set_f32(yscale)
 }
 
-func opGlfwGetMonitorContentScale(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwGetMonitorContentScale(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	xscale, yscale := glfw.GetPrimaryMonitor().GetContentScale()
 	outputs[0].Set_f32(xscale)
 	outputs[1].Set_f32(yscale)
 }
 
-func opGlfwSetWindowPos(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwSetWindowPos(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	windows[inputs[0].Get_str()].SetPos(
 		int(inputs[1].Get_i32()),
 		int(inputs[2].Get_i32()))
 }
 
-func opGlfwShouldClose(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwShouldClose(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(windows[inputs[0].Get_str()].ShouldClose())
 }
 
-func opGlfwGetFramebufferSize(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwGetFramebufferSize(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	width, height := windows[inputs[0].Get_str()].GetFramebufferSize()
 	outputs[0].Set_i32(int32(width))
 	outputs[1].Set_i32(int32(height))
 }
 
-func opGlfwGetWindowPos(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwGetWindowPos(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	x, y := windows[inputs[0].Get_str()].GetPos()
 	outputs[0].Set_i32(int32(x))
 	outputs[1].Set_i32(int32(y))
 }
 
-func opGlfwGetWindowSize(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwGetWindowSize(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	width, height := windows[inputs[0].Get_str()].GetSize()
 	outputs[0].Set_i32(int32(width))
 	outputs[1].Set_i32(int32(height))
 }
 
-func opGlfwSwapInterval(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwSwapInterval(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	glfw.SwapInterval(int(inputs[0].Get_i32()))
 }
 
-func opGlfwPollEvents(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwPollEvents(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	if initialized {
 		glfw.PollEvents()
 	}
 	PollEvents()
 }
 
-func opGlfwGetTime(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwGetTime(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_f64(glfw.GetTime())
 }
 
-func glfwSetKeyCallback(inputs []ast.CXValue, outputs []ast.CXValue) {
+func glfwSetKeyCallback(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	window := inputs[0].Get_str()
 	windows[window].SetKeyCallback(
 		func(w *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
@@ -139,7 +139,7 @@ func glfwSetKeyCallback(inputs []ast.CXValue, outputs []ast.CXValue) {
 		})
 }
 
-func glfwSetCursorPosCallback(inputs []ast.CXValue, outputs []ast.CXValue, eventType EventType) {
+func glfwSetCursorPosCallback(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue, eventType EventType) {
 	window := inputs[0].Get_str()
 	windows[window].SetCursorPosCallback(
 		func(w *glfw.Window, xpos float64, ypos float64) {
@@ -147,7 +147,7 @@ func glfwSetCursorPosCallback(inputs []ast.CXValue, outputs []ast.CXValue, event
 		})
 }
 
-func glfwSetMouseButtonCallback(inputs []ast.CXValue, outputs []ast.CXValue, eventType EventType) {
+func glfwSetMouseButtonCallback(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue, eventType EventType) {
 	window := inputs[0].Get_str()
 	windows[window].SetMouseButtonCallback(
 		func(w *glfw.Window, key glfw.MouseButton, action glfw.Action, mods glfw.ModifierKey) {
@@ -156,72 +156,72 @@ func glfwSetMouseButtonCallback(inputs []ast.CXValue, outputs []ast.CXValue, eve
 		})
 }
 
-func opGlfwSetKeyCallback(inputs []ast.CXValue, outputs []ast.CXValue) { // TODO : to deprecate
-	glfwSetKeyCallback(inputs, outputs)
-	appKeyboardCallback.Init(inputs, outputs)
+func opGlfwSetKeyCallback(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) { // TODO : to deprecate
+	glfwSetKeyCallback(prgrm, inputs, outputs)
+	appKeyboardCallback.Init(prgrm, inputs, outputs)
 }
 
-func opGlfwSetCursorPosCallback(inputs []ast.CXValue, outputs []ast.CXValue) { // TODO : to deprecate
-	glfwSetCursorPosCallback(inputs, outputs, APP_CURSOR_POS)
-	appCursorPositionCallback.Init(inputs, outputs)
+func opGlfwSetCursorPosCallback(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) { // TODO : to deprecate
+	glfwSetCursorPosCallback(prgrm, inputs, outputs, APP_CURSOR_POS)
+	appCursorPositionCallback.Init(prgrm, inputs, outputs)
 }
 
-func opGlfwSetMouseButtonCallback(inputs []ast.CXValue, outputs []ast.CXValue) { // TODO : to deprecate
-	glfwSetMouseButtonCallback(inputs, outputs, APP_MOUSE_BUTTON)
-	appMouseButtonCallback.Init(inputs, outputs)
+func opGlfwSetMouseButtonCallback(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) { // TODO : to deprecate
+	glfwSetMouseButtonCallback(prgrm, inputs, outputs, APP_MOUSE_BUTTON)
+	appMouseButtonCallback.Init(prgrm, inputs, outputs)
 }
 
-func opGlfwSetKeyboardCallback(inputs []ast.CXValue, outputs []ast.CXValue) {
-	glfwSetKeyCallback(inputs, outputs)
-	appKeyboardCallback.InitEx(inputs, outputs)
+func opGlfwSetKeyboardCallback(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	glfwSetKeyCallback(prgrm, inputs, outputs)
+	appKeyboardCallback.InitEx(prgrm, inputs, outputs)
 }
 
-func opGlfwSetMouseCallback(inputs []ast.CXValue, outputs []ast.CXValue) {
-	glfwSetCursorPosCallback(inputs, outputs, APP_MOUSE)
-	glfwSetMouseButtonCallback(inputs, outputs, APP_MOUSE)
-	appMouseCallback.InitEx(inputs, outputs)
+func opGlfwSetMouseCallback(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	glfwSetCursorPosCallback(prgrm, inputs, outputs, APP_MOUSE)
+	glfwSetMouseButtonCallback(prgrm, inputs, outputs, APP_MOUSE)
+	appMouseCallback.InitEx(prgrm, inputs, outputs)
 }
 
-func opGlfwSetFramebufferSizeCallback(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwSetFramebufferSizeCallback(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	window := inputs[0].Get_str()
 
 	windows[window].SetFramebufferSizeCallback(
 		func(w *glfw.Window, width int, height int) {
 			PushFramebufferSizeEvent(float64(width), float64(height)) // TODO : to deprecate, use float64
 		})
-	appFramebufferSizeCallback.InitEx(inputs, outputs)
+	appFramebufferSizeCallback.InitEx(prgrm, inputs, outputs)
 }
 
-func opGlfwSetWindowSizeCallback(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwSetWindowSizeCallback(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	window := inputs[0].Get_str()
 
 	windows[window].SetSizeCallback(
 		func(w *glfw.Window, width int, height int) {
 			PushWindowSizeEvent(float64(width), float64(height)) // TODO : to deprecate, use float64
 		})
-	appWindowSizeCallback.InitEx(inputs, outputs)
+	appWindowSizeCallback.InitEx(prgrm, inputs, outputs)
 }
 
-func opGlfwSetWindowPosCallback(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwSetWindowPosCallback(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	window := inputs[0].Get_str()
 
 	windows[window].SetPosCallback(
 		func(w *glfw.Window, x int, y int) {
 			PushWindowPositionEvent(float64(x), float64(y)) // TODO to deprecate, use float64
 		})
-	appWindowPosCallback.InitEx(inputs, outputs)
+	appWindowPosCallback.InitEx(prgrm, inputs, outputs)
 }
 
-func opGlfwSetStartCallback(inputs []ast.CXValue, outputs []ast.CXValue) {
-	appStartCallback.InitEx(inputs, outputs)
+func opGlfwSetStartCallback(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	appStartCallback.InitEx(prgrm, inputs, outputs)
 	PushEvent(APP_START)
 }
 
-func opGlfwSetStopCallback(inputs []ast.CXValue, outputs []ast.CXValue) {
-	appStopCallback.InitEx(inputs, outputs)
+func opGlfwSetStopCallback(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	appStopCallback.InitEx(prgrm, inputs, outputs)
 }
 
-func opGlfwSetShouldClose(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwSetShouldClose(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	shouldClose := inputs[1].Get_bool()
 	windows[inputs[0].Get_str()].SetShouldClose(shouldClose)
 }

--- a/cx/packages/cxfx/op_gltext.go
+++ b/cx/packages/cxfx/op_gltext.go
@@ -13,42 +13,42 @@ import (
 
 var fonts map[string]*gltext.Font = make(map[string]*gltext.Font, 0)
 
-func loadTrueType(inputs []ast.CXValue, outputs []ast.CXValue, fixedPipeline bool) {
+func loadTrueType(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue, fixedPipeline bool) {
 	if file := cxos.ValidFile(inputs[0].Get_i32()); file != nil {
 		if theFont, err := gltext.LoadTruetype(file,
-            inputs[2].Get_i32(), rune(inputs[3].Get_i32()), rune(inputs[4].Get_i32()),
-            gltext.Direction(inputs[5].Get_i32()), fixedPipeline); err == nil {
+			inputs[2].Get_i32(), rune(inputs[3].Get_i32()), rune(inputs[4].Get_i32()),
+			gltext.Direction(inputs[5].Get_i32()), fixedPipeline); err == nil {
 			fonts[inputs[1].Get_str()] = theFont
 		}
 	}
 }
 
-func opGltextLoadTrueType(inputs []ast.CXValue, outputs []ast.CXValue) {
-	loadTrueType(inputs, outputs, true)
+func opGltextLoadTrueType(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	loadTrueType(prgrm, inputs, outputs, true)
 }
 
-func opGltextLoadTrueTypeCore(inputs []ast.CXValue, outputs []ast.CXValue) {
-	loadTrueType(inputs, outputs, false)
+func opGltextLoadTrueTypeCore(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	loadTrueType(prgrm, inputs, outputs, false)
 }
 
-func opGltextPrintf(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGltextPrintf(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	if err := fonts[inputs[0].Get_str()].Printf(inputs[1].Get_f32(), inputs[2].Get_f32(), inputs[3].Get_str()); err != nil {
 		panic(err)
 	}
 }
 
-func opGltextMetrics(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGltextMetrics(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	width, height := fonts[inputs[0].Get_str()].Metrics(inputs[1].Get_str())
 
 	outputs[0].Set_i32(int32(width))
 	outputs[1].Set_i32(int32(height))
 }
 
-func opGltextTexture(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGltextTexture(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_i32(int32(fonts[inputs[0].Get_str()].Texture()))
 }
 
-func opGltextNextGlyph(inputs []ast.CXValue, outputs []ast.CXValue) { // refactor
+func opGltextNextGlyph(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) { // refactor
 	font := fonts[inputs[0].Get_str()]
 	str := inputs[1].Get_str()
 	var index int = int(inputs[2].Get_i32())
@@ -69,7 +69,7 @@ func opGltextNextGlyph(inputs []ast.CXValue, outputs []ast.CXValue) { // refacto
 		advance = g.Advance
 	}
 
-	outputs[0].Set_i32(int32(runeValue-font.Low()))
+	outputs[0].Set_i32(int32(runeValue - font.Low()))
 	outputs[1].Set_i32(int32(width))
 	outputs[2].Set_i32(int32(x))
 	outputs[3].Set_i32(int32(y))
@@ -78,21 +78,21 @@ func opGltextNextGlyph(inputs []ast.CXValue, outputs []ast.CXValue) { // refacto
 	outputs[6].Set_i32(int32(advance))
 }
 
-func opGltextGlyphBounds(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGltextGlyphBounds(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	font := fonts[inputs[0].Get_str()]
 	var maxGlyphWidth, maxGlyphHeight int = font.GlyphBounds()
 	outputs[0].Set_i32(int32(maxGlyphWidth))
 	outputs[1].Set_i32(int32(maxGlyphHeight))
 }
 
-func opGltextGlyphMetrics(inputs []ast.CXValue, outputs []ast.CXValue) { // refactor
+func opGltextGlyphMetrics(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) { // refactor
 	width, height := fonts[inputs[0].Get_str()].GlyphMetrics(uint32(inputs[1].Get_i32()))
 
 	outputs[0].Set_i32(int32(width))
 	outputs[1].Set_i32(int32(height))
 }
 
-func opGltextGlyphInfo(inputs []ast.CXValue, outputs []ast.CXValue) { // refactor
+func opGltextGlyphInfo(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) { // refactor
 	font := fonts[inputs[0].Get_str()]
 	glyph := inputs[1].Get_i32()
 	var x int = 0

--- a/cx/packages/cxfx/op_openal.go
+++ b/cx/packages/cxfx/op_openal.go
@@ -9,11 +9,10 @@ import (
 	"github.com/skycoin/cx/cx/types"
 	"github.com/skycoin/cx/cx/util"
 	"github.com/skycoin/skycoin/src/cipher/encoder"
-
 	//"golang.org/x/mobile/exp/audio/al"
 )
 
-func opAlLoadWav(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlLoadWav(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	file, err := util.CXOpenFile(inputs[0].Get_str())
 	defer file.Close()
 	if err != nil {
@@ -43,7 +42,7 @@ func opAlLoadWav(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[7].Set_i64(int64(wav.Duration))
 
 	outputSlicePointer := outputs[8].Offset
-	outputSliceOffset := types.Read_ptr(ast.PROGRAM.Memory, outputSlicePointer)
+	outputSliceOffset := types.Read_ptr(prgrm.Memory, outputSlicePointer)
 	outputSliceOffset = ast.SliceResizeEx(outputSliceOffset, types.Cast_int_to_ptr(len(data)), 1)
 	copy(ast.GetSliceData(outputSliceOffset, 1), data)
 	outputs[8].Set_ptr(outputSliceOffset)
@@ -55,4 +54,3 @@ func toBytes(in interface{}) []byte { // REFACTOR : ??
 	}
 	return nil
 }
-

--- a/cx/packages/cxfx/op_openal_desktop.go
+++ b/cx/packages/cxfx/op_openal_desktop.go
@@ -26,80 +26,80 @@ func toSources(in interface{}) []al.Source { // REFACTOR : ??
 	return out
 }
 
-func opAlCloseDevice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlCloseDevice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	al.CloseDevice()
 }
 
-func opAlDeleteBuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlDeleteBuffers(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	buffers := toBuffers(inputs[0].GetSlice_i32())
 	al.DeleteBuffers(buffers...)
 }
 
-func opAlDeleteSources(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlDeleteSources(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	sources := toSources(inputs[0].GetSlice_i32())
 	al.DeleteSources(sources...)
 }
 
-func opAlDeviceError(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlDeviceError(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	err := al.DeviceError()
 	outputs[0].Set_i32(err)
 }
 
-func opAlError(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlError(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	err := al.Error()
 	outputs[0].Set_i32(err)
 }
 
-func opAlExtensions(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlExtensions(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	extensions := al.Extensions()
 	outputs[0].Set_str(extensions)
 }
 
-func opAlOpenDevice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlOpenDevice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	if err := al.OpenDevice(); err != nil {
 		panic(err)
 	}
 }
 
-func opAlPauseSources(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlPauseSources(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	sources := toSources(inputs[0].GetSlice_i32())
 	al.PauseSources(sources...)
 }
 
-func opAlPlaySources(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlPlaySources(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	sources := toSources(inputs[0].GetSlice_i32())
 	al.PlaySources(sources...)
 }
 
-func opAlRenderer(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlRenderer(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	renderer := al.Renderer()
 	outputs[0].Set_str(renderer)
 }
 
-func opAlRewindSources(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlRewindSources(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	sources := toSources(inputs[0].GetSlice_i32())
 	al.RewindSources(sources...)
 }
 
-func opAlStopSources(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlStopSources(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	sources := toSources(inputs[0].GetSlice_i32())
 	al.StopSources(sources...)
 }
 
-func opAlVendor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlVendor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	vendor := al.Vendor()
 	outputs[0].Set_str(vendor)
 }
 
-func opAlVersion(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlVersion(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	version := al.Version()
 	outputs[0].Set_str(version)
 }
 
-func opAlGenBuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlGenBuffers(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	buffers := al.GenBuffers(int(inputs[0].Get_i32()))
 	outputSlicePointer := outputs[0].Offset
-	outputSliceOffset := types.Read_ptr(ast.PROGRAM.Memory, outputSlicePointer)
+	outputSliceOffset := types.Read_ptr(prgrm.Memory, outputSlicePointer)
 	for _, b := range buffers { // REFACTOR append with copy ?
 		var obj [4]byte
 		types.Write_i32(obj[:], 0, int32(b))
@@ -108,7 +108,7 @@ func opAlGenBuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_ptr(outputSliceOffset)
 }
 
-func opAlBufferData(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlBufferData(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	buffer := al.Buffer(inputs[0].Get_i32())
 	format := inputs[1].Get_i32()
 	data := toBytes(inputs[2].GetSlice_ui8())
@@ -116,10 +116,10 @@ func opAlBufferData(inputs []ast.CXValue, outputs []ast.CXValue) {
 	buffer.BufferData(uint32(format), data, frequency)
 }
 
-func opAlGenSources(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlGenSources(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	sources := al.GenSources(int(inputs[0].Get_i32()))
 	outputSlicePointer := outputs[0].Offset
-	outputSliceOffset := types.Read_ptr(ast.PROGRAM.Memory, outputSlicePointer)
+	outputSliceOffset := types.Read_ptr(prgrm.Memory, outputSlicePointer)
 	for _, s := range sources { // REFACTOR append with copy ?
 		var obj [4]byte
 		types.Write_i32(obj[:], 0, int32(s))
@@ -128,28 +128,28 @@ func opAlGenSources(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_ptr(outputSliceOffset)
 }
 
-func opAlSourceBuffersProcessed(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlSourceBuffersProcessed(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	source := al.Source(inputs[0].Get_i32())
 	outputs[0].Set_i32(source.BuffersProcessed())
 }
 
-func opAlSourceBuffersQueued(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlSourceBuffersQueued(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	source := al.Source(inputs[0].Get_i32())
 	outputs[0].Set_i32(source.BuffersQueued())
 }
 
-func opAlSourceQueueBuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlSourceQueueBuffers(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	source := al.Source(inputs[0].Get_i32())
 	buffers := toBuffers(inputs[1].GetSlice_i32())
 	source.QueueBuffers(buffers...)
 }
 
-func opAlSourceState(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlSourceState(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	source := al.Source(inputs[0].Get_i32())
 	outputs[0].Set_i32(source.State())
 }
 
-func opAlSourceUnqueueBuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opAlSourceUnqueueBuffers(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	source := al.Source(inputs[0].Get_i32())
 	buffers := toBuffers(inputs[1].GetSlice_i32())
 	source.UnqueueBuffers(buffers...)

--- a/cx/packages/cxfx/op_opengl.go
+++ b/cx/packages/cxfx/op_opengl.go
@@ -6,8 +6,8 @@ import (
 	"bufio"
 	"fmt"
 	"github.com/skycoin/cx/cx/ast"
-	"github.com/skycoin/cx/cx/util"
 	"github.com/skycoin/cx/cx/types"
+	"github.com/skycoin/cx/cx/util"
 	"image"
 	"image/draw"
 	"image/gif"
@@ -32,35 +32,35 @@ type Texture struct {
 }
 
 func Slice_ui8_ToPtr(value []uint8) unsafe.Pointer {
-    count := len(value)
-    if count == 0 {
-        return unsafe.Pointer(nil)
-    }
-    return unsafe.Pointer(&value[0])
+	count := len(value)
+	if count == 0 {
+		return unsafe.Pointer(nil)
+	}
+	return unsafe.Pointer(&value[0])
 }
 
 func Slice_ui32_ToPtr(value []uint32) unsafe.Pointer {
-    count := len(value)
-    if count == 0 {
-        return unsafe.Pointer(nil)
-    }
-    return unsafe.Pointer(&value[0])
+	count := len(value)
+	if count == 0 {
+		return unsafe.Pointer(nil)
+	}
+	return unsafe.Pointer(&value[0])
 }
 
 func Slice_i32_ToPtr(value []int32) unsafe.Pointer {
-    count := len(value)
-    if count == 0 {
-        return unsafe.Pointer(nil)
-    }
-    return unsafe.Pointer(&value[0])
+	count := len(value)
+	if count == 0 {
+		return unsafe.Pointer(nil)
+	}
+	return unsafe.Pointer(&value[0])
 }
 
 func Slice_f32_ToPtr(value []float32) unsafe.Pointer {
-    count := len(value)
-    if count == 0 {
-        return unsafe.Pointer(nil)
-    }
-    return unsafe.Pointer(&value[0])
+	count := len(value)
+	if count == 0 {
+		return unsafe.Pointer(nil)
+	}
+	return unsafe.Pointer(&value[0])
 }
 
 var gifs map[string]*gif.GIF = make(map[string]*gif.GIF, 0)
@@ -310,7 +310,7 @@ func uploadTexture(path string, target uint32, level uint32, cpuCopy bool) {
 }
 
 // gogl
-func opGlNewTexture(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlNewTexture(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var texture uint32
 	cxglEnable(cxglTEXTURE_2D)
 	cxglGenTextures(1, &texture)
@@ -325,7 +325,7 @@ func opGlNewTexture(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_i32(int32(texture))
 }
 
-func opGlNewTextureCube(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlNewTextureCube(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var texture uint32
 	cxglEnable(cxglTEXTURE_CUBE_MAP)
 	cxglGenTextures(1, &texture)
@@ -345,11 +345,11 @@ func opGlNewTextureCube(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_i32(int32(texture))
 }
 
-func opCxReleaseTexture(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opCxReleaseTexture(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	textures[inputs[0].Get_str()] = Texture{}
 }
 
-func opCxTextureGetPixel(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opCxTextureGetPixel(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var r float32
 	var g float32
 	var b float32
@@ -373,11 +373,11 @@ func opCxTextureGetPixel(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[3].Set_f32(a)
 }
 
-func opGlUploadImageToTexture(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUploadImageToTexture(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	uploadTexture(inputs[0].Get_str(), uint32(inputs[1].Get_i32()), uint32(inputs[2].Get_i32()), inputs[3].Get_bool())
 }
 
-func opGlNewGIF(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlNewGIF(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	path := inputs[0].Get_str()
 
 	file, err := util.CXOpenFile(path)
@@ -400,11 +400,11 @@ func opGlNewGIF(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[3].Set_i32(int32(gif.Config.Height))
 }
 
-func opGlFreeGIF(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlFreeGIF(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	gifs[inputs[0].Get_str()] = nil
 }
 
-func opGlGIFFrameToTexture(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGIFFrameToTexture(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	path := inputs[0].Get_str()
 	frame := inputs[1].Get_i32()
 	texture := inputs[2].Get_i32()
@@ -433,11 +433,11 @@ func opGlGIFFrameToTexture(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_i32(disposal)
 }
 
-func opGlAppend(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlAppend(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputSlicePointer := outputs[0].Offset
-	outputSliceOffset := types.Read_ptr(ast.PROGRAM.Memory, outputSlicePointer)
+	outputSliceOffset := types.Read_ptr(prgrm.Memory, outputSlicePointer)
 
-    inputSliceOffset := ast.GetSliceOffset(inputs[0].FramePointer, inputs[0].Arg)
+	inputSliceOffset := ast.GetSliceOffset(inputs[0].FramePointer, inputs[0].Arg)
 	var inputSliceLen types.Pointer
 	if inputSliceOffset != 0 {
 		inputSliceLen = ast.GetSliceLen(inputSliceOffset)
@@ -453,21 +453,21 @@ func opGlAppend(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // gl_1_0
-func opGlCullFace(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlCullFace(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglCullFace(uint32(inputs[0].Get_i32()))
 }
 
-func opGlFrontFace(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlFrontFace(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglFrontFace(uint32(inputs[0].Get_i32()))
 }
 
-func opGlHint(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlHint(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglHint(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()))
 }
 
-func opGlScissor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlScissor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglScissor(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
@@ -475,14 +475,14 @@ func opGlScissor(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[3].Get_i32())
 }
 
-func opGlTexParameteri(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlTexParameteri(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglTexParameteri(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()),
 		inputs[2].Get_i32())
 }
 
-func opGlTexImage2D(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlTexImage2D(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglTexImage2D(
 		uint32(inputs[0].Get_i32()),
 		inputs[1].Get_i32(),
@@ -492,14 +492,14 @@ func opGlTexImage2D(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[5].Get_i32(),
 		uint32(inputs[6].Get_i32()),
 		uint32(inputs[7].Get_i32()),
-        inputs[8].GetSlice_bytes())
+		inputs[8].GetSlice_bytes())
 }
 
-func opGlClear(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlClear(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglClear(uint32(inputs[0].Get_i32()))
 }
 
-func opGlClearColor(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlClearColor(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglClearColor(
 		inputs[0].Get_f32(),
 		inputs[1].Get_f32(),
@@ -507,19 +507,19 @@ func opGlClearColor(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[3].Get_f32())
 }
 
-func opGlClearStencil(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlClearStencil(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglClearStencil(inputs[0].Get_i32())
 }
 
-func opGlClearDepth(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlClearDepth(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglClearDepth(inputs[0].Get_f64())
 }
 
-func opGlStencilMask(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlStencilMask(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglStencilMask(uint32(inputs[0].Get_i32()))
 }
 
-func opGlColorMask(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlColorMask(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglColorMask(
 		inputs[0].Get_bool(),
 		inputs[1].Get_bool(),
@@ -527,47 +527,47 @@ func opGlColorMask(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[3].Get_bool())
 }
 
-func opGlDepthMask(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDepthMask(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglDepthMask(inputs[0].Get_bool())
 }
 
-func opGlDisable(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDisable(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglDisable(uint32(inputs[0].Get_i32()))
 }
 
-func opGlEnable(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlEnable(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglEnable(uint32(inputs[0].Get_i32()))
 }
 
-func opGlBlendFunc(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlBlendFunc(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglBlendFunc(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()))
 }
 
-func opGlStencilFunc(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlStencilFunc(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglStencilFunc(
 		uint32(inputs[0].Get_i32()),
 		inputs[1].Get_i32(),
 		uint32(inputs[2].Get_i32()))
 }
 
-func opGlStencilOp(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlStencilOp(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglStencilOp(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()),
 		uint32(inputs[2].Get_i32()))
 }
 
-func opGlDepthFunc(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDepthFunc(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglDepthFunc(uint32(inputs[0].Get_i32()))
 }
 
-func opGlGetError(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGetError(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_i32(int32(cxglGetError()))
 }
 
-func opGlGetTexLevelParameteriv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGetTexLevelParameteriv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var outValue int32 = 0
 	cxglGetTexLevelParameteriv(
 		uint32(inputs[0].Get_i32()),
@@ -577,13 +577,13 @@ func opGlGetTexLevelParameteriv(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_i32(outValue)
 }
 
-func opGlDepthRange(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDepthRange(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglDepthRange(
 		inputs[0].Get_f64(),
 		inputs[1].Get_f64())
 }
 
-func opGlViewport(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlViewport(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglViewport(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
@@ -592,14 +592,14 @@ func opGlViewport(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // gl_1_1
-func opGlDrawArrays(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDrawArrays(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglDrawArrays(
 		uint32(inputs[0].Get_i32()),
 		inputs[1].Get_i32(),
 		inputs[2].Get_i32())
 }
 
-func opGlDrawElements(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDrawElements(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglDrawElements(
 		uint32(inputs[0].Get_i32()),
 		inputs[1].Get_i32(),
@@ -607,30 +607,30 @@ func opGlDrawElements(inputs []ast.CXValue, outputs []ast.CXValue) {
 		nil)
 }
 
-func opGlBindTexture(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlBindTexture(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglBindTexture(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()))
 }
 
-func opGlDeleteTextures(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDeleteTextures(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV1 := uint32(inputs[1].Get_i32())
 	cxglDeleteTextures(inputs[0].Get_i32(), &inpV1) // will panic if inp0 > 1
 }
 
-func opGlGenTextures(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGenTextures(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV1 := uint32(inputs[1].Get_i32())
 	cxglGenTextures(inputs[0].Get_i32(), &inpV1) // will panic if inp0 > 1
 	outputs[0].Set_i32(int32(inpV1))
 }
 
 // gl_1_3
-func opGlActiveTexture(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlActiveTexture(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglActiveTexture(uint32(inputs[0].Get_i32()))
 }
 
 // gl_1_4
-func opGlBlendFuncSeparate(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlBlendFuncSeparate(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglBlendFuncSeparate(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()),
@@ -639,20 +639,20 @@ func opGlBlendFuncSeparate(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // gl_1_5
-func opGlBindBuffer(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlBindBuffer(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglBindBuffer(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()))
 }
 
-func opGlDeleteBuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDeleteBuffers(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV1 := uint32(inputs[1].Get_i32())
 	cxglDeleteBuffers(
 		inputs[0].Get_i32(),
 		&inpV1) // will panic if inp0 > 1
 }
 
-func opGlGenBuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGenBuffers(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV1 := uint32(inputs[1].Get_i32())
 	cxglGenBuffers(
 		inputs[0].Get_i32(),
@@ -660,7 +660,7 @@ func opGlGenBuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_i32(int32(inpV1))
 }
 
-func opGlBufferData(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlBufferData(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglBufferData(
 		uint32(inputs[0].Get_i32()),
 		int(inputs[1].Get_i32()),
@@ -668,7 +668,7 @@ func opGlBufferData(inputs []ast.CXValue, outputs []ast.CXValue) {
 		uint32(inputs[3].Get_i32()))
 }
 
-func opGlBufferSubData(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlBufferSubData(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglBufferSubData(
 		uint32(inputs[0].Get_i32()),
 		int(inputs[1].Get_i32()),
@@ -676,13 +676,13 @@ func opGlBufferSubData(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[3].GetSlice_bytes())
 }
 
-func opGlDrawBuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDrawBuffers(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglDrawBuffers(
 		inputs[0].Get_i32(),
 		inputs[1].GetSlice_bytes())
 }
 
-func opGlStencilOpSeparate(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlStencilOpSeparate(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglStencilOpSeparate(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()),
@@ -690,7 +690,7 @@ func opGlStencilOpSeparate(inputs []ast.CXValue, outputs []ast.CXValue) {
 		uint32(inputs[3].Get_i32()))
 }
 
-func opGlStencilFuncSeparate(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlStencilFuncSeparate(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglStencilFuncSeparate(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()),
@@ -698,129 +698,129 @@ func opGlStencilFuncSeparate(inputs []ast.CXValue, outputs []ast.CXValue) {
 		uint32(inputs[3].Get_i32()))
 }
 
-func opGlStencilMaskSeparate(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlStencilMaskSeparate(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglStencilMaskSeparate(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()))
 }
 
-func opGlAttachShader(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlAttachShader(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglAttachShader(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()))
 }
 
-func opGlBindAttribLocation(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlBindAttribLocation(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglBindAttribLocation(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()),
 		inputs[2].Get_str())
 }
 
-func opGlCompileShader(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlCompileShader(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	shader := uint32(inputs[0].Get_i32())
 	cxglCompileShader(shader)
 }
 
-func opGlCreateProgram(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlCreateProgram(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_i32(int32(cxglCreateProgram()))
 }
 
-func opGlCreateShader(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlCreateShader(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int32(cxglCreateShader(uint32(inputs[0].Get_i32())))
 	outputs[0].Set_i32(outV0)
 }
 
-func opGlDeleteProgram(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDeleteProgram(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglDeleteShader(uint32(inputs[0].Get_i32()))
 }
 
-func opGlDeleteShader(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDeleteShader(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglDeleteShader(uint32(inputs[0].Get_i32()))
 }
 
-func opGlDetachShader(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDetachShader(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglDetachShader(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()))
 }
 
-func opGlEnableVertexAttribArray(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlEnableVertexAttribArray(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglEnableVertexAttribArray(uint32(inputs[0].Get_i32()))
 }
 
-func opGlGetAttribLocation(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGetAttribLocation(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := cxglGetAttribLocation(
 		uint32(inputs[0].Get_i32()),
 		inputs[1].Get_str())
 	outputs[0].Set_i32(outV0)
 }
 
-func opGlGetProgramiv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGetProgramiv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := cxglGetProgramiv(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()))
 	outputs[0].Set_i32(outV0)
 }
 
-func opGlGetProgramInfoLog(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGetProgramInfoLog(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := cxglGetProgramInfoLog(
 		uint32(inputs[0].Get_i32()),
 		inputs[1].Get_i32())
 	outputs[0].Set_str(outV0)
 }
 
-func opGlGetShaderiv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGetShaderiv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := cxglGetShaderiv(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()))
 	outputs[0].Set_i32(outV0)
 }
 
-func opGlGetShaderInfoLog(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGetShaderInfoLog(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := cxglGetShaderInfoLog(
 		uint32(inputs[0].Get_i32()),
 		inputs[1].Get_i32())
 	outputs[0].Set_str(outV0)
 }
 
-func opGlGetUniformLocation(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGetUniformLocation(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := cxglGetUniformLocation(
 		uint32(inputs[0].Get_i32()),
 		inputs[1].Get_str())
 	outputs[0].Set_i32(outV0)
 }
 
-func opGlLinkProgram(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlLinkProgram(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	program := uint32(inputs[0].Get_i32())
 	cxglLinkProgram(program)
 }
 
-func opGlShaderSource(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlShaderSource(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglShaderSource(
 		uint32(inputs[0].Get_i32()),
 		inputs[1].Get_i32(),
 		inputs[2].Get_str())
 }
 
-func opGlUseProgram(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUseProgram(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUseProgram(uint32(inputs[0].Get_i32()))
 }
 
-func opGlUniform1f(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform1f(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform1f(
 		inputs[0].Get_i32(),
 		inputs[1].Get_f32())
 }
 
-func opGlUniform2f(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform2f(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform2f(
 		inputs[0].Get_i32(),
 		inputs[1].Get_f32(),
 		inputs[2].Get_f32())
 }
 
-func opGlUniform3f(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform3f(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform3f(
 		inputs[0].Get_i32(),
 		inputs[1].Get_f32(),
@@ -828,7 +828,7 @@ func opGlUniform3f(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[3].Get_f32())
 }
 
-func opGlUniform4f(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform4f(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform4f(
 		inputs[0].Get_i32(),
 		inputs[1].Get_f32(),
@@ -837,20 +837,20 @@ func opGlUniform4f(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[4].Get_f32())
 }
 
-func opGlUniform1i(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform1i(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform1i(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32())
 }
 
-func opGlUniform2i(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform2i(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform2i(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
 		inputs[2].Get_i32())
 }
 
-func opGlUniform3i(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform3i(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform3i(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
@@ -858,7 +858,7 @@ func opGlUniform3i(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[3].Get_i32())
 }
 
-func opGlUniform4i(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform4i(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform4i(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
@@ -867,63 +867,63 @@ func opGlUniform4i(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[4].Get_i32())
 }
 
-func opGlUniform1fv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform1fv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform1fv(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
 		inputs[2].GetSlice_bytes())
 }
 
-func opGlUniform2fv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform2fv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform2fv(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
 		inputs[2].GetSlice_bytes())
 }
 
-func opGlUniform3fv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform3fv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform3fv(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
 		inputs[2].GetSlice_bytes())
 }
 
-func opGlUniform4fv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform4fv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform4fv(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
 		inputs[2].GetSlice_bytes())
 }
 
-func opGlUniform1iv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform1iv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform1iv(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
 		inputs[2].GetSlice_bytes())
 }
 
-func opGlUniform2iv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform2iv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform2iv(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
 		inputs[2].GetSlice_bytes())
 }
 
-func opGlUniform3iv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform3iv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform3iv(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
 		inputs[2].GetSlice_bytes())
 }
 
-func opGlUniform4iv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniform4iv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform4iv(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
 		inputs[2].GetSlice_bytes())
 }
 
-func opGlUniformMatrix2fv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniformMatrix2fv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniformMatrix2fv(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
@@ -931,7 +931,7 @@ func opGlUniformMatrix2fv(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[3].GetSlice_bytes())
 }
 
-func opGlUniformMatrix3fv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniformMatrix3fv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniformMatrix3fv(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
@@ -939,7 +939,7 @@ func opGlUniformMatrix3fv(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[3].GetSlice_bytes())
 }
 
-func opGlUniformMatrix4fv(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniformMatrix4fv(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniformMatrix4fv(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
@@ -947,14 +947,14 @@ func opGlUniformMatrix4fv(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[3].GetSlice_bytes())
 }
 
-func opGlUniformV4F(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniformV4F(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniform4fv(
 		inputs[0].Get_i32(),
 		1,
 		inputs[1].Get_bytes())
 }
 
-func opGlUniformM44F(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniformM44F(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniformMatrix4fv(
 		inputs[0].Get_i32(),
 		1,
@@ -962,7 +962,7 @@ func opGlUniformM44F(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[2].Get_bytes())
 }
 
-func opGlUniformM44FV(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlUniformM44FV(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglUniformMatrix4fv(
 		inputs[0].Get_i32(),
 		inputs[1].Get_i32(),
@@ -970,7 +970,7 @@ func opGlUniformM44FV(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[3].GetSlice_bytes())
 }
 
-func opGlVertexAttribPointer(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlVertexAttribPointer(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglVertexAttribPointer(
 		uint32(inputs[0].Get_i32()),
 		inputs[1].Get_i32(),
@@ -979,7 +979,7 @@ func opGlVertexAttribPointer(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[4].Get_i32(), 0)
 }
 
-func opGlVertexAttribPointerI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlVertexAttribPointerI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglVertexAttribPointer(
 		uint32(inputs[0].Get_i32()),
 		inputs[1].Get_i32(),
@@ -989,7 +989,7 @@ func opGlVertexAttribPointerI32(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[5].Get_i32())
 }
 
-func opGlClearBufferI(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlClearBufferI(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	color := [4]int32{
 		inputs[2].Get_i32(),
 		inputs[3].Get_i32(),
@@ -1002,7 +1002,7 @@ func opGlClearBufferI(inputs []ast.CXValue, outputs []ast.CXValue) {
 		color[:])
 }
 
-func opGlClearBufferUI(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlClearBufferUI(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	color := [4]uint32{
 		inputs[2].Get_ui32(),
 		inputs[3].Get_ui32(),
@@ -1015,7 +1015,7 @@ func opGlClearBufferUI(inputs []ast.CXValue, outputs []ast.CXValue) {
 		color[:])
 }
 
-func opGlClearBufferF(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlClearBufferF(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	color := [4]float32{
 		inputs[2].Get_f32(),
 		inputs[3].Get_f32(),
@@ -1028,24 +1028,24 @@ func opGlClearBufferF(inputs []ast.CXValue, outputs []ast.CXValue) {
 		color[:])
 }
 
-func opGlBindRenderbuffer(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlBindRenderbuffer(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglBindRenderbuffer(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()))
 }
 
-func opGlDeleteRenderbuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDeleteRenderbuffers(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV1 := uint32(inputs[1].Get_i32())
 	cxglDeleteRenderbuffers(inputs[0].Get_i32(), &inpV1) // will panic if inp0 > 1
 }
 
-func opGlGenRenderbuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGenRenderbuffers(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV1 := uint32(inputs[1].Get_i32())
 	cxglGenRenderbuffers(inputs[0].Get_i32(), &inpV1) // will panic if inp0 > 1
 	outputs[0].Set_i32(int32(inpV1))
 }
 
-func opGlRenderbufferStorage(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlRenderbufferStorage(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglRenderbufferStorage(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()),
@@ -1053,29 +1053,29 @@ func opGlRenderbufferStorage(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[3].Get_i32())
 }
 
-func opGlBindFramebuffer(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlBindFramebuffer(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglBindFramebuffer(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()))
 }
 
-func opGlDeleteFramebuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDeleteFramebuffers(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV1 := uint32(inputs[1].Get_i32())
 	cxglDeleteFramebuffers(inputs[0].Get_i32(), &inpV1) // will panic if inp0 > 1
 }
 
-func opGlGenFramebuffers(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGenFramebuffers(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV1 := uint32(inputs[1].Get_i32())
 	cxglGenFramebuffers(inputs[0].Get_i32(), &inpV1) // will panic if inp0 > 1
 	outputs[0].Set_i32(int32(inpV1))
 }
 
-func opGlCheckFramebufferStatus(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlCheckFramebufferStatus(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outV0 := int32(cxglCheckFramebufferStatus(uint32(inputs[0].Get_i32())))
 	outputs[0].Set_i32(outV0)
 }
 
-func opGlFramebufferTexture2D(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlFramebufferTexture2D(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglFramebufferTexture2D(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()),
@@ -1084,7 +1084,7 @@ func opGlFramebufferTexture2D(inputs []ast.CXValue, outputs []ast.CXValue) {
 		inputs[4].Get_i32())
 }
 
-func opGlFramebufferRenderbuffer(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlFramebufferRenderbuffer(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglFramebufferRenderbuffer(
 		uint32(inputs[0].Get_i32()),
 		uint32(inputs[1].Get_i32()),
@@ -1092,11 +1092,11 @@ func opGlFramebufferRenderbuffer(inputs []ast.CXValue, outputs []ast.CXValue) {
 		uint32(inputs[3].Get_i32()))
 }
 
-func opGlGenerateMipmap(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGenerateMipmap(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglGenerateMipmap(uint32(inputs[0].Get_i32()))
 }
 
-func opGlBindVertexArray(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlBindVertexArray(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := uint32(inputs[0].Get_i32())
 	if runtime.GOOS == "darwin" {
 		cxglBindVertexArrayAPPLE(inpV0)
@@ -1105,11 +1105,11 @@ func opGlBindVertexArray(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 }
 
-func opGlBindVertexArrayCore(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlBindVertexArrayCore(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	cxglBindVertexArray(uint32(inputs[0].Get_i32()))
 }
 
-func opGlDeleteVertexArrays(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDeleteVertexArrays(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_i32()
 	inpV1 := uint32(inputs[1].Get_i32())
 	if runtime.GOOS == "darwin" {
@@ -1119,12 +1119,12 @@ func opGlDeleteVertexArrays(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 }
 
-func opGlDeleteVertexArraysCore(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlDeleteVertexArraysCore(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV1 := uint32(inputs[1].Get_i32())
 	cxglDeleteVertexArrays(inputs[0].Get_i32(), &inpV1) // will panic if inp0 > 1
 }
 
-func opGlGenVertexArrays(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGenVertexArrays(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV0 := inputs[0].Get_i32()
 	inpV1 := uint32(inputs[1].Get_i32())
 	if runtime.GOOS == "darwin" {
@@ -1135,7 +1135,7 @@ func opGlGenVertexArrays(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_i32(int32(inpV1))
 }
 
-func opGlGenVertexArraysCore(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlGenVertexArraysCore(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inpV1 := uint32(inputs[1].Get_i32())
 	cxglGenVertexArrays(inputs[0].Get_i32(), &inpV1) // will panic if inp0 > 1
 	outputs[0].Set_i32(int32(inpV1))

--- a/cx/packages/cxfx/utils.go
+++ b/cx/packages/cxfx/utils.go
@@ -13,23 +13,23 @@ var Functions_i32_i32 []Func_i32_i32
 var freeFns map[string]*func() = make(map[string]*func(), 0)
 var cSources map[string]**uint8 = make(map[string]**uint8, 0)
 
-func opGlfwFuncI32I32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwFuncI32I32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	packageName := inputs[0].Get_str()
 	functionName := inputs[1].Get_str()
 	callback := func(a int32, b int32) {
 		var inps [][]byte = make([][]byte, 2)
 		inps[0] = fromI32(a)
 		inps[1] = fromI32(b)
-		if fn, err := ast.PROGRAM.GetFunction(functionName, packageName); err == nil {
-			execute.Callback(ast.PROGRAM, fn, inps)
+		if fn, err := prgrm.GetFunction(functionName, packageName); err == nil {
+			execute.Callback(prgrm, fn, inps)
 		}
 	}
 
 	Functions_i32_i32 = append(Functions_i32_i32, callback)
-	outputs[0].Set_i32(int32(len(Functions_i32_i32)-1))
+	outputs[0].Set_i32(int32(len(Functions_i32_i32) - 1))
 }
 
-func opGlfwCallI32I32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opGlfwCallI32I32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	index := inputs[0].Get_i32()
 	count := int32(len(Functions_i32_i32))
 	if index >= 0 && index < count {

--- a/cx/packages/cxos/op_json.go
+++ b/cx/packages/cxos/op_json.go
@@ -5,10 +5,11 @@ package cxos
 import (
 	"bufio"
 	"encoding/json"
-	"github.com/skycoin/cx/cx/ast"
-	"github.com/skycoin/cx/cx/util"
 	"io"
 	"os"
+
+	"github.com/skycoin/cx/cx/ast"
+	"github.com/skycoin/cx/cx/util"
 )
 
 const (
@@ -42,7 +43,7 @@ var jsons []JSONFile
 var freeJsons []int32
 
 // Open the named json file for reading, returns an i32 identifying the json cxgo.
-func opJsonOpen(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opJsonOpen(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	handle := int32(-1)
 
 	file, err := util.CXOpenFile(inputs[0].Get_str())
@@ -74,9 +75,9 @@ func opJsonOpen(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // Close json cxgo (and all underlying resources) idendified by it's i32 handle.
-func opJsonClose(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opJsonClose(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
-    handle := inputs[0].Get_i32()
+	handle := inputs[0].Get_i32()
 	if jsonFile := validJsonFile(handle); jsonFile != nil {
 		if err := jsonFile.file.Close(); err != nil {
 			panic(err)
@@ -91,7 +92,7 @@ func opJsonClose(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // More return true if there is another element in the current array or object being parsed.
-func opJsonTokenMore(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opJsonTokenMore(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	more := false
 	success := false
 
@@ -105,7 +106,7 @@ func opJsonTokenMore(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // Token parses the next token.
-func opJsonTokenNext(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opJsonTokenNext(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	tokenType := int32(JSON_TOKEN_INVALID)
 	success := false
 
@@ -152,7 +153,7 @@ func opJsonTokenNext(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // Type returns the type of the current token.
-func opJsonTokenType(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opJsonTokenType(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	tokenType := int32(JSON_TOKEN_INVALID)
 	success := false
 
@@ -166,7 +167,7 @@ func opJsonTokenType(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // Delim returns current token as an int32 delimiter.
-func opJsonTokenDelim(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opJsonTokenDelim(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	tokenDelim := int32(JSON_TOKEN_INVALID)
 	success := false
 
@@ -182,7 +183,7 @@ func opJsonTokenDelim(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // Bool returns current token as a bool value.
-func opJsonTokenBool(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opJsonTokenBool(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	tokenBool := false
 	success := false
 
@@ -198,7 +199,7 @@ func opJsonTokenBool(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // Float64 returns current token as float64 value.
-func opJsonTokenF64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opJsonTokenF64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var tokenF64 float64
 	success := false
 
@@ -219,7 +220,7 @@ func opJsonTokenF64(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // Int64 returns current token as int64 value.
-func opJsonTokenI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opJsonTokenI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var tokenI64 int64
 	success := false
 
@@ -237,7 +238,7 @@ func opJsonTokenI64(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // Str returns current token as string value.
-func opJsonTokenStr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opJsonTokenStr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var tokenStr string
 	success := false
 
@@ -248,7 +249,7 @@ func opJsonTokenStr(inputs []ast.CXValue, outputs []ast.CXValue) {
 		}
 	}
 
-    outputs[0].Set_str(tokenStr)
+	outputs[0].Set_str(tokenStr)
 	outputs[1].Set_bool(success)
 }
 

--- a/cx/packages/cxos/op_os.go
+++ b/cx/packages/cxos/op_os.go
@@ -5,17 +5,18 @@ package cxos
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/skycoin/cx/cx/ast"
-	"github.com/skycoin/cx/cx/constants"
-	"github.com/skycoin/cx/cx/globals"
-	"github.com/skycoin/cx/cx/types"
-	"github.com/skycoin/cx/cx/util"
 	"math"
 	"os"
 	"os/exec"
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/skycoin/cx/cx/ast"
+	"github.com/skycoin/cx/cx/constants"
+	"github.com/skycoin/cx/cx/globals"
+	"github.com/skycoin/cx/cx/types"
+	"github.com/skycoin/cx/cx/util"
 )
 
 const (
@@ -35,11 +36,11 @@ func ValidFile(handle int32) *os.File {
 	return nil
 }
 
-func opOsLogFile(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsLogFile(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	util.CXLogFile(inputs[0].Get_bool())
 }
 
-func opOsReadAllText(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadAllText(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 
 	if byts, err := util.CXReadFile(inputs[0].Get_str()); err == nil {
@@ -70,7 +71,7 @@ func getFileHandle(file *os.File) int32 {
 	return handle
 }
 
-func opOsOpen(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsOpen(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	handle := int32(-1)
 	if file, err := util.CXOpenFile(inputs[0].Get_str()); err == nil {
 		handle = getFileHandle(file)
@@ -79,7 +80,7 @@ func opOsOpen(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_i32(int32(handle))
 }
 
-func opOsCreate(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsCreate(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	handle := int32(-1)
 	if file, err := util.CXCreateFile(inputs[0].Get_str()); err == nil {
 		handle = getFileHandle(file)
@@ -88,7 +89,7 @@ func opOsCreate(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_i32(int32(handle))
 }
 
-func opOsClose(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsClose(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 
 	handle := inputs[0].Get_i32()
@@ -104,7 +105,7 @@ func opOsClose(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsSeek(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsSeek(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	offset := int64(-1)
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		var err error
@@ -115,7 +116,7 @@ func opOsSeek(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_i64(offset)
 }
 
-func opOsReadStr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadStr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var len uint64
 	var value string
 	success := false
@@ -132,7 +133,7 @@ func opOsReadStr(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadF64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadF64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var value float64
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
@@ -145,7 +146,7 @@ func opOsReadF64(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadF32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadF32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var value float32
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
@@ -158,7 +159,7 @@ func opOsReadF32(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadUI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var value uint64
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
@@ -171,7 +172,7 @@ func opOsReadUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadUI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var value uint32
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
@@ -184,7 +185,7 @@ func opOsReadUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadUI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var value uint16
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
@@ -197,7 +198,7 @@ func opOsReadUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadUI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var value uint8
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
@@ -210,7 +211,7 @@ func opOsReadUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var value int64
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
@@ -223,7 +224,7 @@ func opOsReadI64(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var value int32
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
@@ -236,7 +237,7 @@ func opOsReadI32(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var value int16
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
@@ -249,7 +250,7 @@ func opOsReadI16(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var value int8
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
@@ -262,7 +263,7 @@ func opOsReadI8(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadBOOL(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadBOOL(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var value bool
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
@@ -275,7 +276,7 @@ func opOsReadBOOL(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsWriteStr(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteStr(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		value := inputs[1].Get_str()
@@ -290,7 +291,7 @@ func opOsWriteStr(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteF64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteF64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, inputs[1].Get_f64()); err == nil {
@@ -301,7 +302,7 @@ func opOsWriteF64(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteF32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteF32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, inputs[1].Get_f32()); err == nil {
@@ -312,7 +313,7 @@ func opOsWriteF32(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteUI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, inputs[1].Get_ui64()); err == nil {
@@ -323,7 +324,7 @@ func opOsWriteUI64(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteUI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, inputs[1].Get_i32()); err == nil {
@@ -334,7 +335,7 @@ func opOsWriteUI32(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteUI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, inputs[1].Get_ui16()); err == nil {
@@ -345,7 +346,7 @@ func opOsWriteUI16(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteUI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, inputs[1].Get_ui8()); err == nil {
@@ -356,7 +357,7 @@ func opOsWriteUI8(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteI64(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteI64(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, inputs[1].Get_i64()); err == nil {
@@ -367,7 +368,7 @@ func opOsWriteI64(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteI32(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteI32(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, inputs[1].Get_i32()); err == nil {
@@ -378,7 +379,7 @@ func opOsWriteI32(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteI16(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteI16(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, inputs[1].Get_i16()); err == nil {
@@ -389,7 +390,7 @@ func opOsWriteI16(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteI8(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteI8(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, inputs[1].Get_i8()); err == nil {
@@ -400,7 +401,7 @@ func opOsWriteI8(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteBOOL(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteBOOL(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if err := binary.Write(file, binary.LittleEndian, inputs[1].Get_bool()); err == nil {
@@ -411,7 +412,7 @@ func opOsWriteBOOL(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func getSlice(inputs []ast.CXValue, outputs []ast.CXValue) (outputSlicePointer types.Pointer, outputSliceOffset types.Pointer, sizeofElement types.Pointer, count types.Pointer) {
+func getSlice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) (outputSlicePointer types.Pointer, outputSliceOffset types.Pointer, sizeofElement types.Pointer, count types.Pointer) {
 	inp1, out0 := inputs[1].Arg, outputs[0].Arg
 
 	if inp1.Type != out0.Type || !(inp1.GetAssignmentElement()).IsSlice || !(out0.GetAssignmentElement()).IsSlice {
@@ -425,9 +426,9 @@ func getSlice(inputs []ast.CXValue, outputs []ast.CXValue) (outputSlicePointer t
 	return
 }
 
-func opOsReadF64Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadF64Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
-	_, outputSliceOffset, sizeofElement, count := getSlice(inputs, outputs)
+	_, outputSliceOffset, sizeofElement, count := getSlice(prgrm, inputs, outputs)
 	if count > 0 {
 		if file := ValidFile(inputs[0].Get_i32()); file != nil {
 			values := make([]float64, count)
@@ -445,9 +446,9 @@ func opOsReadF64Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadF32Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadF32Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
-	_, outputSliceOffset, sizeofElement, count := getSlice(inputs, outputs)
+	_, outputSliceOffset, sizeofElement, count := getSlice(prgrm, inputs, outputs)
 	if count > 0 {
 		if file := ValidFile(inputs[0].Get_i32()); file != nil {
 			values := make([]float32, count)
@@ -465,9 +466,9 @@ func opOsReadF32Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadUI64Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadUI64Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
-	_, outputSliceOffset, sizeofElement, count := getSlice(inputs, outputs)
+	_, outputSliceOffset, sizeofElement, count := getSlice(prgrm, inputs, outputs)
 	if count > 0 {
 		if file := ValidFile(inputs[0].Get_i32()); file != nil {
 			values := make([]uint64, count)
@@ -485,9 +486,9 @@ func opOsReadUI64Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadUI32Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadUI32Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
-	_, outputSliceOffset, sizeofElement, count := getSlice(inputs, outputs)
+	_, outputSliceOffset, sizeofElement, count := getSlice(prgrm, inputs, outputs)
 	if count > 0 {
 		if file := ValidFile(inputs[0].Get_i32()); file != nil {
 			values := make([]uint32, count)
@@ -505,9 +506,9 @@ func opOsReadUI32Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadUI16Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadUI16Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
-	_, outputSliceOffset, sizeofElement, count := getSlice(inputs, outputs)
+	_, outputSliceOffset, sizeofElement, count := getSlice(prgrm, inputs, outputs)
 	if count > 0 {
 		if file := ValidFile(inputs[0].Get_i32()); file != nil {
 			values := make([]uint16, count)
@@ -525,9 +526,9 @@ func opOsReadUI16Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadUI8Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadUI8Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
-	_, outputSliceOffset, sizeofElement, count := getSlice(inputs, outputs)
+	_, outputSliceOffset, sizeofElement, count := getSlice(prgrm, inputs, outputs)
 	if count > 0 {
 		if file := ValidFile(inputs[0].Get_i32()); file != nil {
 			values := make([]uint8, count)
@@ -545,9 +546,9 @@ func opOsReadUI8Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadI64Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadI64Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
-	_, outputSliceOffset, sizeofElement, count := getSlice(inputs, outputs)
+	_, outputSliceOffset, sizeofElement, count := getSlice(prgrm, inputs, outputs)
 	if count > 0 {
 		if file := ValidFile(inputs[0].Get_i32()); file != nil {
 			values := make([]int64, count)
@@ -565,9 +566,9 @@ func opOsReadI64Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadI32Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadI32Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
-	_, outputSliceOffset, sizeofElement, count := getSlice(inputs, outputs)
+	_, outputSliceOffset, sizeofElement, count := getSlice(prgrm, inputs, outputs)
 	if count > 0 {
 		if file := ValidFile(inputs[0].Get_i32()); file != nil {
 			values := make([]int32, count)
@@ -585,9 +586,9 @@ func opOsReadI32Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadI16Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadI16Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
-	_, outputSliceOffset, sizeofElement, count := getSlice(inputs, outputs)
+	_, outputSliceOffset, sizeofElement, count := getSlice(prgrm, inputs, outputs)
 	if count > 0 {
 		if file := ValidFile(inputs[0].Get_i32()); file != nil {
 			values := make([]int16, count)
@@ -605,9 +606,9 @@ func opOsReadI16Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsReadI8Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsReadI8Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
-	_, outputSliceOffset, sizeofElement, count := getSlice(inputs, outputs)
+	_, outputSliceOffset, sizeofElement, count := getSlice(prgrm, inputs, outputs)
 	if count > 0 {
 		if file := ValidFile(inputs[0].Get_i32()); file != nil {
 			values := make([]int8, count)
@@ -625,7 +626,7 @@ func opOsReadI8Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[1].Set_bool(success)
 }
 
-func opOsWriteF64Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteF64Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if data := inputs[1].GetSlice_f64(); data != nil {
@@ -637,7 +638,7 @@ func opOsWriteF64Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteF32Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteF32Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if data := inputs[1].GetSlice_f32(); data != nil {
@@ -649,7 +650,7 @@ func opOsWriteF32Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteUI64Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteUI64Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if data := inputs[1].GetSlice_f64(); data != nil {
@@ -661,7 +662,7 @@ func opOsWriteUI64Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteUI32Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteUI32Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if data := inputs[1].GetSlice_ui32(); data != nil {
@@ -673,7 +674,7 @@ func opOsWriteUI32Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteUI16Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteUI16Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if data := inputs[1].GetSlice_ui16(); data != nil {
@@ -685,7 +686,7 @@ func opOsWriteUI16Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteUI8Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteUI8Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if data := inputs[1].GetSlice_ui8(); data != nil {
@@ -697,7 +698,7 @@ func opOsWriteUI8Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteI64Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteI64Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if data := inputs[1].GetSlice_i64(); data != nil {
@@ -709,7 +710,7 @@ func opOsWriteI64Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteI32Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteI32Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if data := inputs[1].GetSlice_i32(); data != nil {
@@ -721,7 +722,7 @@ func opOsWriteI32Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteI16Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteI16Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if data := inputs[1].GetSlice_i16(); data != nil {
@@ -733,7 +734,7 @@ func opOsWriteI16Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsWriteI8Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsWriteI8Slice(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	success := false
 	if file := ValidFile(inputs[0].Get_i32()); file != nil {
 		if data := inputs[1].GetSlice_i8(); data != nil {
@@ -745,17 +746,17 @@ func opOsWriteI8Slice(inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_bool(success)
 }
 
-func opOsGetWorkingDirectory(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsGetWorkingDirectory(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	//outputs[0].Set_str(cxcore.PROGRAM.Path)
 	outputs[0].Set_str(globals.CxProgramPath)
 }
 
-func opOsExit(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsExit(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	exitCode := inputs[0].Get_i32()
 	os.Exit(int(exitCode))
 }
 
-func opOsRun(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opOsRun(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	var runError int32 = OS_RUN_SUCCESS
 
 	command := inputs[0].Get_str()

--- a/cx/packages/cxos/op_profile.go
+++ b/cx/packages/cxos/op_profile.go
@@ -4,11 +4,12 @@ package cxos
 
 import (
 	"fmt"
-	"github.com/skycoin/cx/cx/ast"
-	"github.com/skycoin/cx/cx/util"
 	"os"
 	"runtime"
 	"runtime/pprof"
+
+	"github.com/skycoin/cx/cx/ast"
+	"github.com/skycoin/cx/cx/util"
 )
 
 var openProfiles map[string]*os.File = make(map[string]*os.File, 0)
@@ -34,12 +35,12 @@ func stopCPUProfile(f *os.File) {
 	defer pprof.StopCPUProfile()
 }
 
-func opStartProfile(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStartProfile(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	profilePath := inputs[0].Get_str()
 	openProfiles[profilePath] = startCPUProfile(profilePath, int(inputs[1].Get_i32()))
 }
 
-func opStopProfile(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opStopProfile(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	profilePath := inputs[0].Get_str()
 	stopCPUProfile(openProfiles[profilePath])
 }

--- a/cx/packages/cxos/op_time.go
+++ b/cx/packages/cxos/op_time.go
@@ -3,22 +3,23 @@
 package cxos
 
 import (
-	"github.com/skycoin/cx/cx/ast"
 	"time"
+
+	"github.com/skycoin/cx/cx/ast"
 )
 
 func makeTimestamp() int64 {
 	return time.Now().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
 }
 
-func opTimeUnixMilli(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opTimeUnixMilli(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	outputs[0].Set_i64(makeTimestamp())
 }
 
-func opTimeUnixNano(inputs []ast.CXValue, outputs []ast.CXValue) {
-    outputs[0].Set_i64(time.Now().UnixNano())
+func opTimeUnixNano(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	outputs[0].Set_i64(time.Now().UnixNano())
 }
 
-func opTimeSleep(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opTimeSleep(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	time.Sleep(time.Duration(inputs[0].Get_i32()) * time.Millisecond)
 }

--- a/cx/packages/regexp/init.go
+++ b/cx/packages/regexp/init.go
@@ -4,11 +4,11 @@ package regexp
 
 import (
 	"github.com/skycoin/cx/cx/ast"
-    "github.com/skycoin/cx/cx/types"
-    . "github.com/skycoin/cx/cx/opcodes"
+	. "github.com/skycoin/cx/cx/opcodes"
+	"github.com/skycoin/cx/cx/types"
 )
 
- func RegisterPackage() {
+func RegisterPackage() {
 	regexpPkg := ast.MakePackage("regexp")
 	regexpStrct := ast.MakeStruct("Regexp")
 
@@ -17,7 +17,6 @@ import (
 	regexpPkg.AddStruct(regexpStrct)
 
 	ast.PROGRAM.AddPackage(regexpPkg)
-
 
 	RegisterFunction("regexp.Compile", opRegexpCompile, In(ast.ConstCxArg_STR), Out(ast.Struct("regexp", "Regexp", "r"), ast.ConstCxArg_STR))
 	RegisterFunction("regexp.MustCompile", opRegexpMustCompile, In(ast.ConstCxArg_STR), Out(ast.Struct("regexp", "Regexp", "r")))

--- a/cx/packages/regexp/op_regexp.go
+++ b/cx/packages/regexp/op_regexp.go
@@ -16,7 +16,7 @@ var regexps map[string]*regexp.Regexp = make(map[string]*regexp.Regexp, 0)
 // regexpCompile is a helper function for `opRegexpMustCompile` and
 // `opRegexpCompile`. `regexpCompile` compiles a `regexp.Regexp` structure
 // and adds it to global `regexps`. It also writes CX structure `regexp.Regexp`.
-func regexpCompile(inputs []ast.CXValue, outputs []ast.CXValue) error {
+func regexpCompile(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) error {
 	// Extracting regular expression to work with, contained in `inp0`.
 	exp := inputs[0].Get_str()
 
@@ -28,7 +28,7 @@ func regexpCompile(inputs []ast.CXValue, outputs []ast.CXValue) error {
 	}
 
 	// Extracting CX `regexp` package.
-	regexpPkg, err := ast.PROGRAM.GetPackage("regexp")
+	regexpPkg, err := prgrm.GetPackage("regexp")
 	if err != nil {
 		panic(err)
 	}
@@ -53,7 +53,7 @@ func regexpCompile(inputs []ast.CXValue, outputs []ast.CXValue) error {
 	// internally.
 	accessExp := []*ast.CXArgument{expFld}
 	reg.Fields = accessExp
-	types.Write_str(ast.PROGRAM.Memory, ast.GetFinalOffset(outputs[0].FramePointer, &reg), exp)
+	types.Write_str(prgrm.Memory, ast.GetFinalOffset(outputs[0].FramePointer, &reg), exp)
 	// Storing `Regexp` instance.
 	regexps[exp], err = regexp.Compile(exp)
 
@@ -61,8 +61,8 @@ func regexpCompile(inputs []ast.CXValue, outputs []ast.CXValue) error {
 }
 
 // opRegexpMustCompile is a wrapper for golang's `regexp`'s `MustCompile`.
-func opRegexpMustCompile(inputs []ast.CXValue, outputs []ast.CXValue) {
-	err := regexpCompile(inputs, outputs)
+func opRegexpMustCompile(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
+	err := regexpCompile(prgrm, inputs, outputs)
 
 	if err != nil {
 		println(err.Error())
@@ -72,10 +72,10 @@ func opRegexpMustCompile(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // opRegexpCompile is a wrapper for golang's `regexp`'s `MustCompile`.
-func opRegexpCompile(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opRegexpCompile(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	// We're only interested in `out1`, which represents the
 	// returned error.
-	err := regexpCompile(inputs, outputs)
+	err := regexpCompile(prgrm, inputs, outputs)
 
 	// Writing error message to `out1`.
 	var errStr string
@@ -86,7 +86,7 @@ func opRegexpCompile(inputs []ast.CXValue, outputs []ast.CXValue) {
 }
 
 // opRegexpCompile is a wrapper for golang's `regexp`'s `MustCompile`.
-func opRegexpFind(inputs []ast.CXValue, outputs []ast.CXValue) {
+func opRegexpFind(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	// Output structure `Regexp`.
 	reg := ast.CXArgument{}
 	err := copier.Copy(&reg, inputs[0].Arg)
@@ -95,7 +95,7 @@ func opRegexpFind(inputs []ast.CXValue, outputs []ast.CXValue) {
 	}
 
 	// Extracting CX `regexp` package.
-	regexpPkg, err := ast.PROGRAM.GetPackage("regexp")
+	regexpPkg, err := prgrm.GetPackage("regexp")
 	if err != nil {
 		panic(err)
 	}
@@ -115,7 +115,7 @@ func opRegexpFind(inputs []ast.CXValue, outputs []ast.CXValue) {
 	// Getting corresponding `Regexp` instance.
 	accessExp := []*ast.CXArgument{expFld}
 	reg.Fields = accessExp
-	exp := types.Read_str(ast.PROGRAM.Memory, ast.GetFinalOffset(inputs[0].FramePointer, &reg))
+	exp := types.Read_str(prgrm.Memory, ast.GetFinalOffset(inputs[0].FramePointer, &reg))
 	r := regexps[exp]
 
 	outputs[0].Set_str(string(r.Find([]byte(inputs[1].Get_str()))))


### PR DESCRIPTION
Fixes #

Changes:
- Change Ccall method to Call method
- Modularize CXCall Call method
- Change opcode format to func(prgrm *CXProgram, inputs []CXValue, outputs []CXValue)
- Remove global calls(ast.PROGRAM) in cx/opcodes and cx/packages

Does this change need to mentioned in CHANGELOG.md?
