### PR TITLE
Refactor/new ast format

### DIFF
--- a/cmd/cx/helpers.go
+++ b/cmd/cx/helpers.go
@@ -93,9 +93,9 @@ func parseProgram(options cxCmdFlags, fileNames []string, sourceCode []*os.File)
 // initMainPkg adds a `main` package with an empty `main` function to `prgrm`.
 func initMainPkg(prgrm *ast.CXProgram) {
 	mod := ast.MakePackage(constants.MAIN_PKG)
-	prgrm.AddPackage(mod)
 	fn := ast.MakeFunction(constants.MAIN_FUNC, actions.CurrentFile, actions.LineNo)
 	mod.AddFunction(fn)
+	prgrm.AddPackage(mod)
 }
 
 // optionTokenize checks if the user wants to use CX to generate the lexer tokens

--- a/cmd/cx/helpers.go
+++ b/cmd/cx/helpers.go
@@ -94,7 +94,7 @@ func parseProgram(options cxCmdFlags, fileNames []string, sourceCode []*os.File)
 func initMainPkg(prgrm *ast.CXProgram) {
 	mod := ast.MakePackage(constants.MAIN_PKG)
 	fn := ast.MakeFunction(constants.MAIN_FUNC, actions.CurrentFile, actions.LineNo)
-	mod.AddFunction(fn)
+	mod.AddFunction(prgrm, fn)
 	prgrm.AddPackage(mod)
 }
 

--- a/cx/ast/ast_cxargument.go
+++ b/cx/ast/ast_cxargument.go
@@ -32,6 +32,8 @@ type CXArgumentStruct struct {
 type CXArgumentPointer struct {
 }
 
+type CXArgumentIndex int
+
 // CXArgument is used to define local variables, global variables,
 // literals (strings, numbers), inputs and outputs to function
 // calls. All of the fields in this structure are determined at

--- a/cx/ast/ast_cxargument.go
+++ b/cx/ast/ast_cxargument.go
@@ -46,7 +46,7 @@ type CXArgument struct {
 	// (e.g. `4`, `"Hello world!"`, `[3]i32{1, 2, 3}`.)
 	Name string
 
-	Package *CXPackage
+	Package CXPackageIndex
 
 	// Lengths is used if the `CXArgument` defines an array or a
 	// slice. The number of dimensions for the array/slice is
@@ -277,7 +277,7 @@ func (arg *CXArgument) GetType() types.Code {
 
 // AddPackage assigns CX package `pkg` to CX argument `arg`.
 func (arg *CXArgument) AddPackage(pkg *CXPackage) *CXArgument {
-	arg.Package = pkg
+	arg.Package = CXPackageIndex(pkg.Index)
 	return arg
 }
 
@@ -294,7 +294,7 @@ func (arg *CXArgument) AddType(typeCode types.Code) *CXArgument {
 // AddInput adds input parameters to `arg` in case arg is of type `TYPE_FUNC`.
 func (arg *CXArgument) AddInput(inp *CXArgument) *CXArgument {
 	arg.Inputs = append(arg.Inputs, inp)
-	if inp.Package == nil {
+	if inp.Package == -1 {
 		inp.Package = arg.Package
 	}
 	return arg
@@ -303,7 +303,7 @@ func (arg *CXArgument) AddInput(inp *CXArgument) *CXArgument {
 // AddOutput adds output parameters to `arg` in case arg is of type `TYPE_FUNC`.
 func (arg *CXArgument) AddOutput(out *CXArgument) *CXArgument {
 	arg.Outputs = append(arg.Outputs, out)
-	if out.Package == nil {
+	if out.Package == -1 {
 		out.Package = arg.Package
 	}
 	return arg
@@ -331,7 +331,7 @@ func Struct(prgrm *CXProgram, pkgName, strctName, argName string) *CXArgument {
 		panic(err)
 	}
 
-	strct, err := pkg.GetStruct(strctName)
+	strct, err := pkg.GetStruct(prgrm, strctName)
 	if err != nil {
 		panic(err)
 	}
@@ -358,7 +358,7 @@ func Slice(typeCode types.Code) *CXArgument {
 // The current standard library only uses basic types and slices. If more options are needed, modify this function
 func Func(pkg *CXPackage, inputs []*CXArgument, outputs []*CXArgument) *CXArgument {
 	arg := Param(types.FUNC)
-	arg.Package = pkg
+	arg.Package = CXPackageIndex(pkg.Index)
 	arg.Inputs = inputs
 	arg.Outputs = outputs
 	return arg
@@ -374,7 +374,8 @@ func Param(typeCode types.Code) *CXArgument {
 // MakeArgument ...
 func MakeArgument(name string, fileName string, fileLine int) *CXArgument {
 	return &CXArgument{
-		Name: name,
+		Name:    name,
+		Package: -1,
 		ArgDetails: &CXArgumentDebug{
 			FileName: fileName,
 			FileLine: fileLine,
@@ -386,7 +387,8 @@ func MakeArgument(name string, fileName string, fileLine int) *CXArgument {
 // MakeField ...
 func MakeField(name string, typeCode types.Code, fileName string, fileLine int) *CXArgument {
 	return &CXArgument{
-		Name: name,
+		Name:    name,
+		Package: -1,
 		ArgDetails: &CXArgumentDebug{
 			FileName: fileName,
 			FileLine: fileLine,
@@ -400,7 +402,8 @@ func MakeField(name string, typeCode types.Code, fileName string, fileLine int) 
 func MakeGlobal(name string, typeCode types.Code, fileName string, fileLine int) *CXArgument {
 	size := typeCode.Size()
 	global := &CXArgument{
-		Name: name,
+		Name:    name,
+		Package: -1,
 		ArgDetails: &CXArgumentDebug{
 			FileName: fileName,
 			FileLine: fileLine,

--- a/cx/ast/ast_cxatomicoperator.go
+++ b/cx/ast/ast_cxatomicoperator.go
@@ -5,7 +5,7 @@ type CXAtomicOperator struct {
 	Outputs  []*CXArgument
 	Operator *CXFunction
 
-	Function *CXFunction
+	Function CXFunctionIndex
 	Package  CXPackageIndex
 	Label    string
 
@@ -17,7 +17,7 @@ type CXAtomicOperator struct {
 // ----------------------------------------------------------------
 //                             `CXAtomicOperator` Getters
 
-func (op *CXAtomicOperator) GetOperatorName() string {
+func (op *CXAtomicOperator) GetOperatorName(prgrm *CXProgram) string {
 	if op.Operator.IsBuiltIn() {
 		return OpNames[op.Operator.AtomicOPCode]
 	}

--- a/cx/ast/ast_cxatomicoperator.go
+++ b/cx/ast/ast_cxatomicoperator.go
@@ -6,7 +6,7 @@ type CXAtomicOperator struct {
 	Operator *CXFunction
 
 	Function *CXFunction
-	Package  *CXPackage
+	Package  CXPackageIndex
 	Label    string
 
 	// used for jmp statements
@@ -31,7 +31,8 @@ func (op *CXAtomicOperator) GetOperatorName() string {
 // AddInput ...
 func (op *CXAtomicOperator) AddInput(param *CXArgument) *CXAtomicOperator {
 	op.Inputs = append(op.Inputs, param)
-	if param.Package == nil {
+
+	if param.Package == -1 {
 		param.Package = op.Package
 	}
 	return op
@@ -47,7 +48,7 @@ func (op *CXAtomicOperator) RemoveInput() {
 // AddOutput ...
 func (op *CXAtomicOperator) AddOutput(param *CXArgument) *CXAtomicOperator {
 	op.Outputs = append(op.Outputs, param)
-	if param.Package == nil {
+	if param.Package == -1 {
 		param.Package = op.Package
 	}
 	return op

--- a/cx/ast/ast_cxcall.go
+++ b/cx/ast/ast_cxcall.go
@@ -82,6 +82,7 @@ func processBuiltInOperators(prgrm *CXProgram, expr *CXExpression, globalInputs 
 		// TODO: resolve this at compile time
 		atomicType := cxAtomicOp.Inputs[0].GetType()
 		cxAtomicOp.Operator = GetTypedOperator(atomicType, cxAtomicOp.Operator.AtomicOPCode)
+
 	}
 	inputs := cxAtomicOp.Inputs
 	inputCount := len(inputs)
@@ -165,7 +166,6 @@ func processNonAtomicOperators(prgrm *CXProgram, expr *CXExpression, fp types.Po
 	}
 
 	newFP := newCall.FramePointer
-
 	// wiping next stack frame (removing garbage)
 	for c := types.Pointer(0); c < cxAtomicOp.Operator.Size; c++ {
 		prgrm.Memory[newFP+c] = 0

--- a/cx/ast/ast_cxfunction.go
+++ b/cx/ast/ast_cxfunction.go
@@ -190,7 +190,7 @@ func (fn *CXFunction) AddExpression(prgrm *CXProgram, expr *CXExpression) *CXFun
 		}
 
 		cxAtomicOp.Package = fn.Package
-		cxAtomicOp.Function = fn
+		cxAtomicOp.Function = CXFunctionIndex(fn.Index)
 	}
 
 	fn.Expressions = append(fn.Expressions, expr)
@@ -206,7 +206,7 @@ func (fn *CXFunction) AddExpressionByLineNumber(prgrm *CXProgram, expr *CXExpres
 		panic(err)
 	}
 	cxAtomicOp.Package = fn.Package
-	cxAtomicOp.Function = fn
+	cxAtomicOp.Function = CXFunctionIndex(fn.Index)
 
 	lenExprs := len(fn.Expressions)
 	if lenExprs == line {
@@ -241,6 +241,7 @@ func (fn *CXFunction) RemoveExpression(line int) {
 func MakeAtomicOperatorExpression(prgrm *CXProgram, op *CXFunction) *CXExpression {
 	index := prgrm.AddCXAtomicOp(&CXAtomicOperator{
 		Operator: op,
+		// Function: -1,
 	})
 
 	return &CXExpression{

--- a/cx/ast/ast_cxfunction.go
+++ b/cx/ast/ast_cxfunction.go
@@ -7,6 +7,8 @@ import (
 	"github.com/skycoin/cx/cx/types"
 )
 
+type CXFunctionIndex int
+
 // CXFunction is used to represent a CX function.
 type CXFunction struct {
 	// Metadata

--- a/cx/ast/ast_cxfunction.go
+++ b/cx/ast/ast_cxfunction.go
@@ -12,8 +12,8 @@ type CXFunctionIndex int
 // CXFunction is used to represent a CX function.
 type CXFunction struct {
 	// Metadata
-	Name         string     // Name of the function
-	Package      *CXPackage // The package it's a member of
+	Name         string         // Name of the function
+	Package      CXPackageIndex // The package it's a member of
 	AtomicOPCode int
 
 	// Contents

--- a/cx/ast/ast_cxfunction.go
+++ b/cx/ast/ast_cxfunction.go
@@ -12,6 +12,7 @@ type CXFunctionIndex int
 // CXFunction is used to represent a CX function.
 type CXFunction struct {
 	// Metadata
+	Index        int
 	Name         string         // Name of the function
 	Package      CXPackageIndex // The package it's a member of
 	AtomicOPCode int
@@ -54,6 +55,7 @@ func (cxf CXFunction) IsAtomic() bool {
 func MakeFunction(name string, fileName string, fileLine int) *CXFunction {
 	return &CXFunction{
 		Name:     name,
+		Index:    -1,
 		FileName: fileName,
 		FileLine: fileLine,
 	}

--- a/cx/ast/ast_cxpackage.go
+++ b/cx/ast/ast_cxpackage.go
@@ -10,7 +10,8 @@ type CXPackageIndex int
 // CXPackage is used to represent a CX package.
 type CXPackage struct {
 	// Metadata
-	Name string // Name of the package
+	Name  string // Name of the package
+	Index int    // Index of package inside the CXPackage array
 
 	// Contents
 	Imports   map[string]*CXPackage  // imported packages
@@ -191,7 +192,7 @@ func (pkg *CXPackage) RemoveFunction(fnName string) {
 
 // AddStruct ...
 func (pkg *CXPackage) AddStruct(strct *CXStruct) *CXPackage {
-	strct.Package = pkg
+	strct.Package = CXPackageIndex(pkg.Index)
 	pkg.Structs[strct.Name] = strct
 	pkg.CurrentStruct = strct
 

--- a/cx/ast/ast_cxpackage.go
+++ b/cx/ast/ast_cxpackage.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 )
 
+type CXPackageIndex int
+
 // CXPackage is used to represent a CX package.
 type CXPackage struct {
 	// Metadata

--- a/cx/ast/ast_cxprogram.go
+++ b/cx/ast/ast_cxprogram.go
@@ -95,10 +95,6 @@ func MakeProgram() *CXProgram {
 
 // AddPackage ...
 func (cxprogram *CXProgram) AddPackage(mod *CXPackage) CXPackageIndex {
-	// if cxprogram.Packages[mod.Name] != nil {
-	// 	return
-	// }
-
 	index := cxprogram.AddPackageInArray(mod)
 
 	cxprogram.Packages[mod.Name] = CXPackageIndex(index)
@@ -161,6 +157,10 @@ func (cxprogram *CXProgram) AddFunctionInArray(fn *CXFunction) CXFunctionIndex {
 }
 
 func (cxprogram *CXProgram) GetFunctionFromArray(index CXFunctionIndex) (*CXFunction, error) {
+	if index == -1 {
+		return nil, nil
+	}
+
 	if int(index) > (len(cxprogram.CXFunctions) - 1) {
 		return nil, fmt.Errorf("error: CXFunctions[%d]: index out of bounds", index)
 	}
@@ -340,7 +340,7 @@ func (cxprogram *CXProgram) GetCurrentFunction() (*CXFunction, error) {
 		return &CXFunction{}, err
 	}
 
-	if currentPackage.CurrentFunction != -1 {
+	if currentPackage.CurrentFunction == -1 {
 		return nil, errors.New("current function is nil")
 	}
 
@@ -477,7 +477,6 @@ func (cxprogram *CXProgram) PrintAllObjects() {
 
 	for c := types.Pointer(0); c <= cxprogram.CallCounter; c++ {
 		op := cxprogram.CallStack[c].Operator
-
 		for _, ptr := range op.ListOfPointers {
 			heapOffset := types.Read_ptr(cxprogram.Memory, fp+ptr.Offset)
 

--- a/cx/ast/ast_cxprogram.go
+++ b/cx/ast/ast_cxprogram.go
@@ -41,8 +41,8 @@ type CXProgram struct {
 
 	// For new CX AST arrays
 	CXAtomicOps []*CXAtomicOperator
-	CXArgs      []*CXArgument
-	CXLines     []*CXLine
+	CXArgs      []CXArgument
+	CXLines     []CXLine
 	CXPackages  []CXPackage
 	CXFunctions []*CXFunction
 	// Then reference the package of function by CxFunction id
@@ -153,7 +153,7 @@ func (cxprogram *CXProgram) GetCXLine(index int) (*CXLine, error) {
 		return nil, fmt.Errorf("error: CXLines[%d]: index out of bounds", index)
 	}
 
-	return cxprogram.CXLines[index], nil
+	return &cxprogram.CXLines[index], nil
 }
 
 func (cxprogram *CXProgram) GetCXArg(index int) (*CXArgument, error) {
@@ -161,7 +161,7 @@ func (cxprogram *CXProgram) GetCXArg(index int) (*CXArgument, error) {
 		return nil, fmt.Errorf("error: CXArgs[%d]: index out of bounds", index)
 	}
 
-	return cxprogram.CXArgs[index], nil
+	return &cxprogram.CXArgs[index], nil
 }
 
 func (cxprogram *CXProgram) GetCXAtomicOp(index int) (*CXAtomicOperator, error) {
@@ -173,13 +173,13 @@ func (cxprogram *CXProgram) GetCXAtomicOp(index int) (*CXAtomicOperator, error) 
 }
 
 func (cxprogram *CXProgram) AddCXLine(CXLine *CXLine) int {
-	cxprogram.CXLines = append(cxprogram.CXLines, CXLine)
+	cxprogram.CXLines = append(cxprogram.CXLines, *CXLine)
 
 	return len(cxprogram.CXLines) - 1
 }
 
 func (cxprogram *CXProgram) AddCXArg(CXArg *CXArgument) int {
-	cxprogram.CXArgs = append(cxprogram.CXArgs, CXArg)
+	cxprogram.CXArgs = append(cxprogram.CXArgs, *CXArg)
 
 	return len(cxprogram.CXArgs) - 1
 }

--- a/cx/ast/ast_cxprogram.go
+++ b/cx/ast/ast_cxprogram.go
@@ -26,7 +26,7 @@ type CXProgram struct {
 	Packages map[string]CXPackageIndex // Packages in a CX program
 
 	// Runtime information
-	ProgramInput []*CXArgument // OS input arguments
+	ProgramInput []CXArgumentIndex // OS input arguments
 	//ProgramOutput []*CXArgument // outputs to the OS
 	Memory []byte // Used when running the program
 
@@ -156,8 +156,8 @@ func (cxprogram *CXProgram) GetCXLine(index int) (*CXLine, error) {
 	return &cxprogram.CXLines[index], nil
 }
 
-func (cxprogram *CXProgram) GetCXArg(index int) (*CXArgument, error) {
-	if index > (len(cxprogram.CXArgs) - 1) {
+func (cxprogram *CXProgram) GetCXArg(index CXArgumentIndex) (*CXArgument, error) {
+	if int(index) > (len(cxprogram.CXArgs) - 1) {
 		return nil, fmt.Errorf("error: CXArgs[%d]: index out of bounds", index)
 	}
 

--- a/cx/ast/ast_cxprogram.go
+++ b/cx/ast/ast_cxprogram.go
@@ -104,10 +104,12 @@ func (cxprogram *CXProgram) AddPackage(mod *CXPackage) {
 	cxprogram.CurrentPackage = CXPackageIndex(index)
 }
 
-func (cxprogram *CXProgram) AddPackageInArray(pkg *CXPackage) int {
+func (cxprogram *CXProgram) AddPackageInArray(pkg *CXPackage) CXPackageIndex {
+	// The index of pkg after it will be added in the array
+	pkg.Index = len(cxprogram.CXPackages)
 	cxprogram.CXPackages = append(cxprogram.CXPackages, *pkg)
 
-	return len(cxprogram.CXPackages) - 1
+	return CXPackageIndex(pkg.Index)
 }
 
 func (cxprogram *CXProgram) GetPackageFromArray(index CXPackageIndex) (*CXPackage, error) {

--- a/cx/ast/ast_cxstruct.go
+++ b/cx/ast/ast_cxstruct.go
@@ -11,9 +11,9 @@ import (
 // CXStruct is used to represent a CX struct.
 type CXStruct struct {
 	// Metadata
-	Name    string        // Name of the struct
-	Package *CXPackage    // The package this struct belongs to
-	Size    types.Pointer // The size in memory that this struct takes.
+	Name    string         // Name of the struct
+	Package CXPackageIndex // The package this struct belongs to
+	Size    types.Pointer  // The size in memory that this struct takes.
 
 	// Contents
 	Fields []*CXArgument // The fields of the struct

--- a/cx/ast/garbage_collector.go
+++ b/cx/ast/garbage_collector.go
@@ -12,7 +12,12 @@ func MarkAndCompact(prgrm *CXProgram) {
 
 	// marking, setting forward addresses and updating references
 	// global variables
-	for _, pkg := range prgrm.Packages {
+	for _, pkgIdx := range prgrm.Packages {
+		pkg, err := prgrm.GetPackageFromArray(pkgIdx)
+		if err != nil {
+			panic(err)
+		}
+
 		for _, glbl := range pkg.Globals {
 			if (glbl.IsPointer() || glbl.IsSlice || glbl.Type == types.STR) && glbl.StructType == nil {
 				// Getting the offset to the object in the heap
@@ -203,7 +208,12 @@ func DisplaceReferences(prgrm *CXProgram, off types.Pointer, numPkgs int) {
 	updated := make(map[types.Pointer]types.Pointer)
 
 	count := 0
-	for _, pkg := range prgrm.Packages {
+	for _, pkgIdx := range prgrm.Packages {
+		pkg, err := prgrm.GetPackageFromArray(pkgIdx)
+		if err != nil {
+			panic(err)
+		}
+
 		if count > numPkgs {
 			break
 		}
@@ -352,7 +362,12 @@ func updatePointers(prgrm *CXProgram, oldAddr, newAddr types.Pointer) {
 	// TODO: `oldAddr` could be received as a slice of bytes that represent the old address of the object,
 	// as it needs to be converted to bytes later on anyways. However, I'm sticking to an int32
 	// for a bit more of clarity.
-	for _, pkg := range prgrm.Packages {
+	for _, pkgIdx := range prgrm.Packages {
+		pkg, err := prgrm.GetPackageFromArray(pkgIdx)
+		if err != nil {
+			panic(err)
+		}
+
 		for _, glbl := range pkg.Globals {
 			if (glbl.IsPointer() || glbl.IsSlice || glbl.Type == types.STR) && glbl.StructType == nil {
 				// Getting the offset to the object in the heap

--- a/cx/ast/globals.go
+++ b/cx/ast/globals.go
@@ -9,6 +9,6 @@ var PROGRAM *CXProgram //Why do we have global?
 // Initializing `CXProgram` structure where packages, structs, functions and
 // global variables that belong to core packages are stored.
 func init() {
-	prgrm := CXProgram{Packages: make(map[string]*CXPackage, 0)}
+	prgrm := CXProgram{Packages: make(map[string]CXPackageIndex, 0)}
 	PROGRAM = &prgrm
 }

--- a/cx/ast/opcodes2.go
+++ b/cx/ast/opcodes2.go
@@ -32,4 +32,3 @@ func GetTypedOperatorOffset(typeCode types.Code, opCode int) int {
 func GetTypedOperator(typeCode types.Code, opCode int) *CXFunction {
 	return Operators[GetTypedOperatorOffset(typeCode, opCode)]
 }
-

--- a/cx/ast/serialize.go
+++ b/cx/ast/serialize.go
@@ -484,7 +484,15 @@ func serializeProgram(prgrm *CXProgram, s *SerializedCXProgram) {
 		panic("package reference not found")
 	}
 
-	sPrgrm.InputsOffset, sPrgrm.InputsSize = serializeSliceOfArguments(prgrm.ProgramInput, s)
+	args := []*CXArgument{}
+	for _, argIdx := range prgrm.ProgramInput {
+		arg, err := prgrm.GetCXArg(argIdx)
+		if err != nil {
+			panic(err)
+		}
+		args = append(args, arg)
+	}
+	sPrgrm.InputsOffset, sPrgrm.InputsSize = serializeSliceOfArguments(args, s)
 	//sPrgrm.OutputsOffset, sPrgrm.OutputsSize = serializeSliceOfArguments(prgrm.ProgramOutput, s)
 
 	sPrgrm.CallStackOffset, sPrgrm.CallStackSize = serializeCalls(prgrm.CallStack[:prgrm.CallCounter], s)

--- a/cx/ast/stack.go
+++ b/cx/ast/stack.go
@@ -78,7 +78,7 @@ func (cxprogram *CXProgram) PrintStack() {
 				// fmt.Println("\t", inp.Name, "\t", ":", "\t", GetPrintableValue(fp, inp))
 				// exprs += fmt.Sprintln("\t", stackValueHeader(inp.FileName, inp.FileLine), "\t", ":", "\t", GetPrintableValue(fp, inp))
 
-				exprs += fmt.Sprintf("\t%s : %s() : %s\n", stackValueHeader(inp.ArgDetails.FileName, inp.ArgDetails.FileLine), cxAtomicOp.GetOperatorName(), GetPrintableValue(cxprogram, fp, inp))
+				exprs += fmt.Sprintf("\t%s : %s() : %s\n", stackValueHeader(inp.ArgDetails.FileName, inp.ArgDetails.FileLine), cxAtomicOp.GetOperatorName(cxprogram), GetPrintableValue(cxprogram, fp, inp))
 
 				dupNames = append(dupNames, inpPkg.Name+inp.Name)
 			}
@@ -106,7 +106,7 @@ func (cxprogram *CXProgram) PrintStack() {
 				// fmt.Println("\t", out.Name, "\t", ":", "\t", GetPrintableValue(fp, out))
 				// exprs += fmt.Sprintln("\t", stackValueHeader(out.FileName, out.FileLine), ":", GetPrintableValue(fp, out))
 
-				exprs += fmt.Sprintf("\t%s : %s() : %s\n", stackValueHeader(out.ArgDetails.FileName, out.ArgDetails.FileLine), cxAtomicOp.GetOperatorName(), GetPrintableValue(cxprogram, fp, out))
+				exprs += fmt.Sprintf("\t%s : %s() : %s\n", stackValueHeader(out.ArgDetails.FileName, out.ArgDetails.FileLine), cxAtomicOp.GetOperatorName(cxprogram), GetPrintableValue(cxprogram, fp, out))
 
 				dupNames = append(dupNames, outPkg.Name+out.Name)
 			}

--- a/cx/ast/stack.go
+++ b/cx/ast/stack.go
@@ -30,14 +30,22 @@ func (cxprogram *CXProgram) PrintStack() {
 			fmt.Println("ProgramInput")
 			fmt.Printf("\t%s : %s() : %s\n", stackValueHeader(inp.ArgDetails.FileName, inp.ArgDetails.FileLine), op.Name, GetPrintableValue(cxprogram, fp, inp))
 
-			dupNames = append(dupNames, inp.Package.Name+inp.Name)
+			inpPkg, err := cxprogram.GetPackageFromArray(inp.Package)
+			if err != nil {
+				panic(err)
+			}
+			dupNames = append(dupNames, inpPkg.Name+inp.Name)
 		}
 
 		for _, out := range op.Outputs {
 			fmt.Println("ProgramOutput")
 			fmt.Printf("\t%s : %s() : %s\n", stackValueHeader(out.ArgDetails.FileName, out.ArgDetails.FileLine), op.Name, GetPrintableValue(cxprogram, fp, out))
 
-			dupNames = append(dupNames, out.Package.Name+out.Name)
+			outPkg, err := cxprogram.GetPackageFromArray(out.Package)
+			if err != nil {
+				panic(err)
+			}
+			dupNames = append(dupNames, outPkg.Name+out.Name)
 		}
 
 		// fmt.Println("Expressions")
@@ -51,9 +59,14 @@ func (cxprogram *CXProgram) PrintStack() {
 				if inp.Name == "" || cxAtomicOp.Operator == nil {
 					continue
 				}
+
+				inpPkg, err := cxprogram.GetPackageFromArray(inp.Package)
+				if err != nil {
+					panic(err)
+				}
 				var dup bool
 				for _, name := range dupNames {
-					if name == inp.Package.Name+inp.Name {
+					if name == inpPkg.Name+inp.Name {
 						dup = true
 						break
 					}
@@ -67,16 +80,21 @@ func (cxprogram *CXProgram) PrintStack() {
 
 				exprs += fmt.Sprintf("\t%s : %s() : %s\n", stackValueHeader(inp.ArgDetails.FileName, inp.ArgDetails.FileLine), cxAtomicOp.GetOperatorName(), GetPrintableValue(cxprogram, fp, inp))
 
-				dupNames = append(dupNames, inp.Package.Name+inp.Name)
+				dupNames = append(dupNames, inpPkg.Name+inp.Name)
 			}
 
 			for _, out := range cxAtomicOp.Outputs {
 				if out.Name == "" || cxAtomicOp.Operator == nil {
 					continue
 				}
+
+				outPkg, err := cxprogram.GetPackageFromArray(out.Package)
+				if err != nil {
+					panic(err)
+				}
 				var dup bool
 				for _, name := range dupNames {
-					if name == out.Package.Name+out.Name {
+					if name == outPkg.Name+out.Name {
 						dup = true
 						break
 					}
@@ -90,7 +108,7 @@ func (cxprogram *CXProgram) PrintStack() {
 
 				exprs += fmt.Sprintf("\t%s : %s() : %s\n", stackValueHeader(out.ArgDetails.FileName, out.ArgDetails.FileLine), cxAtomicOp.GetOperatorName(), GetPrintableValue(cxprogram, fp, out))
 
-				dupNames = append(dupNames, out.Package.Name+out.Name)
+				dupNames = append(dupNames, outPkg.Name+out.Name)
 			}
 		}
 

--- a/cx/ast/tostring.go
+++ b/cx/ast/tostring.go
@@ -31,7 +31,7 @@ func ToString(cxprogram *CXProgram) string {
 	}
 
 	currentFunction, _ = cxprogram.GetCurrentFunction()
-	currentPackage.CurrentFunction = currentFunction
+	currentPackage.CurrentFunction = CXFunctionIndex(currentFunction.Index)
 
 	BuildStrPackages(cxprogram, &ast3) //what does this do?
 
@@ -98,11 +98,16 @@ func buildStrFunctions(prgrm *CXProgram, pkg *CXPackage, ast1 *string) {
 	// We need to declare the counter outside so we can
 	// ignore the increment from the `*init` function.
 	var j int
-	for _, fn := range pkg.Functions {
+	for _, fnIdx := range pkg.Functions {
+		fn, err := prgrm.GetFunctionFromArray(fnIdx)
+		if err != nil {
+			panic(err)
+		}
+
 		if fn.Name == constants.SYS_INIT_FUNC {
 			continue
 		}
-		_, err := pkg.SelectFunction(fn.Name)
+		_, err = pkg.SelectFunction(prgrm, fn.Name)
 		if err != nil {
 			panic(err)
 		}

--- a/cx/ast/tostring.go
+++ b/cx/ast/tostring.go
@@ -25,12 +25,14 @@ func ToString(cxprogram *CXProgram) string {
 	var currentPackage *CXPackage
 
 	currentPackage, err := cxprogram.GetCurrentPackage()
-
 	if err != nil {
 		panic("CXProgram.ToString(): error, currentPackage is nil")
 	}
 
-	currentFunction, _ = cxprogram.GetCurrentFunction()
+	currentFunction, err = cxprogram.GetCurrentFunction()
+	if err != nil {
+		panic(err)
+	}
 	currentPackage.CurrentFunction = CXFunctionIndex(currentFunction.Index)
 
 	BuildStrPackages(cxprogram, &ast3) //what does this do?

--- a/cx/ast/tostring.go
+++ b/cx/ast/tostring.go
@@ -186,7 +186,12 @@ func BuildStrPackages(prgrm *CXProgram, ast *string) {
 	// We need to declare the counter outside so we can
 	// ignore the increments from core or stdlib packages.
 	var i int
-	for _, pkg := range prgrm.Packages {
+	for _, pkgIdx := range prgrm.Packages {
+		pkg, err := prgrm.GetPackageFromArray(pkgIdx)
+		if err != nil {
+			panic(err)
+		}
+
 		if constants2.IsCorePackage(pkg.Name) {
 			continue
 		}

--- a/cx/astapi/arguments.go
+++ b/cx/astapi/arguments.go
@@ -52,7 +52,7 @@ func AddNativeInputToExpression(cxprogram *cxast.CXProgram, packageName, functio
 	}
 
 	arg := cxast.MakeField(inputName, inputType, "", -1).AddType(types.Code(inputType))
-	arg.Package = pkg
+	arg.Package = cxast.CXPackageIndex(pkg.Index)
 
 	cxAtomicOp, _, _, err := cxprogram.GetOperation(expr)
 	if err != nil {
@@ -150,7 +150,7 @@ func AddNativeOutputToExpression(cxprogram *cxast.CXProgram, packageName, functi
 	}
 
 	arg := cxast.MakeField(outputName, outputType, "", -1).AddType(types.Code(outputType))
-	arg.Package = pkg
+	arg.Package = cxast.CXPackageIndex(pkg.Index)
 
 	cxAtomicOp, _, _, err := cxprogram.GetOperation(expr)
 	if err != nil {
@@ -345,7 +345,11 @@ func GetAccessibleArgsForFunctionByType(cxprogram *cxast.CXProgram, packageLocat
 		}
 	}
 
-	for _, imp := range pkg.Imports {
+	for _, impIdx := range pkg.Imports {
+		imp, err := cxprogram.GetPackageFromArray(impIdx)
+		if err != nil {
+			panic(err)
+		}
 		for _, global := range imp.Globals {
 			if global.IsStruct {
 				for _, field := range global.StructType.Fields {
@@ -417,7 +421,7 @@ func AddLiteralInputToExpression(cxprogram *cxast.CXProgram, packageName, functi
 		panic(err)
 	}
 
-	arg.Package = pkg
+	arg.Package = cxast.CXPackageIndex(pkg.Index)
 	cxAtomicOp2.AddInput(arg)
 
 	return nil

--- a/cx/astapi/arguments.go
+++ b/cx/astapi/arguments.go
@@ -391,7 +391,7 @@ func AddLiteralInputToExpression(cxprogram *cxast.CXProgram, packageName, functi
 	if err != nil {
 		return err
 	}
-	cxprogram.CurrentPackage = pkg
+	cxprogram.CurrentPackage = cxprogram.Packages[packageName]
 	fn, err := FindFunction(cxprogram, functionName)
 	if err != nil {
 		return err

--- a/cx/astapi/arguments_test.go
+++ b/cx/astapi/arguments_test.go
@@ -124,7 +124,13 @@ func TestASTAPI_Arguments(t *testing.T) {
 
 	t.Run("add global", func(t *testing.T) {
 		arg := cxast.MakeGlobal("testGlobal", types.I16, "", -1)
-		cxprogram.Packages["main"].AddGlobal(arg)
+
+		cxpackage, err := cxprogram.GetPackageFromArray(cxprogram.Packages["main"])
+		if err != nil {
+			panic(err)
+		}
+
+		cxpackage.AddGlobal(arg)
 	})
 
 	t.Run("get accessible i16 args", func(t *testing.T) {

--- a/cx/astapi/expressions.go
+++ b/cx/astapi/expressions.go
@@ -34,6 +34,7 @@ func AddNativeExpressionToFunction(cxprogram *cxast.CXProgram, functionName stri
 	if err != nil {
 		panic(err)
 	}
+
 	cxAtomicOp.Operator.Name = cxast.OpNames[expressionType]
 
 	fn, err := FindFunction(cxprogram, functionName)

--- a/cx/astapi/functions.go
+++ b/cx/astapi/functions.go
@@ -102,7 +102,7 @@ func AddNativeInputToFunction(cxprogram *cxast.CXProgram, packageName, functionN
 	}
 
 	arg := cxast.MakeField(inputName, inputType, "", -1).AddType(types.Code(inputType))
-	arg.Package = pkg
+	arg.Package = cxast.CXPackageIndex(pkg.Index)
 	fn.AddInput(arg)
 
 	return nil
@@ -174,7 +174,7 @@ func AddNativeOutputToFunction(cxprogram *cxast.CXProgram, packageName, function
 		return err
 	}
 	arg := cxast.MakeField(outputName, outputType, "", -1).AddType(types.Code(outputType))
-	arg.Package = pkg
+	arg.Package = cxast.CXPackageIndex(pkg.Index)
 	fn.AddOutput(arg)
 
 	return nil

--- a/cx/astapi/functions.go
+++ b/cx/astapi/functions.go
@@ -32,7 +32,7 @@ func AddEmptyFunctionToPackage(cxprogram *cxast.CXProgram, packageName, function
 		return err
 	}
 
-	pkg.AddFunction(fn)
+	pkg.AddFunction(cxprogram, fn)
 
 	return nil
 }

--- a/cx/astapi/packages.go
+++ b/cx/astapi/packages.go
@@ -20,7 +20,12 @@ import (
 // []string{"main", "secondpackage", "thirdpackage"}
 //
 func GetPackagesNameList(cxprogram *cxast.CXProgram) (list []string) {
-	for _, pkg := range cxprogram.Packages {
+	for _, pkgIdx := range cxprogram.Packages {
+		pkg, err := cxprogram.GetPackageFromArray(pkgIdx)
+		if err != nil {
+			panic(err)
+		}
+
 		list = append(list, pkg.Name)
 	}
 	return list

--- a/cx/astapi/util.go
+++ b/cx/astapi/util.go
@@ -27,7 +27,12 @@ func FindFunction(cxprogram *cxast.CXProgram, functionName string) (*cxast.CXFun
 			panic(err)
 		}
 
-		for _, fn := range pkg.Functions {
+		for _, fnIdx := range pkg.Functions {
+			fn, err := cxprogram.GetFunctionFromArray(fnIdx)
+			if err != nil {
+				return nil, err
+			}
+
 			if fn.Name == functionName {
 				return fn, nil
 			}

--- a/cx/astapi/util.go
+++ b/cx/astapi/util.go
@@ -7,7 +7,12 @@ import (
 )
 
 func FindPackage(cxprogram *cxast.CXProgram, packageName string) (*cxast.CXPackage, error) {
-	for _, pkg := range cxprogram.Packages {
+	for _, pkgIdx := range cxprogram.Packages {
+		pkg, err := cxprogram.GetPackageFromArray(pkgIdx)
+		if err != nil {
+			panic(err)
+		}
+
 		if pkg.Name == packageName {
 			return pkg, nil
 		}
@@ -16,7 +21,12 @@ func FindPackage(cxprogram *cxast.CXProgram, packageName string) (*cxast.CXPacka
 }
 
 func FindFunction(cxprogram *cxast.CXProgram, functionName string) (*cxast.CXFunction, error) {
-	for _, pkg := range cxprogram.Packages {
+	for _, pkgIdx := range cxprogram.Packages {
+		pkg, err := cxprogram.GetPackageFromArray(pkgIdx)
+		if err != nil {
+			panic(err)
+		}
+
 		for _, fn := range pkg.Functions {
 			if fn.Name == functionName {
 				return fn, nil

--- a/cx/execute/callback.go
+++ b/cx/execute/callback.go
@@ -23,7 +23,7 @@ func Callback(cxprogram *ast.CXProgram, fn *ast.CXFunction, inputs [][]byte) (ou
 	newCall.Operator = fn
 	newCall.Line = 0
 	newCall.FramePointer = cxprogram.Stack.Pointer
-	cxprogram.Stack.Pointer += newCall.Operator.Size
+	cxprogram.Stack.Pointer += fn.Size
 	newFP := newCall.FramePointer
 
 	// wiping next mem frame (removing garbage)

--- a/cx/execute/execute.go
+++ b/cx/execute/execute.go
@@ -85,7 +85,12 @@ func RunCxAst(cxprogram *ast.CXProgram, untilEnd bool, maxOps int, untilCall typ
 				toCallName = ast.OpNames[cxAtomicOp.Operator.AtomicOPCode]
 			} else {
 				if cxAtomicOp.Operator.Name != "" {
-					toCallName = cxAtomicOp.Operator.Package.Name + "." + cxAtomicOp.Operator.Name
+					opPkg, err := cxprogram.GetPackageFromArray(cxAtomicOp.Operator.Package)
+					if err != nil {
+						panic(err)
+					}
+
+					toCallName = opPkg.Name + "." + cxAtomicOp.Operator.Name
 				} else {
 					// then it's the end of the program got from nested function calls
 					cxprogram.Terminated = true

--- a/cx/execute/execute.go
+++ b/cx/execute/execute.go
@@ -21,7 +21,8 @@ func getLastLine(cxprogram *ast.CXProgram) *ast.CXExpression {
 	}
 
 	cxAtomicOp := &ast.CXAtomicOperator{
-		Operator: ast.MakeFunction("", "", -1),
+		// Operator: nil,
+		Function: -1,
 	}
 
 	index := cxprogram.AddCXAtomicOp(cxAtomicOp)
@@ -124,7 +125,7 @@ func runSysInitFunc(cxprogram *ast.CXProgram, mod *ast.CXPackage) error {
 	}
 
 	// *init function
-	mainCall := MakeCall(fn)
+	mainCall := MakeCall(cxprogram, fn)
 	cxprogram.CallStack[0] = mainCall
 	cxprogram.Stack.Pointer = fn.Size
 
@@ -195,7 +196,7 @@ func RunCompiled(cxprogram *ast.CXProgram, maxOps int, args []string) error {
 		}
 
 		// main function
-		mainCall := MakeCall(fn)
+		mainCall := MakeCall(cxprogram, fn)
 		mainCall.FramePointer = cxprogram.Stack.Pointer
 		// initializing program resources
 		cxprogram.CallStack[0] = mainCall
@@ -230,7 +231,7 @@ func RunCompiled(cxprogram *ast.CXProgram, maxOps int, args []string) error {
 	return nil
 }
 
-func MakeCall(op *ast.CXFunction) ast.CXCall {
+func MakeCall(prgrm *ast.CXProgram, op *ast.CXFunction) ast.CXCall {
 	return ast.CXCall{
 		Operator:     op,
 		Line:         0,

--- a/cx/execute/execute.go
+++ b/cx/execute/execute.go
@@ -118,7 +118,7 @@ func runSysInitFunc(cxprogram *ast.CXProgram, mod *ast.CXPackage) error {
 	var inputs []ast.CXValue
 	var outputs []ast.CXValue
 
-	fn, err := mod.SelectFunction(constants.SYS_INIT_FUNC)
+	fn, err := mod.SelectFunction(cxprogram, constants.SYS_INIT_FUNC)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func RunCompiled(cxprogram *ast.CXProgram, maxOps int, args []string) error {
 			return err
 		}
 
-		fn, err := mod.SelectFunction(constants.MAIN_FUNC)
+		fn, err := mod.SelectFunction(cxprogram, constants.MAIN_FUNC)
 		if err != nil {
 			return err
 		}

--- a/cx/generator/program_generator.go
+++ b/cx/generator/program_generator.go
@@ -36,7 +36,7 @@ func GenerateRandomExpressions(prgrm *cxast.CXProgram, inputFn *cxast.CXFunction
 			panic(err)
 		}
 
-		cxAtomicOp.Package = inputPkg
+		cxAtomicOp.Package = cxast.CXPackageIndex(inputPkg.Index)
 		cxAtomicOp.Function = inputFn
 		for c := 0; c < len(op.Inputs); c++ {
 			cxAtomicOp.Inputs = append(cxAtomicOp.Inputs, getRandInp(prgrm, expr))

--- a/cx/generator/program_generator.go
+++ b/cx/generator/program_generator.go
@@ -37,14 +37,14 @@ func GenerateRandomExpressions(prgrm *cxast.CXProgram, inputFn *cxast.CXFunction
 		}
 
 		cxAtomicOp.Package = cxast.CXPackageIndex(inputPkg.Index)
-		cxAtomicOp.Function = inputFn
+		cxAtomicOp.Function = cxast.CXFunctionIndex(inputFn.Index)
 		for c := 0; c < len(op.Inputs); c++ {
 			cxAtomicOp.Inputs = append(cxAtomicOp.Inputs, getRandInp(prgrm, expr))
 		}
 
 		// if operator is jmp, add then and else lines
 		if IsJumpOperator(op.AtomicOPCode) {
-			lineNumOptions := numExprs - len(cxAtomicOp.Function.Expressions)
+			lineNumOptions := numExprs - len(inputFn.Expressions)
 			if lineNumOptions < 0 {
 				lineNumOptions = (lineNumOptions * -1) - 2
 			}
@@ -133,6 +133,11 @@ func getRandInp(prgrm *cxast.CXProgram, expr *cxast.CXExpression) *cxast.CXArgum
 		panic(err)
 	}
 
+	cxAtomicOpFunction, err := prgrm.GetFunctionFromArray(cxAtomicOp.Function)
+	if err != nil {
+		panic(err)
+	}
+
 	// Find available arg options.
 	optionsFromInputs, optionsFromExpressions := findArgOptions(prgrm, expr, cxAtomicOp.Operator.Inputs[0].Type)
 	lengthOfOptions := len(optionsFromInputs) + len(optionsFromExpressions)
@@ -147,10 +152,10 @@ func getRandInp(prgrm *cxast.CXProgram, expr *cxast.CXExpression) *cxast.CXArgum
 	gotOptionsFromFunctionInputs := rndExprIdx < len(optionsFromInputs)
 
 	if gotOptionsFromFunctionInputs {
-		argToCopy = cxAtomicOp.Function.Inputs[optionsFromInputs[rndExprIdx]]
+		argToCopy = cxAtomicOpFunction.Inputs[optionsFromInputs[rndExprIdx]]
 	} else {
 		rndExprIdx -= len(optionsFromInputs)
-		cxAtomicOp1, err := prgrm.GetCXAtomicOpFromExpressions(cxAtomicOp.Function.Expressions, optionsFromExpressions[rndExprIdx])
+		cxAtomicOp1, err := prgrm.GetCXAtomicOpFromExpressions(cxAtomicOpFunction.Expressions, optionsFromExpressions[rndExprIdx])
 		if err != nil {
 			panic(err)
 		}
@@ -168,7 +173,7 @@ func getRandInp(prgrm *cxast.CXProgram, expr *cxast.CXExpression) *cxast.CXArgum
 		determineExpressionOffset(prgrm, &arg, expr, optionsFromExpressions[rndExprIdx])
 		arg.Name = strconv.Itoa(optionsFromExpressions[rndExprIdx])
 	}
-	arg.Package = cxAtomicOp.Function.Package
+	arg.Package = cxAtomicOpFunction.Package
 
 	return &arg
 }
@@ -182,12 +187,18 @@ func addNewExpression(prgrm *cxast.CXProgram, expr *cxast.CXExpression, expressi
 		panic(err)
 	}
 
+	exprCXAtomicOpFunction, err := prgrm.GetFunctionFromArray(exprCXAtomicOp.Function)
+	if err != nil {
+		panic(err)
+	}
+
 	newExprCXLine := cxast.MakeCXLineExpression(prgrm, "", -1, "")
 	newExpr := cxast.MakeAtomicOperatorExpression(prgrm, cxast.Natives[expressionType])
 	newExprCXAtomicOp, _, _, err := prgrm.GetOperation(newExpr)
 	if err != nil {
 		panic(err)
 	}
+
 	newExprCXAtomicOp.Operator.Name = cxast.OpNames[expressionType]
 
 	// Add expression's inputs
@@ -195,10 +206,10 @@ func addNewExpression(prgrm *cxast.CXProgram, expr *cxast.CXExpression, expressi
 		optionsFromInputs, optionsFromExpressions := findArgOptions(prgrm, expr, newExprCXAtomicOp.Operator.Inputs[0].Type)
 		rndExprIdx = rand.Intn(len(optionsFromInputs) + len(optionsFromExpressions))
 		if rndExprIdx < len(optionsFromInputs) {
-			argToAdd = exprCXAtomicOp.Function.Inputs[optionsFromInputs[rndExprIdx]]
+			argToAdd = exprCXAtomicOpFunction.Inputs[optionsFromInputs[rndExprIdx]]
 		} else {
 			rndExprIdx -= len(optionsFromInputs)
-			argToAddCXAtomicOp, err := prgrm.GetCXAtomicOpFromExpressions(exprCXAtomicOp.Function.Expressions, optionsFromExpressions[rndExprIdx])
+			argToAddCXAtomicOp, err := prgrm.GetCXAtomicOpFromExpressions(exprCXAtomicOpFunction.Expressions, optionsFromExpressions[rndExprIdx])
 			if err != nil {
 				panic(err)
 			}
@@ -208,15 +219,15 @@ func addNewExpression(prgrm *cxast.CXProgram, expr *cxast.CXExpression, expressi
 	}
 
 	// Add expression's output
-	argOutName := strconv.Itoa(len(exprCXAtomicOp.Function.Expressions))
+	argOutName := strconv.Itoa(len(exprCXAtomicOpFunction.Expressions))
 	argOut := cxast.MakeField(argOutName, types.BOOL, "", -1)
 	argOut.AddType(types.Code(types.BOOL))
-	argOut.Package = exprCXAtomicOp.Function.Package
+	argOut.Package = exprCXAtomicOpFunction.Package
 	newExprCXAtomicOp.AddOutput(argOut)
-	exprCXAtomicOp.Function.AddExpression(prgrm, newExprCXLine)
-	exprCXAtomicOp.Function.AddExpression(prgrm, newExpr)
+	exprCXAtomicOpFunction.AddExpression(prgrm, newExprCXLine)
+	exprCXAtomicOpFunction.AddExpression(prgrm, newExpr)
 
-	determineExpressionOffset(prgrm, argOut, expr, len(exprCXAtomicOp.Function.Expressions))
+	determineExpressionOffset(prgrm, argOut, expr, len(exprCXAtomicOpFunction.Expressions))
 
 	return argOut
 }
@@ -230,8 +241,12 @@ func findArgOptions(prgrm *cxast.CXProgram, expr *cxast.CXExpression, argTypeToF
 		panic(err)
 	}
 
+	cxAtomicOpFunction, err := prgrm.GetFunctionFromArray(cxAtomicOp.Function)
+	if err != nil {
+		panic(err)
+	}
 	// loop in inputs
-	for i, inp := range cxAtomicOp.Function.Inputs {
+	for i, inp := range cxAtomicOpFunction.Inputs {
 		if inp.Type == argTypeToFind && inp.Name != "" {
 			// add index to options from inputs
 			optionsFromInputs = append(optionsFromInputs, i)
@@ -239,7 +254,7 @@ func findArgOptions(prgrm *cxast.CXProgram, expr *cxast.CXExpression, argTypeToF
 	}
 
 	// loop in expression outputs
-	for i, exp := range cxAtomicOp.Function.Expressions {
+	for i, exp := range cxAtomicOpFunction.Expressions {
 		expCXAtomicOp, _, _, err := prgrm.GetOperation(exp)
 		if err != nil {
 			panic(err)
@@ -262,7 +277,12 @@ func getRandOut(prgrm *cxast.CXProgram, expr *cxast.CXExpression) *cxast.CXArgum
 		panic(err)
 	}
 
-	for i, exp := range cxAtomicOp.Function.Expressions {
+	cxAtomicOpFunction, err := prgrm.GetFunctionFromArray(cxAtomicOp.Function)
+	if err != nil {
+		panic(err)
+	}
+
+	for i, exp := range cxAtomicOpFunction.Expressions {
 		if exp.Type == ast.CX_LINE {
 			continue
 		}
@@ -270,6 +290,7 @@ func getRandOut(prgrm *cxast.CXProgram, expr *cxast.CXExpression) *cxast.CXArgum
 		if err != nil {
 			panic(err)
 		}
+
 		if len(expCXAtomicOp.Operator.Outputs) > 0 && expCXAtomicOp.Operator.Outputs[0].Type == cxAtomicOp.Operator.Outputs[0].Type {
 			optionsFromExpressions = append(optionsFromExpressions, i)
 		}
@@ -277,7 +298,7 @@ func getRandOut(prgrm *cxast.CXProgram, expr *cxast.CXExpression) *cxast.CXArgum
 
 	rndExprIdx := rand.Intn(len(optionsFromExpressions))
 
-	copyCXAtomicOp, err := prgrm.GetCXAtomicOpFromExpressions(cxAtomicOp.Function.Expressions, optionsFromExpressions[rndExprIdx])
+	copyCXAtomicOp, err := prgrm.GetCXAtomicOpFromExpressions(cxAtomicOpFunction.Expressions, optionsFromExpressions[rndExprIdx])
 	if err != nil {
 		panic(err)
 	}
@@ -289,7 +310,7 @@ func getRandOut(prgrm *cxast.CXProgram, expr *cxast.CXExpression) *cxast.CXArgum
 	}
 
 	determineExpressionOffset(prgrm, &arg, expr, optionsFromExpressions[rndExprIdx])
-	arg.Package = cxAtomicOp.Function.Package
+	arg.Package = cxAtomicOpFunction.Package
 	arg.Name = strconv.Itoa(optionsFromExpressions[rndExprIdx])
 
 	return &arg
@@ -301,15 +322,20 @@ func determineExpressionOffset(prgrm *cxast.CXProgram, arg *cxast.CXArgument, ex
 		panic(err)
 	}
 
-	// Determining the offset where the expression should be writing to.
-	for c := 0; c < len(cxAtomicOp.Function.Inputs); c++ {
-		arg.Offset += cxAtomicOp.Function.Inputs[c].TotalSize
+	cxAtomicOpFunction, err := prgrm.GetFunctionFromArray(cxAtomicOp.Function)
+	if err != nil {
+		panic(err)
 	}
-	for c := 0; c < len(cxAtomicOp.Function.Outputs); c++ {
-		arg.Offset += cxAtomicOp.Function.Outputs[c].TotalSize
+
+	// Determining the offset where the expression should be writing to.
+	for c := 0; c < len(cxAtomicOpFunction.Inputs); c++ {
+		arg.Offset += cxAtomicOpFunction.Inputs[c].TotalSize
+	}
+	for c := 0; c < len(cxAtomicOpFunction.Outputs); c++ {
+		arg.Offset += cxAtomicOpFunction.Outputs[c].TotalSize
 	}
 	for c := 0; c < indexOfSelectedOption; c++ {
-		cxAtomicOp1, err := prgrm.GetCXAtomicOpFromExpressions(cxAtomicOp.Function.Expressions, c)
+		cxAtomicOp1, err := prgrm.GetCXAtomicOpFromExpressions(cxAtomicOpFunction.Expressions, c)
 		if err != nil {
 			panic(err)
 		}

--- a/cx/opcodes/op_aff.go
+++ b/cx/opcodes/op_aff.go
@@ -339,7 +339,12 @@ func QueryFunction(prgrm *ast.CXProgram, fn *ast.CXFunction, expr *ast.CXExpress
 	if err != nil {
 		panic(err)
 	}
-	for _, f := range pkg.Functions {
+	for _, fIdx := range pkg.Functions {
+		f, err := prgrm.GetFunctionFromArray(fIdx)
+		if err != nil {
+			panic(err)
+		}
+
 		if f.Name == constants.SYS_INIT_FUNC {
 			continue
 		}
@@ -679,7 +684,11 @@ func opAffOn(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) 
 		panic(err)
 	}
 
-	prevFn := prevPkg.CurrentFunction
+	prevFnIdx := prevPkg.CurrentFunction
+	prevFn, err := prgrm.GetFunctionFromArray(prevFnIdx)
+	if err != nil {
+		panic(err)
+	}
 	prevExpr := prevFn.CurrentExpression
 
 	call := prgrm.GetCurrentCall()
@@ -712,8 +721,8 @@ func opAffOn(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) 
 
 	// returning to previous state
 	prgrm.CurrentPackage = prevPkgIdx
-	prevPkg.CurrentFunction = prevFn
-	prevPkg.CurrentFunction.CurrentExpression = prevExpr
+	prevPkg.CurrentFunction = prevFnIdx
+	prevFn.CurrentExpression = prevExpr
 
 	for i, aff := range affs {
 		fmt.Printf("%d - %s\n", i, aff)
@@ -729,7 +738,11 @@ func opAffOf(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) 
 		panic(err)
 	}
 
-	prevFn := prevPkg.CurrentFunction
+	prevFnIdx := prevPkg.CurrentFunction
+	prevFn, err := prgrm.GetFunctionFromArray(prevFnIdx)
+	if err != nil {
+		panic(err)
+	}
 	prevExpr := prevFn.CurrentExpression
 
 	call := prgrm.GetCurrentCall()
@@ -761,8 +774,8 @@ func opAffOf(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) 
 
 	// returning to previous state
 	prgrm.CurrentPackage = prevPkgIdx
-	prevPkg.CurrentFunction = prevFn
-	prevPkg.CurrentFunction.CurrentExpression = prevExpr
+	prevPkg.CurrentFunction = prevFnIdx
+	prevFn.CurrentExpression = prevExpr
 
 	for i, aff := range affs {
 		fmt.Printf("%d - %s\n", i, aff)
@@ -861,7 +874,11 @@ func opAffInform(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXVal
 		panic(err)
 	}
 
-	prevFn := prevPkg.CurrentFunction
+	prevFnIdx := prevPkg.CurrentFunction
+	prevFn, err := prgrm.GetFunctionFromArray(prevFnIdx)
+	if err != nil {
+		panic(err)
+	}
 	prevExpr := prevFn.CurrentExpression
 
 	var tgtPkg = ast.CXPackage(*prevPkg)
@@ -963,8 +980,8 @@ func opAffInform(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXVal
 
 	// returning to previous state
 	prgrm.CurrentPackage = prevPkgIdx
-	prevPkg.CurrentFunction = prevFn
-	prevPkg.CurrentFunction.CurrentExpression = prevExpr
+	prevPkg.CurrentFunction = prevFnIdx
+	prevFn.CurrentExpression = prevExpr
 }
 
 func opAffRequest(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
@@ -980,7 +997,11 @@ func opAffRequest(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXVa
 		panic(err)
 	}
 
-	prevFn := prevPkg.CurrentFunction
+	prevFnIdx := prevPkg.CurrentFunction
+	prevFn, err := prgrm.GetFunctionFromArray(prevFnIdx)
+	if err != nil {
+		panic(err)
+	}
 	prevExpr := prevFn.CurrentExpression
 
 	var tgtPkg = ast.CXPackage(*prevPkg)
@@ -1102,8 +1123,8 @@ func opAffRequest(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXVa
 
 	// returning to previous state
 	prgrm.CurrentPackage = prevPkgIdx
-	prevPkg.CurrentFunction = prevFn
-	prevPkg.CurrentFunction.CurrentExpression = prevExpr
+	prevPkg.CurrentFunction = prevFnIdx
+	prevFn.CurrentExpression = prevExpr
 }
 
 func opAffQuery(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {

--- a/cx/opcodes/op_aff.go
+++ b/cx/opcodes/op_aff.go
@@ -137,9 +137,14 @@ func queryParam(prgrm *ast.CXProgram, fn *ast.CXFunction, args []*ast.CXArgument
 		var typOffset types.Pointer
 		elt := arg.GetAssignmentElement()
 		if elt.StructType != nil {
+			strctTypePkg, err := prgrm.GetPackageFromArray(elt.StructType.Package)
+			if err != nil {
+				panic(err)
+			}
+
 			// then it's struct type
 			// typOffset = WriteObjectRetOff(encoder.Serialize(elt.StructType.Package.Name + "." + elt.StructType.Name))
-			typOffset = types.AllocWrite_str_data(prgrm, prgrm.Memory, elt.StructType.Package.Name+"."+elt.StructType.Name)
+			typOffset = types.AllocWrite_str_data(prgrm, prgrm.Memory, strctTypePkg.Name+"."+elt.StructType.Name)
 		} else {
 			// then it's native type
 			// typOffset = WriteObjectRetOff(encoder.Serialize(TypeNames[elt.Type]))
@@ -255,9 +260,14 @@ func getSignatureSlice(prgrm *ast.CXProgram, params []*ast.CXArgument) types.Poi
 
 		var typOffset types.Pointer
 		if param.StructType != nil {
+			strctTypePkg, err := prgrm.GetPackageFromArray(param.StructType.Package)
+			if err != nil {
+				panic(err)
+			}
+
 			// then it's struct type
 			// typOffset = WriteObjectRetOff(encoder.Serialize(param.StructType.Package.Name + "." + param.StructType.Name))
-			typOffset = types.AllocWrite_str_data(prgrm, prgrm.Memory, param.StructType.Package.Name+"."+param.StructType.Name)
+			typOffset = types.AllocWrite_str_data(prgrm, prgrm.Memory, strctTypePkg.Name+"."+param.StructType.Name)
 		} else {
 			// then it's native type
 			// typOffset = WriteObjectRetOff(encoder.Serialize(TypeNames[param.Type]))

--- a/cx/opcodes/op_aff.go
+++ b/cx/opcodes/op_aff.go
@@ -641,7 +641,12 @@ func getAffordances(prgrm *ast.CXProgram, inp1 *ast.CXArgument, fp types.Pointer
 func opAffOn(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inp1, inp2 := inputs[0].Arg, inputs[1].Arg
 
-	prevPkg := prgrm.CurrentPackage
+	prevPkgIdx := prgrm.CurrentPackage
+	prevPkg, err := prgrm.GetPackageFromArray(prevPkgIdx)
+	if err != nil {
+		panic(err)
+	}
+
 	prevFn := prevPkg.CurrentFunction
 	prevExpr := prevFn.CurrentExpression
 
@@ -674,9 +679,9 @@ func opAffOn(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) 
 	getAffordances(prgrm, inp1, fp, tgtElt, tgtArgType, tgtArgIndex, &tgtPkg, &tgtFn, &tgtExpr, onMessages, &affs)
 
 	// returning to previous state
-	prgrm.CurrentPackage = prevPkg
-	prgrm.CurrentPackage.CurrentFunction = prevFn
-	prgrm.CurrentPackage.CurrentFunction.CurrentExpression = prevExpr
+	prgrm.CurrentPackage = prevPkgIdx
+	prevPkg.CurrentFunction = prevFn
+	prevPkg.CurrentFunction.CurrentExpression = prevExpr
 
 	for i, aff := range affs {
 		fmt.Printf("%d - %s\n", i, aff)
@@ -686,7 +691,12 @@ func opAffOn(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) 
 func opAffOf(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
 	inp1, inp2 := inputs[0].Arg, inputs[1].Arg
 
-	prevPkg := prgrm.CurrentPackage
+	prevPkgIdx := prgrm.CurrentPackage
+	prevPkg, err := prgrm.GetPackageFromArray(prevPkgIdx)
+	if err != nil {
+		panic(err)
+	}
+
 	prevFn := prevPkg.CurrentFunction
 	prevExpr := prevFn.CurrentExpression
 
@@ -715,9 +725,9 @@ func opAffOf(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) 
 	getAffordances(prgrm, inp1, fp, tgtElt, tgtArgType, tgtArgIndex, &tgtPkg, &tgtFn, &tgtExpr, ofMessages, &affs)
 
 	// returning to previous state
-	prgrm.CurrentPackage = prevPkg
-	prgrm.CurrentPackage.CurrentFunction = prevFn
-	prgrm.CurrentPackage.CurrentFunction.CurrentExpression = prevExpr
+	prgrm.CurrentPackage = prevPkgIdx
+	prevPkg.CurrentFunction = prevFn
+	prevPkg.CurrentFunction.CurrentExpression = prevExpr
 
 	for i, aff := range affs {
 		fmt.Printf("%d - %s\n", i, aff)
@@ -810,7 +820,12 @@ func opAffInform(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXVal
 	expr := call.Operator.Expressions[call.Line]
 	fp := inputs[0].FramePointer
 
-	prevPkg := prgrm.CurrentPackage
+	prevPkgIdx := prgrm.CurrentPackage
+	prevPkg, err := prgrm.GetPackageFromArray(prevPkgIdx)
+	if err != nil {
+		panic(err)
+	}
+
 	prevFn := prevPkg.CurrentFunction
 	prevExpr := prevFn.CurrentExpression
 
@@ -912,9 +927,9 @@ func opAffInform(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXVal
 	}
 
 	// returning to previous state
-	prgrm.CurrentPackage = prevPkg
-	prgrm.CurrentPackage.CurrentFunction = prevFn
-	prgrm.CurrentPackage.CurrentFunction.CurrentExpression = prevExpr
+	prgrm.CurrentPackage = prevPkgIdx
+	prevPkg.CurrentFunction = prevFn
+	prevPkg.CurrentFunction.CurrentExpression = prevExpr
 }
 
 func opAffRequest(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {
@@ -924,7 +939,12 @@ func opAffRequest(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXVa
 	expr := call.Operator.Expressions[call.Line]
 	fp := inputs[0].FramePointer
 
-	prevPkg := prgrm.CurrentPackage
+	prevPkgIdx := prgrm.CurrentPackage
+	prevPkg, err := prgrm.GetPackageFromArray(prevPkgIdx)
+	if err != nil {
+		panic(err)
+	}
+
 	prevFn := prevPkg.CurrentFunction
 	prevExpr := prevFn.CurrentExpression
 
@@ -1046,9 +1066,9 @@ func opAffRequest(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXVa
 	}
 
 	// returning to previous state
-	prgrm.CurrentPackage = prevPkg
-	prgrm.CurrentPackage.CurrentFunction = prevFn
-	prgrm.CurrentPackage.CurrentFunction.CurrentExpression = prevExpr
+	prgrm.CurrentPackage = prevPkgIdx
+	prevPkg.CurrentFunction = prevFn
+	prevPkg.CurrentFunction.CurrentExpression = prevExpr
 }
 
 func opAffQuery(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {

--- a/cx/opcodes/op_aff.go
+++ b/cx/opcodes/op_aff.go
@@ -61,6 +61,7 @@ func CallAffPredicate(prgrm *ast.CXProgram, fn *ast.CXFunction, predValue []byte
 	newCall.Operator = fn
 	newCall.Line = 0
 	newCall.FramePointer = prgrm.Stack.Pointer
+
 	prgrm.Stack.Pointer += newCall.Operator.Size
 
 	newFP := newCall.FramePointer
@@ -91,7 +92,6 @@ func CallAffPredicate(prgrm *ast.CXProgram, fn *ast.CXFunction, predValue []byte
 	}
 
 	prevCall.Line--
-
 	return types.GetSlice_byte(prgrm.Memory, ast.GetFinalOffset(prgrm,
 		newCall.FramePointer,
 		newCall.Operator.Outputs[0]),
@@ -189,7 +189,12 @@ func QueryArgument(prgrm *ast.CXProgram, fn *ast.CXFunction, expr *ast.CXExpress
 		panic(err)
 	}
 
-	for _, ex := range cxAtomicOp.Function.Expressions {
+	cxAtomicOpFunction, err := prgrm.GetFunctionFromArray(cxAtomicOp.Function)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, ex := range cxAtomicOpFunction.Expressions {
 		exCXAtomicOp, _, _, err := prgrm.GetOperation(ex)
 		if err != nil {
 			panic(err)
@@ -212,7 +217,12 @@ func QueryExpressions(prgrm *ast.CXProgram, fn *ast.CXFunction, expr *ast.CXExpr
 		panic(err)
 	}
 
-	for _, ex := range cxAtomicOp.Function.Expressions {
+	cxAtomicOpFunction, err := prgrm.GetFunctionFromArray(cxAtomicOp.Function)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, ex := range cxAtomicOpFunction.Expressions {
 		exCXAtomicOp, _, _, err := prgrm.GetOperation(ex)
 		if err != nil {
 			panic(err)
@@ -692,6 +702,7 @@ func opAffOn(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) 
 	prevExpr := prevFn.CurrentExpression
 
 	call := prgrm.GetCurrentCall()
+
 	expr := call.Operator.Expressions[call.Line]
 	fp := inputs[0].FramePointer
 
@@ -701,7 +712,12 @@ func opAffOn(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) 
 	if err != nil {
 		panic(err)
 	}
-	var tgtFn = ast.CXFunction(*cxAtomicOp.Function)
+	cxAtomicOpFunction, err := prgrm.GetFunctionFromArray(cxAtomicOp.Function)
+	if err != nil {
+		panic(err)
+	}
+
+	var tgtFn = ast.CXFunction(*cxAtomicOpFunction)
 	var tgtExpr = ast.CXExpression(*prevExpr)
 
 	// processing the target
@@ -753,12 +769,18 @@ func opAffOf(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) 
 	if err != nil {
 		panic(err)
 	}
+
+	cxAtomicOpFunction, err := prgrm.GetFunctionFromArray(cxAtomicOp.Function)
+	if err != nil {
+		panic(err)
+	}
+
 	opPkg, err := prgrm.GetPackageFromArray(cxAtomicOp.Package)
 	if err != nil {
 		panic(err)
 	}
 	var tgtPkg = ast.CXPackage(*opPkg)
-	var tgtFn = ast.CXFunction(*cxAtomicOp.Function)
+	var tgtFn = ast.CXFunction(*cxAtomicOpFunction)
 	var tgtExpr = ast.CXExpression(*prevExpr)
 
 	// processing the target
@@ -888,7 +910,12 @@ func opAffInform(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXVal
 		panic(err)
 	}
 
-	var tgtFn = ast.CXFunction(*cxAtomicOp.Function)
+	cxAtomicOpFunction, err := prgrm.GetFunctionFromArray(cxAtomicOp.Function)
+	if err != nil {
+		panic(err)
+	}
+
+	var tgtFn = ast.CXFunction(*cxAtomicOpFunction)
 	var tgtExpr = ast.CXExpression(*prevExpr)
 
 	// processing the target
@@ -1011,7 +1038,12 @@ func opAffRequest(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXVa
 		panic(err)
 	}
 
-	var tgtFn = ast.CXFunction(*cxAtomicOp.Function)
+	cxAtomicOpFunction, err := prgrm.GetFunctionFromArray(cxAtomicOp.Function)
+	if err != nil {
+		panic(err)
+	}
+
+	var tgtFn = ast.CXFunction(*cxAtomicOpFunction)
 	var tgtExpr = ast.CXExpression(*prevExpr)
 
 	// processing the target

--- a/cx/opcodes/opcodes.go
+++ b/cx/opcodes/opcodes.go
@@ -62,6 +62,7 @@ func RegisterOperator(name string, handler ast.OpcodeHandler, inputs []*ast.CXAr
 func MakeNativeFunction(opCode int, inputs []*ast.CXArgument, outputs []*ast.CXArgument) *ast.CXFunction {
 	fn := &ast.CXFunction{
 		AtomicOPCode: opCode,
+		Index:        -1,
 	}
 
 	offset := types.Pointer(0)

--- a/cx/packages/cxfx/event.go
+++ b/cx/packages/cxfx/event.go
@@ -70,7 +70,12 @@ func (cb *CXCallback) Init(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs [
 		panic(err)
 	}
 
-	cb.init(prgrm, inputs, outputs, cxAtomicOp.Package.Name)
+	pkg, err := prgrm.GetPackageFromArray(cxAtomicOp.Package)
+	if err != nil {
+		panic(err)
+	}
+
+	cb.init(prgrm, inputs, outputs, pkg.Name)
 }
 
 func (cb *CXCallback) InitEx(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXValue) {

--- a/cx/packages/regexp/op_regexp.go
+++ b/cx/packages/regexp/op_regexp.go
@@ -34,7 +34,7 @@ func regexpCompile(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXV
 	}
 
 	// Extracting `regexp`'s Regexp structure.
-	regexpType, err := regexpPkg.GetStruct("Regexp")
+	regexpType, err := regexpPkg.GetStruct(prgrm, "Regexp")
 	if err != nil {
 		panic(err)
 	}
@@ -101,7 +101,7 @@ func opRegexpFind(prgrm *ast.CXProgram, inputs []ast.CXValue, outputs []ast.CXVa
 	}
 
 	// Extracting `regexp`'s Regexp structure.
-	regexpType, err := regexpPkg.GetStruct("Regexp")
+	regexpType, err := regexpPkg.GetStruct(prgrm, "Regexp")
 	if err != nil {
 		panic(err)
 	}

--- a/cxparser/actions/assignment.go
+++ b/cxparser/actions/assignment.go
@@ -325,7 +325,7 @@ func Assignment(prgrm *ast.CXProgram, to []*ast.CXExpression, assignOp string, f
 
 			if fromCXAtomicOp.Operator.AtomicOPCode != constants.OP_IDENTITY {
 				// it's a short variable declaration
-				toCXAtomicOp.Outputs[0].Size = ast.Natives[fromCXAtomicOp.Operator.AtomicOPCode].Outputs[0].Size
+				toCXAtomicOp.Outputs[0].Size = fromCXAtomicOp.Operator.Outputs[0].Size
 				toCXAtomicOp.Outputs[0].Type = fromCXAtomicOp.Operator.Outputs[0].Type
 				toCXAtomicOp.Outputs[0].PointerTargetType = fromCXAtomicOp.Operator.Outputs[0].PointerTargetType
 				toCXAtomicOp.Outputs[0].Lengths = fromCXAtomicOp.Operator.Outputs[0].Lengths

--- a/cxparser/actions/assignment.go
+++ b/cxparser/actions/assignment.go
@@ -140,13 +140,13 @@ func ShortAssignment(prgrm *ast.CXProgram, expr *ast.CXExpression, exprCXLine *a
 
 	cxAtomicOp.AddInput(toCXAtomicOp.Outputs[0])
 	cxAtomicOp.AddOutput(toCXAtomicOp.Outputs[0])
-	cxAtomicOp.Package = pkg
+	cxAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 	if fromCXAtomicOp.Operator == nil {
 		cxAtomicOp.AddInput(fromCXAtomicOp.Outputs[0])
 	} else {
 		sym := ast.MakeArgument(MakeGenSym(constants.LOCAL_PREFIX), CurrentFile, LineNo).AddType(fromCXAtomicOp.Inputs[0].Type)
-		sym.Package = pkg
+		sym.Package = ast.CXPackageIndex(pkg.Index)
 		sym.PreviouslyDeclared = true
 		fromCXAtomicOp.AddOutput(sym)
 		cxAtomicOp.AddInput(sym)
@@ -215,7 +215,7 @@ func Assignment(prgrm *ast.CXProgram, to []*ast.CXExpression, assignOp string, f
 		if err != nil {
 			panic(err)
 		}
-		cxAtomicOp.Package = pkg
+		cxAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 		var sym *ast.CXArgument
 
@@ -241,7 +241,7 @@ func Assignment(prgrm *ast.CXProgram, to []*ast.CXExpression, assignOp string, f
 			sym.IsSlice = outTypeArg.IsSlice
 			// sym.IsSlice = from[idx].Operator.ProgramOutput[0].IsSlice
 		}
-		sym.Package = pkg
+		sym.Package = ast.CXPackageIndex(pkg.Index)
 		sym.PreviouslyDeclared = true
 		sym.IsShortAssignmentDeclaration = true
 

--- a/cxparser/actions/declarations.go
+++ b/cxparser/actions/declarations.go
@@ -272,6 +272,8 @@ func DeclareImport(prgrm *ast.CXProgram, name string, currentFile string, lineNo
 		panic(err)
 	}
 
+	pkgIdx := prgrm.GetCurrentPackageIndex()
+
 	// Checking if it's a package in the CX workspace by trying to find a
 	// slash (/) in the name.
 	// We start backwards and we stop if we find a slash.
@@ -311,7 +313,7 @@ func DeclareImport(prgrm *ast.CXProgram, name string, currentFile string, lineNo
 		imp := ast.MakePackage(ident)
 		pkg.AddImport(imp)
 		prgrm.AddPackage(imp)
-		prgrm.CurrentPackage = pkg
+		prgrm.CurrentPackage = pkgIdx
 
 		if ident == "aff" {
 			AffordanceStructs(prgrm, imp, currentFile, lineNo)

--- a/cxparser/actions/declarations.go
+++ b/cxparser/actions/declarations.go
@@ -104,7 +104,7 @@ func DeclareGlobalInPackage(prgrm *ast.CXProgram, pkg *ast.CXPackage,
 				*glbl = *declaration_specifiers
 
 				if initializer[len(initializer)-1].IsStructLiteral() {
-					index := prgrm.AddCXAtomicOp(&ast.CXAtomicOperator{Outputs: []*ast.CXArgument{glbl}})
+					index := prgrm.AddCXAtomicOp(&ast.CXAtomicOperator{Outputs: []*ast.CXArgument{glbl}, Function: -1})
 					initializer = StructLiteralAssignment(prgrm,
 						[]*ast.CXExpression{
 							{
@@ -181,7 +181,7 @@ func DeclareGlobalInPackage(prgrm *ast.CXProgram, pkg *ast.CXPackage,
 				declaration_specifiers.Package = ast.CXPackageIndex(pkg.Index)
 
 				if initializer[len(initializer)-1].IsStructLiteral() {
-					index := prgrm.AddCXAtomicOp(&ast.CXAtomicOperator{Outputs: []*ast.CXArgument{declaration_specifiers}})
+					index := prgrm.AddCXAtomicOp(&ast.CXAtomicOperator{Outputs: []*ast.CXArgument{declaration_specifiers}, Function: -1})
 					initializer = StructLiteralAssignment(prgrm,
 						[]*ast.CXExpression{
 							{

--- a/cxparser/actions/declarations.go
+++ b/cxparser/actions/declarations.go
@@ -39,7 +39,7 @@ func DeclareGlobal(prgrm *ast.CXProgram, declarator *ast.CXArgument, declaration
 func DeclareGlobalInPackage(prgrm *ast.CXProgram, pkg *ast.CXPackage,
 	declarator *ast.CXArgument, declaration_specifiers *ast.CXArgument,
 	initializer []*ast.CXExpression, doesInitialize bool) {
-	declaration_specifiers.Package = pkg
+	declaration_specifiers.Package = ast.CXPackageIndex(pkg.Index)
 
 	// Treat the name a bit different whether it's defined already or not.
 	if glbl, err := pkg.GetGlobal(declarator.Name); err == nil {
@@ -161,7 +161,7 @@ func DeclareGlobalInPackage(prgrm *ast.CXProgram, pkg *ast.CXPackage,
 				declaration_specifiers.Offset = offExprAtomicOp.Outputs[0].Offset
 				declaration_specifiers.Size = offExprAtomicOp.Outputs[0].Size
 				declaration_specifiers.TotalSize = offExprAtomicOp.Outputs[0].TotalSize
-				declaration_specifiers.Package = pkg
+				declaration_specifiers.Package = ast.CXPackageIndex(pkg.Index)
 
 				initializerAtomicOp.Operator = ast.Natives[constants.OP_IDENTITY]
 				initializerAtomicOp.AddInput(initializerAtomicOp.Outputs[0])
@@ -178,7 +178,7 @@ func DeclareGlobalInPackage(prgrm *ast.CXProgram, pkg *ast.CXPackage,
 				declaration_specifiers.Offset = offExprAtomicOp.Outputs[0].Offset
 				declaration_specifiers.Size = offExprAtomicOp.Outputs[0].Size
 				declaration_specifiers.TotalSize = offExprAtomicOp.Outputs[0].TotalSize
-				declaration_specifiers.Package = pkg
+				declaration_specifiers.Package = ast.CXPackageIndex(pkg.Index)
 
 				if initializer[len(initializer)-1].IsStructLiteral() {
 					index := prgrm.AddCXAtomicOp(&ast.CXAtomicOperator{Outputs: []*ast.CXArgument{declaration_specifiers}})
@@ -214,7 +214,7 @@ func DeclareGlobalInPackage(prgrm *ast.CXProgram, pkg *ast.CXPackage,
 			declaration_specifiers.Offset = offExprAtomicOp.Outputs[0].Offset
 			declaration_specifiers.Size = offExprAtomicOp.Outputs[0].Size
 			declaration_specifiers.TotalSize = offExprAtomicOp.Outputs[0].TotalSize
-			declaration_specifiers.Package = pkg
+			declaration_specifiers.Package = ast.CXPackageIndex(pkg.Index)
 
 			pkg.AddGlobal(declaration_specifiers)
 		}
@@ -272,8 +272,6 @@ func DeclareImport(prgrm *ast.CXProgram, name string, currentFile string, lineNo
 		panic(err)
 	}
 
-	pkgIdx := prgrm.GetCurrentPackageIndex()
-
 	// Checking if it's a package in the CX workspace by trying to find a
 	// slash (/) in the name.
 	// We start backwards and we stop if we find a slash.
@@ -295,14 +293,14 @@ func DeclareImport(prgrm *ast.CXProgram, name string, currentFile string, lineNo
 	}
 
 	// If the package is already imported, then there is nothing more to be done.
-	if _, err := pkg.GetImport(ident); err == nil {
+	if _, err := pkg.GetImport(prgrm, ident); err == nil {
 		return
 	}
 
 	// If the package is already defined in the program, just add it to
 	// the importing package.
 	if imp, err := prgrm.GetPackage(ident); err == nil {
-		pkg.AddImport(imp)
+		pkg.AddImport(prgrm, imp)
 		return
 	}
 
@@ -311,12 +309,17 @@ func DeclareImport(prgrm *ast.CXProgram, name string, currentFile string, lineNo
 	// something is panic-level wrong.
 	if constants2.IsCorePackage(ident) {
 		imp := ast.MakePackage(ident)
-		pkg.AddImport(imp)
-		prgrm.AddPackage(imp)
-		prgrm.CurrentPackage = pkgIdx
+		impIdx := prgrm.AddPackage(imp)
+		newImp, err := prgrm.GetPackageFromArray(impIdx)
+		if err != nil {
+			panic(err)
+		}
+		pkg.AddImport(prgrm, newImp)
+
+		prgrm.CurrentPackage = ast.CXPackageIndex(pkg.Index)
 
 		if ident == "aff" {
-			AffordanceStructs(prgrm, imp, currentFile, lineNo)
+			AffordanceStructs(prgrm, newImp, currentFile, lineNo)
 		}
 	} else {
 		// This should never happen.
@@ -353,11 +356,11 @@ func DeclareLocal(prgrm *ast.CXProgram, declarator *ast.CXArgument, declarationS
 	if err != nil {
 		panic(err)
 	}
-	cxAtomicOp.Package = pkg
+	cxAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 	declarationSpecifiers.Name = declarator.Name
 	declarationSpecifiers.ArgDetails.FileLine = declarator.ArgDetails.FileLine
-	declarationSpecifiers.Package = pkg
+	declarationSpecifiers.Package = ast.CXPackageIndex(pkg.Index)
 	declarationSpecifiers.PreviouslyDeclared = true
 	cxAtomicOp.AddOutput(declarationSpecifiers)
 
@@ -383,7 +386,7 @@ func DeclareLocal(prgrm *ast.CXProgram, declarator *ast.CXArgument, declarationS
 			if err != nil {
 				panic(err)
 			}
-			cxExprAtomicOp.Package = pkg
+			cxExprAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 			initOut := initializerAtomicOp.Outputs[0]
 			// CX checks the output of an expression to determine if it's being passed
@@ -424,11 +427,11 @@ func DeclareLocal(prgrm *ast.CXProgram, declarator *ast.CXArgument, declarationS
 		if err != nil {
 			panic(err)
 		}
-		cxAtomicOp.Package = pkg
+		cxAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 		declarationSpecifiers.Name = declarator.Name
 		declarationSpecifiers.ArgDetails.FileLine = declarator.ArgDetails.FileLine
-		declarationSpecifiers.Package = pkg
+		declarationSpecifiers.Package = ast.CXPackageIndex(pkg.Index)
 		declarationSpecifiers.PreviouslyDeclared = true
 		cxAtomicOp.AddOutput(declarationSpecifiers)
 
@@ -528,7 +531,7 @@ func DeclarationSpecifiersStruct(prgrm *ast.CXProgram, ident string, pkgName str
 
 	if isExternal {
 		// custom type in an imported package
-		imp, err := pkg.GetImport(pkgName)
+		imp, err := pkg.GetImport(prgrm, pkgName)
 		if err != nil {
 			panic(err)
 		}
@@ -545,7 +548,7 @@ func DeclarationSpecifiersStruct(prgrm *ast.CXProgram, ident string, pkgName str
 		arg.Size = strct.Size
 		arg.TotalSize = strct.Size
 
-		arg.Package = pkg
+		arg.Package = ast.CXPackageIndex(pkg.Index)
 		arg.DeclarationSpecifiers = append(arg.DeclarationSpecifiers, constants.DECL_STRUCT)
 
 		return arg
@@ -563,7 +566,7 @@ func DeclarationSpecifiersStruct(prgrm *ast.CXProgram, ident string, pkgName str
 		arg.StructType = strct
 		arg.Size = strct.Size
 		arg.TotalSize = strct.Size
-		arg.Package = pkg
+		arg.Package = ast.CXPackageIndex(pkg.Index)
 
 		return arg
 	}

--- a/cxparser/actions/expressions.go
+++ b/cxparser/actions/expressions.go
@@ -31,7 +31,7 @@ func IterationExpressions(prgrm *ast.CXProgram, init []*ast.CXExpression, cond [
 	if err != nil {
 		panic(err)
 	}
-	upExprAtomicOp.Package = pkg
+	upExprAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 	trueArg := WritePrimary(prgrm, types.BOOL, encoder.Serialize(true), false)
 	trueArgAtomicOp, err := prgrm.GetCXAtomicOpFromExpressions(trueArg, 0)
@@ -53,7 +53,7 @@ func IterationExpressions(prgrm *ast.CXProgram, init []*ast.CXExpression, cond [
 	if err != nil {
 		panic(err)
 	}
-	downExprAtomicOp.Package = pkg
+	downExprAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 	lastCondAtomicOp, err := prgrm.GetCXAtomicOpFromExpressions(cond, len(cond)-1)
 	if err != nil {
@@ -62,13 +62,13 @@ func IterationExpressions(prgrm *ast.CXProgram, init []*ast.CXExpression, cond [
 
 	if len(lastCondAtomicOp.Outputs) < 1 {
 		predicate := ast.MakeArgument(MakeGenSym(constants.LOCAL_PREFIX), CurrentFile, LineNo).AddType(lastCondAtomicOp.Operator.Outputs[0].Type)
-		predicate.Package = pkg
+		predicate.Package = ast.CXPackageIndex(pkg.Index)
 		predicate.PreviouslyDeclared = true
 		lastCondAtomicOp.AddOutput(predicate)
 		downExprAtomicOp.AddInput(predicate)
 	} else {
 		predicate := lastCondAtomicOp.Outputs[0]
-		predicate.Package = pkg
+		predicate.Package = ast.CXPackageIndex(pkg.Index)
 		predicate.PreviouslyDeclared = true
 		downExprAtomicOp.AddInput(predicate)
 	}
@@ -137,7 +137,7 @@ func trueJmpExpressions(prgrm *ast.CXProgram, opcode int) []*ast.CXExpression {
 
 	exprAtomicOp.AddInput(trueArgAtomicOp.Outputs[0])
 
-	exprAtomicOp.Package = pkg
+	exprAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 	return []*ast.CXExpression{exprCXLine, expr}
 }
@@ -168,7 +168,7 @@ func SelectionExpressions(prgrm *ast.CXProgram, condExprs []*ast.CXExpression, t
 	if err != nil {
 		panic(err)
 	}
-	ifExprAtomicOp.Package = pkg
+	ifExprAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 	lastCondExprsAtomicOp, err := prgrm.GetCXAtomicOpFromExpressions(condExprs, len(condExprs)-1)
 	if err != nil {
@@ -211,7 +211,7 @@ func SelectionExpressions(prgrm *ast.CXProgram, condExprs []*ast.CXExpression, t
 	if err != nil {
 		panic(err)
 	}
-	skipExprAtomicOp.Package = pkg
+	skipExprAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 	trueArg := WritePrimary(prgrm, types.BOOL, encoder.Serialize(true), false)
 	trueArgAtomicOp, err := prgrm.GetCXAtomicOpFromExpressions(trueArg, 0)
@@ -290,7 +290,7 @@ func OperatorExpression(prgrm *ast.CXProgram, leftExprs []*ast.CXExpression, rig
 		name.TotalSize = ast.GetSize(lastLeftExprsAtomicOp.Operator.Outputs[0])
 		name.Type = lastLeftExprsAtomicOp.Operator.Outputs[0].Type
 		name.PointerTargetType = lastLeftExprsAtomicOp.Operator.Outputs[0].PointerTargetType
-		name.Package = pkg
+		name.Package = ast.CXPackageIndex(pkg.Index)
 		name.PreviouslyDeclared = true
 
 		lastLeftExprsAtomicOp.Outputs = append(lastLeftExprsAtomicOp.Outputs, name)
@@ -308,7 +308,7 @@ func OperatorExpression(prgrm *ast.CXProgram, leftExprs []*ast.CXExpression, rig
 		name.TotalSize = ast.GetSize(lastRightExprsAtomicOp.Operator.Outputs[0])
 		name.Type = lastRightExprsAtomicOp.Operator.Outputs[0].Type
 		name.PointerTargetType = lastRightExprsAtomicOp.Operator.Outputs[0].PointerTargetType
-		name.Package = pkg
+		name.Package = ast.CXPackageIndex(pkg.Index)
 		name.PreviouslyDeclared = true
 
 		lastRightExprsAtomicOp.Outputs = append(lastRightExprsAtomicOp.Outputs, name)
@@ -322,7 +322,7 @@ func OperatorExpression(prgrm *ast.CXProgram, leftExprs []*ast.CXExpression, rig
 	}
 
 	// we can't know the type until we compile the full function
-	cxAtomicOp.Package = pkg
+	cxAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 	if len(lastLeftExprsAtomicOp.Outputs[0].Indexes) > 0 || lastLeftExprsAtomicOp.Operator != nil {
 		// then it's a function call or an array access
@@ -394,7 +394,7 @@ func UnaryExpression(prgrm *ast.CXProgram, op string, prevExprs []*ast.CXExpress
 			if err != nil {
 				panic(err)
 			}
-			cxAtomicOp.Package = pkg
+			cxAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 			cxAtomicOp.AddInput(exprOut)
 
@@ -409,7 +409,7 @@ func UnaryExpression(prgrm *ast.CXProgram, op string, prevExprs []*ast.CXExpress
 			if err != nil {
 				panic(err)
 			}
-			cxAtomicOp.Package = pkg
+			cxAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 			cxAtomicOp.AddInput(exprOut)
 			prevExprs[len(prevExprs)-1] = expr
 		} else {
@@ -523,7 +523,7 @@ func AddJmpToReturnExpressions(prgrm *ast.CXProgram, exprs ReturnExpressions) []
 	// simulating a label so it gets executed without evaluating a predicate
 	cxAtomicOp.Label = MakeGenSym(constants.LABEL_PREFIX)
 	cxAtomicOp.ThenLines = types.MAX_INT32
-	cxAtomicOp.Package = pkg
+	cxAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 	retExprs = append(retExprs, exprCXLine, expr)
 

--- a/cxparser/actions/expressions.go
+++ b/cxparser/actions/expressions.go
@@ -431,7 +431,7 @@ func AssociateReturnExpressions(prgrm *ast.CXProgram, idx int, retExprs []*ast.C
 		panic(err)
 	}
 
-	fn, err = pkg.GetCurrentFunction()
+	fn, err = pkg.GetCurrentFunction(prgrm)
 	if err != nil {
 		panic(err)
 	}
@@ -487,7 +487,7 @@ func AddJmpToReturnExpressions(prgrm *ast.CXProgram, exprs ReturnExpressions) []
 		panic(err)
 	}
 
-	fn, err = pkg.GetCurrentFunction()
+	fn, err = pkg.GetCurrentFunction(prgrm)
 	if err != nil {
 		panic(err)
 	}

--- a/cxparser/actions/literals.go
+++ b/cxparser/actions/literals.go
@@ -26,7 +26,7 @@ func SliceLiteralExpression(prgrm *ast.CXProgram, typeCode types.Code, exprs []*
 		panic(err)
 	}
 
-	slcVarExprAtomicOp.Package = pkg
+	slcVarExprAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 	slcVar := ast.MakeArgument(symName, CurrentFile, LineNo)
 	slcVar.AddType(typeCode)
 	slcVar = DeclarationSpecifiers(slcVar, []types.Pointer{0}, constants.DECL_SLICE)
@@ -34,7 +34,7 @@ func SliceLiteralExpression(prgrm *ast.CXProgram, typeCode types.Code, exprs []*
 	slcVar.TotalSize = types.POINTER_SIZE
 
 	slcVarExprAtomicOp.AddOutput(slcVar)
-	slcVar.Package = pkg
+	slcVar.Package = ast.CXPackageIndex(pkg.Index)
 	slcVar.PreviouslyDeclared = true
 
 	result = append(result, slcVarExprCXLine, slcVarExpr)
@@ -53,9 +53,9 @@ func SliceLiteralExpression(prgrm *ast.CXProgram, typeCode types.Code, exprs []*
 
 		if expr.IsArrayLiteral() {
 			symInp := ast.MakeArgument(symName, CurrentFile, LineNo).AddType(typeCode)
-			symInp.Package = pkg
+			symInp.Package = ast.CXPackageIndex(pkg.Index)
 			symOut := ast.MakeArgument(symName, CurrentFile, LineNo).AddType(typeCode)
-			symOut.Package = pkg
+			symOut.Package = ast.CXPackageIndex(pkg.Index)
 
 			endPointsCounter++
 
@@ -66,7 +66,7 @@ func SliceLiteralExpression(prgrm *ast.CXProgram, typeCode types.Code, exprs []*
 				panic(err)
 			}
 
-			symExprAtomicOp.Package = pkg
+			symExprAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 			symExprAtomicOp.AddOutput(symOut)
 
 			if exprAtomicOp.Operator == nil {
@@ -113,12 +113,12 @@ func SliceLiteralExpression(prgrm *ast.CXProgram, typeCode types.Code, exprs []*
 
 	symOutput := ast.MakeArgument(symNameOutput, CurrentFile, LineNo).AddType(typeCode)
 	symOutput.IsSlice = true
-	symOutput.Package = pkg
+	symOutput.Package = ast.CXPackageIndex(pkg.Index)
 	symOutput.PreviouslyDeclared = true
 
 	symInput := ast.MakeArgument(symName, CurrentFile, LineNo).AddType(typeCode)
 	symInput.IsSlice = true
-	symInput.Package = pkg
+	symInput.Package = ast.CXPackageIndex(pkg.Index)
 
 	symInput.TotalSize = types.POINTER_SIZE
 	symOutput.TotalSize = types.POINTER_SIZE
@@ -130,7 +130,7 @@ func SliceLiteralExpression(prgrm *ast.CXProgram, typeCode types.Code, exprs []*
 		panic(err)
 	}
 
-	symExprAtomicOp.Package = pkg
+	symExprAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 	symExprAtomicOp.Outputs = append(symExprAtomicOp.Outputs, symOutput)
 	symExprAtomicOp.Inputs = append(symExprAtomicOp.Inputs, symInput)
 
@@ -160,7 +160,7 @@ func PrimaryStructLiteral(prgrm *ast.CXProgram, ident string, strctFlds []*ast.C
 				fld.PointerTargetType = cxAtomicOp.Outputs[0].PointerTargetType
 				expr.ExpressionType = ast.CXEXPR_STRUCT_LITERAL
 
-				cxAtomicOp.Outputs[0].Package = pkg
+				cxAtomicOp.Outputs[0].Package = ast.CXPackageIndex(pkg.Index)
 				// expr.ProgramOutput[0].Program = prgrm
 
 				if cxAtomicOp.Outputs[0].StructType == nil {
@@ -188,7 +188,7 @@ func PrimaryStructLiteral(prgrm *ast.CXProgram, ident string, strctFlds []*ast.C
 func PrimaryStructLiteralExternal(prgrm *ast.CXProgram, impName string, ident string, strctFlds []*ast.CXExpression) []*ast.CXExpression {
 	var result []*ast.CXExpression
 	if pkg, err := prgrm.GetCurrentPackage(); err == nil {
-		if _, err := pkg.GetImport(impName); err == nil {
+		if _, err := pkg.GetImport(prgrm, impName); err == nil {
 			if strct, err := prgrm.GetStruct(ident, impName); err == nil {
 				for _, expr := range strctFlds {
 					if expr.Type == ast.CX_LINE {
@@ -205,7 +205,7 @@ func PrimaryStructLiteralExternal(prgrm *ast.CXProgram, impName string, ident st
 
 					expr.ExpressionType = ast.CXEXPR_STRUCT_LITERAL
 
-					cxAtomicOp.Outputs[0].Package = pkg
+					cxAtomicOp.Outputs[0].Package = ast.CXPackageIndex(pkg.Index)
 					// expr.ProgramOutput[0].Program = prgrm
 
 					cxAtomicOp.Outputs[0].StructType = strct
@@ -245,14 +245,14 @@ func ArrayLiteralExpression(prgrm *ast.CXProgram, arrSizes []types.Pointer, type
 		panic(err)
 	}
 
-	arrVarExprAtomicOp.Package = pkg
+	arrVarExprAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 	arrVar := ast.MakeArgument(symName, CurrentFile, LineNo)
 	arrVar = DeclarationSpecifiers(arrVar, arrSizes, constants.DECL_ARRAY)
 	arrVar.AddType(typeCode)
 	arrVar.TotalSize = arrVar.Size * TotalLength(arrVar.Lengths)
 
 	arrVarExprAtomicOp.AddOutput(arrVar)
-	arrVar.Package = pkg
+	arrVar.Package = ast.CXPackageIndex(pkg.Index)
 	arrVar.PreviouslyDeclared = true
 
 	result = append(result, arrVarExprCXLine, arrVarExpr)
@@ -271,7 +271,7 @@ func ArrayLiteralExpression(prgrm *ast.CXProgram, arrSizes []types.Pointer, type
 			expr.ExpressionType = ast.CXEXPR_UNUSED
 
 			sym := ast.MakeArgument(symName, CurrentFile, LineNo).AddType(typeCode)
-			sym.Package = pkg
+			sym.Package = ast.CXPackageIndex(pkg.Index)
 			sym.PreviouslyDeclared = true
 
 			if sym.Type == types.STR || sym.Type == types.AFF {
@@ -325,14 +325,14 @@ func ArrayLiteralExpression(prgrm *ast.CXProgram, arrSizes []types.Pointer, type
 	symOutput := ast.MakeArgument(symNameOutput, CurrentFile, LineNo).AddType(typeCode)
 	// symOutput.Lengths = append(symOutput.Lengths, arrSizes[len(arrSizes)-1])
 	symOutput.Lengths = arrSizes
-	symOutput.Package = pkg
+	symOutput.Package = ast.CXPackageIndex(pkg.Index)
 	symOutput.PreviouslyDeclared = true
 	symOutput.TotalSize = symOutput.Size * TotalLength(symOutput.Lengths)
 
 	symInput := ast.MakeArgument(symName, CurrentFile, LineNo).AddType(typeCode)
 	// symInput.Lengths = append(symInput.Lengths, arrSizes[len(arrSizes)-1])
 	symInput.Lengths = arrSizes
-	symInput.Package = pkg
+	symInput.Package = ast.CXPackageIndex(pkg.Index)
 	symInput.PreviouslyDeclared = true
 	symInput.TotalSize = symInput.Size * TotalLength(symInput.Lengths)
 
@@ -342,7 +342,7 @@ func ArrayLiteralExpression(prgrm *ast.CXProgram, arrSizes []types.Pointer, type
 	if err != nil {
 		panic(err)
 	}
-	symExprAtomicOp.Package = pkg
+	symExprAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 	symExprAtomicOp.Outputs = append(symExprAtomicOp.Outputs, symOutput)
 	symExprAtomicOp.Inputs = append(symExprAtomicOp.Inputs, symInput)
 

--- a/cxparser/actions/misc.go
+++ b/cxparser/actions/misc.go
@@ -54,7 +54,7 @@ func WritePrimary(prgrm *ast.CXProgram, typeCode types.Code, byts []byte, isSlic
 	if pkg, err := prgrm.GetCurrentPackage(); err == nil {
 		arg := ast.MakeArgument("", CurrentFile, LineNo)
 		arg.AddType(typeCode)
-		arg.Package = pkg
+		arg.Package = ast.CXPackageIndex(pkg.Index)
 
 		size := types.Cast_int_to_ptr(len(byts))
 
@@ -102,7 +102,7 @@ func WritePrimary(prgrm *ast.CXProgram, typeCode types.Code, byts []byte, isSlic
 			panic(err)
 		}
 
-		cxAtomicOp.Package = pkg
+		cxAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 		cxAtomicOp.AddOutput(arg)
 		return []*ast.CXExpression{expr}
 	} else {
@@ -123,7 +123,7 @@ func StructLiteralFields(prgrm *ast.CXProgram, ident string) *ast.CXExpression {
 		arg := ast.MakeArgument("", CurrentFile, LineNo)
 		arg.AddType(types.IDENTIFIER)
 		arg.Name = ident
-		arg.Package = pkg
+		arg.Package = ast.CXPackageIndex(pkg.Index)
 
 		expr := ast.MakeAtomicOperatorExpression(prgrm, nil)
 		cxAtomicOp, _, _, err := prgrm.GetOperation(expr)
@@ -131,7 +131,7 @@ func StructLiteralFields(prgrm *ast.CXProgram, ident string) *ast.CXExpression {
 			panic(err)
 		}
 		cxAtomicOp.AddOutput(arg)
-		cxAtomicOp.Package = pkg
+		cxAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 		return expr
 	} else {
@@ -254,7 +254,7 @@ func PrimaryIdentifier(prgrm *ast.CXProgram, ident string) []*ast.CXExpression {
 		arg.AddType(types.IDENTIFIER)
 		// arg.Typ = "ident"
 		arg.Name = ident
-		arg.Package = pkg
+		arg.Package = ast.CXPackageIndex(pkg.Index)
 
 		// exprCXLine := ast.MakeCXLineExpression(prgrm, CurrentFile, LineNo, LineStr)
 		// expr := &cxcore.CXExpression{ProgramOutput: []*cxcore.CXArgument{arg}}
@@ -264,7 +264,7 @@ func PrimaryIdentifier(prgrm *ast.CXProgram, ident string) []*ast.CXExpression {
 			panic(err)
 		}
 		cxAtomicOp.AddOutput(arg)
-		cxAtomicOp.Package = pkg
+		cxAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 
 		return []*ast.CXExpression{expr}
 	} else {

--- a/cxparser/actions/misc.go
+++ b/cxparser/actions/misc.go
@@ -234,7 +234,11 @@ func AffordanceStructs(prgrm *ast.CXProgram, pkg *ast.CXPackage, currentFile str
 	prgrmFldFreeHeap.TotalSize = types.I64.Size()
 
 	// prgrmFldCaller := cxcore.MakeField("Caller", cxcore.TYPE_STRUCT, "", 0)
-	prgrmFldCaller := DeclarationSpecifiersStruct(prgrm, callStrct.Name, callStrct.Package.Name, false, currentFile, lineNo)
+	strctPkg, err := prgrm.GetPackageFromArray(callStrct.Package)
+	if err != nil {
+		panic(err)
+	}
+	prgrmFldCaller := DeclarationSpecifiersStruct(prgrm, callStrct.Name, strctPkg.Name, false, currentFile, lineNo)
 	prgrmFldCaller.Name = "Caller"
 
 	prgrmStrct.AddField(prgrmFldCallCounter)

--- a/cxparser/cxparsing/cxparsing.go
+++ b/cxparser/cxparsing/cxparsing.go
@@ -67,7 +67,7 @@ func ParseSourceCode(sourceCode []*os.File, fileNames []string) {
 	if osPkg, err := actions.AST.GetPackage(constants.OS_PKG); err == nil {
 		if _, err := osPkg.GetGlobal(constants.OS_ARGS); err != nil {
 			arg0 := ast.MakeArgument(constants.OS_ARGS, "", -1).AddType(types.UNDEFINED)
-			arg0.Package = osPkg
+			arg0.Package = ast.CXPackageIndex(osPkg.Index)
 
 			arg1 := ast.MakeArgument(constants.OS_ARGS, "", -1).AddType(types.STR)
 			arg1 = actions.DeclarationSpecifiers(arg1, []types.Pointer{0}, constants.DECL_BASIC)

--- a/cxparser/cxparsing/utils.go
+++ b/cxparser/cxparsing/utils.go
@@ -300,12 +300,16 @@ func AddInitFunction(prgrm *ast.CXProgram) error {
 	}
 
 	initFn := ast.MakeFunction(constants.SYS_INIT_FUNC, actions.CurrentFile, actions.LineNo)
-	mainPkg.AddFunction(initFn)
+	_, fnIdx := mainPkg.AddFunction(prgrm, initFn)
+	initFnFromArr, err := prgrm.GetFunctionFromArray(fnIdx)
+	if err != nil {
+		return err
+	}
 
 	//Init Expressions
-	actions.FunctionDeclaration(prgrm, initFn, nil, nil, prgrm.SysInitExprs)
+	actions.FunctionDeclaration(prgrm, initFnFromArr, nil, nil, prgrm.SysInitExprs)
 
-	if _, err := mainPkg.SelectFunction(constants.MAIN_FUNC); err != nil {
+	if _, err := mainPkg.SelectFunction(prgrm, constants.MAIN_FUNC); err != nil {
 		return err
 	}
 	return nil

--- a/cxparser/cxparsing/utils.go
+++ b/cxparser/cxparsing/utils.go
@@ -84,7 +84,11 @@ func Preliminarystage(srcStrs, srcNames []string) int {
 					if pkg, err := cxpartialparsing.Program.GetPackage(match[len(match)-1]); err != nil {
 						// then it hasn't been added
 						newPkg := ast.MakePackage(match[len(match)-1])
-						cxpartialparsing.Program.AddPackage(newPkg)
+						pkgIdx := cxpartialparsing.Program.AddPackage(newPkg)
+						newPkg, err = cxpartialparsing.Program.GetPackageFromArray(pkgIdx)
+						if err != nil {
+							panic(err)
+						}
 						prePkg = newPkg
 					} else {
 						prePkg = pkg
@@ -184,7 +188,11 @@ func Preliminarystage(srcStrs, srcNames []string) int {
 					if pkg, err := cxpartialparsing.Program.GetPackage(match[len(match)-1]); err != nil {
 						// then it hasn't been added
 						prePkg = ast.MakePackage(match[len(match)-1])
-						cxpartialparsing.Program.AddPackage(prePkg)
+						pkgIdx := cxpartialparsing.Program.AddPackage(prePkg)
+						prePkg, err = cxpartialparsing.Program.GetPackageFromArray(pkgIdx)
+						if err != nil {
+							panic(err)
+						}
 					} else {
 						prePkg = pkg
 					}
@@ -256,7 +264,7 @@ func Preliminarystage(srcStrs, srcNames []string) int {
 						// then it hasn't been added
 						arg := ast.MakeArgument(match[len(match)-1], "", 0)
 						arg.Offset = types.InvalidPointer
-						arg.Package = prePkg
+						arg.Package = ast.CXPackageIndex(prePkg.Index)
 						prePkg.AddGlobal(arg)
 					}
 				}

--- a/cxparser/cxparsingcompletor/init.go
+++ b/cxparser/cxparsingcompletor/init.go
@@ -1,8 +1,8 @@
 package parsingcompletor
 
 import (
-	"github.com/skycoin/cx/cx/opcodes"
 	cxinit "github.com/skycoin/cx/cx/init"
+	"github.com/skycoin/cx/cx/opcodes"
 )
 
 var Initialized bool

--- a/cxparser/cxparsingcompletor/parsingcompletor.go
+++ b/cxparser/cxparsingcompletor/parsingcompletor.go
@@ -2292,7 +2292,7 @@ yydefault:
 		yyDollar = yyS[yypt-2 : yypt+1]
 //line cxparser/cxparsingcompletor/parsingcompletor.y:1173
 		{
-			var lastFirstAtomicOp *ast.CXAtomicOperator
+			lastFirstAtomicOp := &ast.CXAtomicOperator{}
 			var err error
 
 			if len(yyDollar[1].expressions) > 0 {

--- a/cxparser/cxparsingcompletor/parsingcompletor.go
+++ b/cxparser/cxparsingcompletor/parsingcompletor.go
@@ -1373,7 +1373,7 @@ yydefault:
 				arg := ast.MakeArgument("", actions.CurrentFile, actions.LineNo)
 				arg.AddType(types.UNDEFINED)
 				arg.Name = yyDollar[1].tok
-				arg.Package = pkg
+				arg.Package = ast.CXPackageIndex(pkg.Index)
 				yyVAL.argument = arg
 			} else {
 				panic(err)
@@ -2457,7 +2457,7 @@ yydefault:
 				panic(err)
 			}
 
-			cxAtomicOp.Package = pkg
+			cxAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
 			cxAtomicOp.Label = yyDollar[2].tok
 			yyVAL.expressions = []*ast.CXExpression{exprCXLine, expr}
 

--- a/cxparser/cxparsingcompletor/parsingcompletor.y
+++ b/cxparser/cxparsingcompletor/parsingcompletor.y
@@ -1171,7 +1171,7 @@ expression_statement:
                 { $$ = nil }
 	|       expression SEMICOLON
                 {          
-                        var lastFirstAtomicOp *ast.CXAtomicOperator
+                        lastFirstAtomicOp:=&ast.CXAtomicOperator{}
                         var err error
 
                         if len($1) > 0 {
@@ -1182,7 +1182,7 @@ expression_statement:
                         }
                        
 
-			if len($1) > 0 && lastFirstAtomicOp.Operator == nil && !$1[len($1) - 1].IsMethodCall() {
+			if len($1) > 0 && lastFirstAtomicOp.Operator == nil  && !$1[len($1) - 1].IsMethodCall() {
 				outs := lastFirstAtomicOp.Outputs
 				if len(outs) > 0 {
 					println(ast.CompilationError(outs[0].ArgDetails.FileName, outs[0].ArgDetails.FileLine), "invalid expression")

--- a/cxparser/cxparsingcompletor/parsingcompletor.y
+++ b/cxparser/cxparsingcompletor/parsingcompletor.y
@@ -348,7 +348,7 @@ direct_declarator:
 				arg := ast.MakeArgument("", actions.CurrentFile, actions.LineNo)
                 arg.AddType(types.UNDEFINED)
 				arg.Name = $1
-				arg.Package = pkg
+				arg.Package = ast.CXPackageIndex(pkg.Index)
 				$$ = arg
 			} else {
 				panic(err)
@@ -1313,7 +1313,7 @@ jump_statement: GOTO IDENTIFIER SEMICOLON
                                 panic(err)
                         }
 
-                        cxAtomicOp.Package = pkg
+                        cxAtomicOp.Package = ast.CXPackageIndex(pkg.Index)
                         cxAtomicOp.Label = $2
                         $$ = []*ast.CXExpression{exprCXLine,expr}
 			

--- a/cxparser/cxpartialparsing/cxpartialparsing.go
+++ b/cxparser/cxpartialparsing/cxpartialparsing.go
@@ -374,7 +374,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line cxparser/cxpartialparsing/cxpartialparsing.y:783
+//line cxparser/cxpartialparsing/cxpartialparsing.y:784
 
 //line yacctab:1
 var yyExca = [...]int{
@@ -1293,9 +1293,8 @@ yydefault:
 
 			if pkg, err := Program.GetCurrentPackage(); err == nil {
 				fn := ast.MakeFunction(fnName, CurrentFileName, lineNo)
-				pkg.AddFunction(fn)
-
 				fn.AddInput(yyDollar[3].arguments[0])
+				pkg.AddFunction(fn)
 
 				yyVAL.function = fn
 			} else {
@@ -1304,43 +1303,43 @@ yydefault:
 		}
 	case 19:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:257
+//line cxparser/cxpartialparsing/cxpartialparsing.y:258
 		{
 			yyVAL.arguments = nil
 		}
 	case 20:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:259
+//line cxparser/cxpartialparsing/cxpartialparsing.y:260
 		{
 			yyVAL.arguments = yyDollar[2].arguments
 		}
 	case 21:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:264
+//line cxparser/cxpartialparsing/cxpartialparsing.y:265
 		{
 			PreFunctionDeclaration(yyDollar[1].function, yyDollar[2].arguments, nil)
 		}
 	case 22:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:268
+//line cxparser/cxpartialparsing/cxpartialparsing.y:269
 		{
 			PreFunctionDeclaration(yyDollar[1].function, yyDollar[2].arguments, yyDollar[3].arguments)
 		}
 	case 24:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:280
+//line cxparser/cxpartialparsing/cxpartialparsing.y:281
 		{
 			yyVAL.arguments = []*ast.CXArgument{yyDollar[1].argument}
 		}
 	case 25:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:284
+//line cxparser/cxpartialparsing/cxpartialparsing.y:285
 		{
 			yyVAL.arguments = append(yyDollar[1].arguments, yyDollar[3].argument)
 		}
 	case 26:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:291
+//line cxparser/cxpartialparsing/cxpartialparsing.y:292
 		{
 			yyDollar[2].argument.Name = yyDollar[1].argument.Name
 			yyDollar[2].argument.Package = yyDollar[1].argument.Package
@@ -1349,13 +1348,13 @@ yydefault:
 		}
 	case 30:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:309
+//line cxparser/cxpartialparsing/cxpartialparsing.y:310
 		{
 			if pkg, err := Program.GetCurrentPackage(); err == nil {
 				arg := ast.MakeArgument("", actions.CurrentFile, actions.LineNo)
 				arg.AddType(types.UNDEFINED)
 				arg.Name = yyDollar[1].tok
-				arg.Package = pkg
+				arg.Package = ast.CXPackageIndex(pkg.Index)
 				yyVAL.argument = arg
 			} else {
 				panic(err)
@@ -1363,53 +1362,53 @@ yydefault:
 		}
 	case 31:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:321
+//line cxparser/cxpartialparsing/cxpartialparsing.y:322
 		{
 			yyVAL.argument = yyDollar[2].argument
 		}
 	case 32:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:325
+//line cxparser/cxpartialparsing/cxpartialparsing.y:326
 		{
 			arg := actions.DeclarationSpecifiersStruct(Program, yyDollar[1].tok, "", false, actions.CurrentFile, actions.LineNo)
 			yyVAL.arguments = []*ast.CXArgument{arg}
 		}
 	case 33:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:330
+//line cxparser/cxpartialparsing/cxpartialparsing.y:331
 		{
 			arg := actions.DeclarationSpecifiersBasic(types.Code(yyDollar[1].i))
 			yyVAL.arguments = []*ast.CXArgument{arg}
 		}
 	case 34:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:335
+//line cxparser/cxpartialparsing/cxpartialparsing.y:336
 		{
 			arg := actions.DeclarationSpecifiersStruct(Program, yyDollar[3].tok, "", false, actions.CurrentFile, actions.LineNo)
 			yyVAL.arguments = append(yyDollar[1].arguments, arg)
 		}
 	case 35:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:340
+//line cxparser/cxpartialparsing/cxpartialparsing.y:341
 		{
 			arg := actions.DeclarationSpecifiersBasic(types.Code(yyDollar[3].i))
 			yyVAL.arguments = append(yyDollar[1].arguments, arg)
 		}
 	case 36:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:348
+//line cxparser/cxpartialparsing/cxpartialparsing.y:349
 		{
 			yyVAL.arguments = yyDollar[2].arguments
 		}
 	case 37:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:352
+//line cxparser/cxpartialparsing/cxpartialparsing.y:353
 		{
 			yyVAL.arguments = nil
 		}
 	case 38:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:359
+//line cxparser/cxpartialparsing/cxpartialparsing.y:360
 		{
 			arg := ast.MakeArgument("", actions.CurrentFile, actions.LineNo).AddType(types.FUNC)
 			arg.Inputs = yyDollar[2].arguments
@@ -1418,165 +1417,165 @@ yydefault:
 		}
 	case 39:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:366
+//line cxparser/cxpartialparsing/cxpartialparsing.y:367
 		{
 			yyVAL.argument = actions.DeclarationSpecifiers(yyDollar[2].argument, []types.Pointer{0}, constants.DECL_POINTER)
 		}
 	case 40:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:374
+//line cxparser/cxpartialparsing/cxpartialparsing.y:375
 		{
 			yyVAL.argument = actions.DeclarationSpecifiers(yyDollar[3].argument, []types.Pointer{0}, constants.DECL_SLICE)
 		}
 	case 41:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:378
+//line cxparser/cxpartialparsing/cxpartialparsing.y:379
 		{
 			yyVAL.argument = actions.DeclarationSpecifiersBasic(types.Code(yyDollar[1].i))
 		}
 	case 42:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:382
+//line cxparser/cxpartialparsing/cxpartialparsing.y:383
 		{
 			yyVAL.argument = actions.DeclarationSpecifiersStruct(Program, yyDollar[1].tok, "", false, CurrentFileName, lineNo)
 		}
 	case 43:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:386
+//line cxparser/cxpartialparsing/cxpartialparsing.y:387
 		{
 			basic := actions.DeclarationSpecifiersBasic(types.Code(yyDollar[2].i))
 			yyVAL.argument = actions.DeclarationSpecifiers(basic, types.Cast_sint_to_sptr(yyDollar[1].ints), constants.DECL_ARRAY)
 		}
 	case 44:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:391
+//line cxparser/cxpartialparsing/cxpartialparsing.y:392
 		{
 			strct := actions.DeclarationSpecifiersStruct(Program, yyDollar[2].tok, "", false, actions.CurrentFile, actions.LineNo)
 			yyVAL.argument = actions.DeclarationSpecifiers(strct, types.Cast_sint_to_sptr(yyDollar[1].ints), constants.DECL_ARRAY)
 		}
 	case 45:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:396
+//line cxparser/cxpartialparsing/cxpartialparsing.y:397
 		{
 			yyVAL.argument = actions.DeclarationSpecifiersStruct(Program, yyDollar[3].tok, yyDollar[1].tok, true, CurrentFileName, lineNo)
 		}
 	case 46:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:400
+//line cxparser/cxpartialparsing/cxpartialparsing.y:401
 		{
 			yyVAL.argument = actions.DeclarationSpecifiersStruct(Program, yyDollar[3].tok, types.Code(yyDollar[1].i).Name(), true, CurrentFileName, lineNo)
 		}
 	case 47:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:411
+//line cxparser/cxpartialparsing/cxpartialparsing.y:412
 		{
 			yyVAL.i = int(types.AFF)
 		}
 	case 48:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:413
+//line cxparser/cxpartialparsing/cxpartialparsing.y:414
 		{
 			yyVAL.i = int(types.BOOL)
 		}
 	case 49:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:415
+//line cxparser/cxpartialparsing/cxpartialparsing.y:416
 		{
 			yyVAL.i = int(types.STR)
 		}
 	case 50:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:417
+//line cxparser/cxpartialparsing/cxpartialparsing.y:418
 		{
 			yyVAL.i = int(types.F32)
 		}
 	case 51:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:419
+//line cxparser/cxpartialparsing/cxpartialparsing.y:420
 		{
 			yyVAL.i = int(types.F64)
 		}
 	case 52:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:421
+//line cxparser/cxpartialparsing/cxpartialparsing.y:422
 		{
 			yyVAL.i = int(types.I8)
 		}
 	case 53:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:423
+//line cxparser/cxpartialparsing/cxpartialparsing.y:424
 		{
 			yyVAL.i = int(types.I16)
 		}
 	case 54:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:425
+//line cxparser/cxpartialparsing/cxpartialparsing.y:426
 		{
 			yyVAL.i = int(types.I32)
 		}
 	case 55:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:427
+//line cxparser/cxpartialparsing/cxpartialparsing.y:428
 		{
 			yyVAL.i = int(types.I64)
 		}
 	case 56:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:429
+//line cxparser/cxpartialparsing/cxpartialparsing.y:430
 		{
 			yyVAL.i = int(types.UI8)
 		}
 	case 57:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:431
+//line cxparser/cxpartialparsing/cxpartialparsing.y:432
 		{
 			yyVAL.i = int(types.UI16)
 		}
 	case 58:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:433
+//line cxparser/cxpartialparsing/cxpartialparsing.y:434
 		{
 			yyVAL.i = int(types.UI32)
 		}
 	case 59:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:435
+//line cxparser/cxpartialparsing/cxpartialparsing.y:436
 		{
 			yyVAL.i = int(types.UI64)
 		}
 	case 66:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:463
+//line cxparser/cxpartialparsing/cxpartialparsing.y:464
 		{
 			yyVAL.ints = []int{int(yyDollar[2].i32)}
 		}
 	case 67:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:467
+//line cxparser/cxpartialparsing/cxpartialparsing.y:468
 		{
 			yyVAL.ints = append(yyDollar[1].ints, int(yyDollar[3].i32))
 		}
 	case 68:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:474
+//line cxparser/cxpartialparsing/cxpartialparsing.y:475
 		{
 			yyVAL.ints = []int{0}
 		}
 	case 69:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:478
+//line cxparser/cxpartialparsing/cxpartialparsing.y:479
 		{
 			yyVAL.ints = append(yyDollar[1].ints, 0)
 		}
 	case 90:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:540
+//line cxparser/cxpartialparsing/cxpartialparsing.y:541
 		{
 			yyVAL.i32 = yyDollar[1].i32
 		}
 	case 91:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:544
+//line cxparser/cxpartialparsing/cxpartialparsing.y:545
 		{
 			yyVAL.i32 = -yyDollar[2].i32
 		}

--- a/cxparser/cxpartialparsing/cxpartialparsing.go
+++ b/cxparser/cxpartialparsing/cxpartialparsing.go
@@ -374,7 +374,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line cxparser/cxpartialparsing/cxpartialparsing.y:784
+//line cxparser/cxpartialparsing/cxpartialparsing.y:790
 
 //line yacctab:1
 var yyExca = [...]int{
@@ -1274,16 +1274,20 @@ yydefault:
 		{
 			if pkg, err := Program.GetCurrentPackage(); err == nil {
 				fn := ast.MakeFunction(yyDollar[2].tok, CurrentFileName, lineNo)
-				pkg.AddFunction(fn)
+				_, fnIdx := pkg.AddFunction(Program, fn)
+				newFn, err := Program.GetFunctionFromArray(fnIdx)
+				if err != nil {
+					panic(err)
+				}
 
-				yyVAL.function = fn
+				yyVAL.function = newFn
 			} else {
 				panic(err)
 			}
 		}
 	case 18:
 		yyDollar = yyS[yypt-5 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:235
+//line cxparser/cxpartialparsing/cxpartialparsing.y:239
 		{
 			if len(yyDollar[3].arguments) > 1 {
 				panic("method has multiple receivers")
@@ -1294,52 +1298,56 @@ yydefault:
 			if pkg, err := Program.GetCurrentPackage(); err == nil {
 				fn := ast.MakeFunction(fnName, CurrentFileName, lineNo)
 				fn.AddInput(yyDollar[3].arguments[0])
-				pkg.AddFunction(fn)
+				_, fnIdx := pkg.AddFunction(Program, fn)
+				newFn, err := Program.GetFunctionFromArray(fnIdx)
+				if err != nil {
+					panic(err)
+				}
 
-				yyVAL.function = fn
+				yyVAL.function = newFn
 			} else {
 				panic(err)
 			}
 		}
 	case 19:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:258
+//line cxparser/cxpartialparsing/cxpartialparsing.y:264
 		{
 			yyVAL.arguments = nil
 		}
 	case 20:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:260
+//line cxparser/cxpartialparsing/cxpartialparsing.y:266
 		{
 			yyVAL.arguments = yyDollar[2].arguments
 		}
 	case 21:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:265
+//line cxparser/cxpartialparsing/cxpartialparsing.y:271
 		{
 			PreFunctionDeclaration(yyDollar[1].function, yyDollar[2].arguments, nil)
 		}
 	case 22:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:269
+//line cxparser/cxpartialparsing/cxpartialparsing.y:275
 		{
 			PreFunctionDeclaration(yyDollar[1].function, yyDollar[2].arguments, yyDollar[3].arguments)
 		}
 	case 24:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:281
+//line cxparser/cxpartialparsing/cxpartialparsing.y:287
 		{
 			yyVAL.arguments = []*ast.CXArgument{yyDollar[1].argument}
 		}
 	case 25:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:285
+//line cxparser/cxpartialparsing/cxpartialparsing.y:291
 		{
 			yyVAL.arguments = append(yyDollar[1].arguments, yyDollar[3].argument)
 		}
 	case 26:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:292
+//line cxparser/cxpartialparsing/cxpartialparsing.y:298
 		{
 			yyDollar[2].argument.Name = yyDollar[1].argument.Name
 			yyDollar[2].argument.Package = yyDollar[1].argument.Package
@@ -1348,7 +1356,7 @@ yydefault:
 		}
 	case 30:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:310
+//line cxparser/cxpartialparsing/cxpartialparsing.y:316
 		{
 			if pkg, err := Program.GetCurrentPackage(); err == nil {
 				arg := ast.MakeArgument("", actions.CurrentFile, actions.LineNo)
@@ -1362,53 +1370,53 @@ yydefault:
 		}
 	case 31:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:322
+//line cxparser/cxpartialparsing/cxpartialparsing.y:328
 		{
 			yyVAL.argument = yyDollar[2].argument
 		}
 	case 32:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:326
+//line cxparser/cxpartialparsing/cxpartialparsing.y:332
 		{
 			arg := actions.DeclarationSpecifiersStruct(Program, yyDollar[1].tok, "", false, actions.CurrentFile, actions.LineNo)
 			yyVAL.arguments = []*ast.CXArgument{arg}
 		}
 	case 33:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:331
+//line cxparser/cxpartialparsing/cxpartialparsing.y:337
 		{
 			arg := actions.DeclarationSpecifiersBasic(types.Code(yyDollar[1].i))
 			yyVAL.arguments = []*ast.CXArgument{arg}
 		}
 	case 34:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:336
+//line cxparser/cxpartialparsing/cxpartialparsing.y:342
 		{
 			arg := actions.DeclarationSpecifiersStruct(Program, yyDollar[3].tok, "", false, actions.CurrentFile, actions.LineNo)
 			yyVAL.arguments = append(yyDollar[1].arguments, arg)
 		}
 	case 35:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:341
+//line cxparser/cxpartialparsing/cxpartialparsing.y:347
 		{
 			arg := actions.DeclarationSpecifiersBasic(types.Code(yyDollar[3].i))
 			yyVAL.arguments = append(yyDollar[1].arguments, arg)
 		}
 	case 36:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:349
+//line cxparser/cxpartialparsing/cxpartialparsing.y:355
 		{
 			yyVAL.arguments = yyDollar[2].arguments
 		}
 	case 37:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:353
+//line cxparser/cxpartialparsing/cxpartialparsing.y:359
 		{
 			yyVAL.arguments = nil
 		}
 	case 38:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:360
+//line cxparser/cxpartialparsing/cxpartialparsing.y:366
 		{
 			arg := ast.MakeArgument("", actions.CurrentFile, actions.LineNo).AddType(types.FUNC)
 			arg.Inputs = yyDollar[2].arguments
@@ -1417,165 +1425,165 @@ yydefault:
 		}
 	case 39:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:367
+//line cxparser/cxpartialparsing/cxpartialparsing.y:373
 		{
 			yyVAL.argument = actions.DeclarationSpecifiers(yyDollar[2].argument, []types.Pointer{0}, constants.DECL_POINTER)
 		}
 	case 40:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:375
+//line cxparser/cxpartialparsing/cxpartialparsing.y:381
 		{
 			yyVAL.argument = actions.DeclarationSpecifiers(yyDollar[3].argument, []types.Pointer{0}, constants.DECL_SLICE)
 		}
 	case 41:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:379
+//line cxparser/cxpartialparsing/cxpartialparsing.y:385
 		{
 			yyVAL.argument = actions.DeclarationSpecifiersBasic(types.Code(yyDollar[1].i))
 		}
 	case 42:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:383
+//line cxparser/cxpartialparsing/cxpartialparsing.y:389
 		{
 			yyVAL.argument = actions.DeclarationSpecifiersStruct(Program, yyDollar[1].tok, "", false, CurrentFileName, lineNo)
 		}
 	case 43:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:387
+//line cxparser/cxpartialparsing/cxpartialparsing.y:393
 		{
 			basic := actions.DeclarationSpecifiersBasic(types.Code(yyDollar[2].i))
 			yyVAL.argument = actions.DeclarationSpecifiers(basic, types.Cast_sint_to_sptr(yyDollar[1].ints), constants.DECL_ARRAY)
 		}
 	case 44:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:392
+//line cxparser/cxpartialparsing/cxpartialparsing.y:398
 		{
 			strct := actions.DeclarationSpecifiersStruct(Program, yyDollar[2].tok, "", false, actions.CurrentFile, actions.LineNo)
 			yyVAL.argument = actions.DeclarationSpecifiers(strct, types.Cast_sint_to_sptr(yyDollar[1].ints), constants.DECL_ARRAY)
 		}
 	case 45:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:397
+//line cxparser/cxpartialparsing/cxpartialparsing.y:403
 		{
 			yyVAL.argument = actions.DeclarationSpecifiersStruct(Program, yyDollar[3].tok, yyDollar[1].tok, true, CurrentFileName, lineNo)
 		}
 	case 46:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:401
+//line cxparser/cxpartialparsing/cxpartialparsing.y:407
 		{
 			yyVAL.argument = actions.DeclarationSpecifiersStruct(Program, yyDollar[3].tok, types.Code(yyDollar[1].i).Name(), true, CurrentFileName, lineNo)
 		}
 	case 47:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:412
+//line cxparser/cxpartialparsing/cxpartialparsing.y:418
 		{
 			yyVAL.i = int(types.AFF)
 		}
 	case 48:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:414
+//line cxparser/cxpartialparsing/cxpartialparsing.y:420
 		{
 			yyVAL.i = int(types.BOOL)
 		}
 	case 49:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:416
+//line cxparser/cxpartialparsing/cxpartialparsing.y:422
 		{
 			yyVAL.i = int(types.STR)
 		}
 	case 50:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:418
+//line cxparser/cxpartialparsing/cxpartialparsing.y:424
 		{
 			yyVAL.i = int(types.F32)
 		}
 	case 51:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:420
+//line cxparser/cxpartialparsing/cxpartialparsing.y:426
 		{
 			yyVAL.i = int(types.F64)
 		}
 	case 52:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:422
+//line cxparser/cxpartialparsing/cxpartialparsing.y:428
 		{
 			yyVAL.i = int(types.I8)
 		}
 	case 53:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:424
+//line cxparser/cxpartialparsing/cxpartialparsing.y:430
 		{
 			yyVAL.i = int(types.I16)
 		}
 	case 54:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:426
+//line cxparser/cxpartialparsing/cxpartialparsing.y:432
 		{
 			yyVAL.i = int(types.I32)
 		}
 	case 55:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:428
+//line cxparser/cxpartialparsing/cxpartialparsing.y:434
 		{
 			yyVAL.i = int(types.I64)
 		}
 	case 56:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:430
+//line cxparser/cxpartialparsing/cxpartialparsing.y:436
 		{
 			yyVAL.i = int(types.UI8)
 		}
 	case 57:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:432
+//line cxparser/cxpartialparsing/cxpartialparsing.y:438
 		{
 			yyVAL.i = int(types.UI16)
 		}
 	case 58:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:434
+//line cxparser/cxpartialparsing/cxpartialparsing.y:440
 		{
 			yyVAL.i = int(types.UI32)
 		}
 	case 59:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:436
+//line cxparser/cxpartialparsing/cxpartialparsing.y:442
 		{
 			yyVAL.i = int(types.UI64)
 		}
 	case 66:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:464
+//line cxparser/cxpartialparsing/cxpartialparsing.y:470
 		{
 			yyVAL.ints = []int{int(yyDollar[2].i32)}
 		}
 	case 67:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:468
+//line cxparser/cxpartialparsing/cxpartialparsing.y:474
 		{
 			yyVAL.ints = append(yyDollar[1].ints, int(yyDollar[3].i32))
 		}
 	case 68:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:475
+//line cxparser/cxpartialparsing/cxpartialparsing.y:481
 		{
 			yyVAL.ints = []int{0}
 		}
 	case 69:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:479
+//line cxparser/cxpartialparsing/cxpartialparsing.y:485
 		{
 			yyVAL.ints = append(yyDollar[1].ints, 0)
 		}
 	case 90:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:541
+//line cxparser/cxpartialparsing/cxpartialparsing.y:547
 		{
 			yyVAL.i32 = yyDollar[1].i32
 		}
 	case 91:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:545
+//line cxparser/cxpartialparsing/cxpartialparsing.y:551
 		{
 			yyVAL.i32 = -yyDollar[2].i32
 		}

--- a/cxparser/cxpartialparsing/cxpartialparsing.go
+++ b/cxparser/cxpartialparsing/cxpartialparsing.go
@@ -374,7 +374,7 @@ const yyEofCode = 1
 const yyErrCode = 2
 const yyInitialStackSize = 16
 
-//line cxparser/cxpartialparsing/cxpartialparsing.y:790
+//line cxparser/cxpartialparsing/cxpartialparsing.y:789
 
 //line yacctab:1
 var yyExca = [...]int{
@@ -1297,13 +1297,12 @@ yydefault:
 
 			if pkg, err := Program.GetCurrentPackage(); err == nil {
 				fn := ast.MakeFunction(fnName, CurrentFileName, lineNo)
-				fn.AddInput(yyDollar[3].arguments[0])
 				_, fnIdx := pkg.AddFunction(Program, fn)
 				newFn, err := Program.GetFunctionFromArray(fnIdx)
 				if err != nil {
 					panic(err)
 				}
-
+				newFn.AddInput(yyDollar[3].arguments[0])
 				yyVAL.function = newFn
 			} else {
 				panic(err)
@@ -1311,43 +1310,43 @@ yydefault:
 		}
 	case 19:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:264
+//line cxparser/cxpartialparsing/cxpartialparsing.y:263
 		{
 			yyVAL.arguments = nil
 		}
 	case 20:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:266
+//line cxparser/cxpartialparsing/cxpartialparsing.y:265
 		{
 			yyVAL.arguments = yyDollar[2].arguments
 		}
 	case 21:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:271
+//line cxparser/cxpartialparsing/cxpartialparsing.y:270
 		{
 			PreFunctionDeclaration(yyDollar[1].function, yyDollar[2].arguments, nil)
 		}
 	case 22:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:275
+//line cxparser/cxpartialparsing/cxpartialparsing.y:274
 		{
 			PreFunctionDeclaration(yyDollar[1].function, yyDollar[2].arguments, yyDollar[3].arguments)
 		}
 	case 24:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:287
+//line cxparser/cxpartialparsing/cxpartialparsing.y:286
 		{
 			yyVAL.arguments = []*ast.CXArgument{yyDollar[1].argument}
 		}
 	case 25:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:291
+//line cxparser/cxpartialparsing/cxpartialparsing.y:290
 		{
 			yyVAL.arguments = append(yyDollar[1].arguments, yyDollar[3].argument)
 		}
 	case 26:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:298
+//line cxparser/cxpartialparsing/cxpartialparsing.y:297
 		{
 			yyDollar[2].argument.Name = yyDollar[1].argument.Name
 			yyDollar[2].argument.Package = yyDollar[1].argument.Package
@@ -1356,7 +1355,7 @@ yydefault:
 		}
 	case 30:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:316
+//line cxparser/cxpartialparsing/cxpartialparsing.y:315
 		{
 			if pkg, err := Program.GetCurrentPackage(); err == nil {
 				arg := ast.MakeArgument("", actions.CurrentFile, actions.LineNo)
@@ -1370,53 +1369,53 @@ yydefault:
 		}
 	case 31:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:328
+//line cxparser/cxpartialparsing/cxpartialparsing.y:327
 		{
 			yyVAL.argument = yyDollar[2].argument
 		}
 	case 32:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:332
+//line cxparser/cxpartialparsing/cxpartialparsing.y:331
 		{
 			arg := actions.DeclarationSpecifiersStruct(Program, yyDollar[1].tok, "", false, actions.CurrentFile, actions.LineNo)
 			yyVAL.arguments = []*ast.CXArgument{arg}
 		}
 	case 33:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:337
+//line cxparser/cxpartialparsing/cxpartialparsing.y:336
 		{
 			arg := actions.DeclarationSpecifiersBasic(types.Code(yyDollar[1].i))
 			yyVAL.arguments = []*ast.CXArgument{arg}
 		}
 	case 34:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:342
+//line cxparser/cxpartialparsing/cxpartialparsing.y:341
 		{
 			arg := actions.DeclarationSpecifiersStruct(Program, yyDollar[3].tok, "", false, actions.CurrentFile, actions.LineNo)
 			yyVAL.arguments = append(yyDollar[1].arguments, arg)
 		}
 	case 35:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:347
+//line cxparser/cxpartialparsing/cxpartialparsing.y:346
 		{
 			arg := actions.DeclarationSpecifiersBasic(types.Code(yyDollar[3].i))
 			yyVAL.arguments = append(yyDollar[1].arguments, arg)
 		}
 	case 36:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:355
+//line cxparser/cxpartialparsing/cxpartialparsing.y:354
 		{
 			yyVAL.arguments = yyDollar[2].arguments
 		}
 	case 37:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:359
+//line cxparser/cxpartialparsing/cxpartialparsing.y:358
 		{
 			yyVAL.arguments = nil
 		}
 	case 38:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:366
+//line cxparser/cxpartialparsing/cxpartialparsing.y:365
 		{
 			arg := ast.MakeArgument("", actions.CurrentFile, actions.LineNo).AddType(types.FUNC)
 			arg.Inputs = yyDollar[2].arguments
@@ -1425,165 +1424,165 @@ yydefault:
 		}
 	case 39:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:373
+//line cxparser/cxpartialparsing/cxpartialparsing.y:372
 		{
 			yyVAL.argument = actions.DeclarationSpecifiers(yyDollar[2].argument, []types.Pointer{0}, constants.DECL_POINTER)
 		}
 	case 40:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:381
+//line cxparser/cxpartialparsing/cxpartialparsing.y:380
 		{
 			yyVAL.argument = actions.DeclarationSpecifiers(yyDollar[3].argument, []types.Pointer{0}, constants.DECL_SLICE)
 		}
 	case 41:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:385
+//line cxparser/cxpartialparsing/cxpartialparsing.y:384
 		{
 			yyVAL.argument = actions.DeclarationSpecifiersBasic(types.Code(yyDollar[1].i))
 		}
 	case 42:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:389
+//line cxparser/cxpartialparsing/cxpartialparsing.y:388
 		{
 			yyVAL.argument = actions.DeclarationSpecifiersStruct(Program, yyDollar[1].tok, "", false, CurrentFileName, lineNo)
 		}
 	case 43:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:393
+//line cxparser/cxpartialparsing/cxpartialparsing.y:392
 		{
 			basic := actions.DeclarationSpecifiersBasic(types.Code(yyDollar[2].i))
 			yyVAL.argument = actions.DeclarationSpecifiers(basic, types.Cast_sint_to_sptr(yyDollar[1].ints), constants.DECL_ARRAY)
 		}
 	case 44:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:398
+//line cxparser/cxpartialparsing/cxpartialparsing.y:397
 		{
 			strct := actions.DeclarationSpecifiersStruct(Program, yyDollar[2].tok, "", false, actions.CurrentFile, actions.LineNo)
 			yyVAL.argument = actions.DeclarationSpecifiers(strct, types.Cast_sint_to_sptr(yyDollar[1].ints), constants.DECL_ARRAY)
 		}
 	case 45:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:403
+//line cxparser/cxpartialparsing/cxpartialparsing.y:402
 		{
 			yyVAL.argument = actions.DeclarationSpecifiersStruct(Program, yyDollar[3].tok, yyDollar[1].tok, true, CurrentFileName, lineNo)
 		}
 	case 46:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:407
+//line cxparser/cxpartialparsing/cxpartialparsing.y:406
 		{
 			yyVAL.argument = actions.DeclarationSpecifiersStruct(Program, yyDollar[3].tok, types.Code(yyDollar[1].i).Name(), true, CurrentFileName, lineNo)
 		}
 	case 47:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:418
+//line cxparser/cxpartialparsing/cxpartialparsing.y:417
 		{
 			yyVAL.i = int(types.AFF)
 		}
 	case 48:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:420
+//line cxparser/cxpartialparsing/cxpartialparsing.y:419
 		{
 			yyVAL.i = int(types.BOOL)
 		}
 	case 49:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:422
+//line cxparser/cxpartialparsing/cxpartialparsing.y:421
 		{
 			yyVAL.i = int(types.STR)
 		}
 	case 50:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:424
+//line cxparser/cxpartialparsing/cxpartialparsing.y:423
 		{
 			yyVAL.i = int(types.F32)
 		}
 	case 51:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:426
+//line cxparser/cxpartialparsing/cxpartialparsing.y:425
 		{
 			yyVAL.i = int(types.F64)
 		}
 	case 52:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:428
+//line cxparser/cxpartialparsing/cxpartialparsing.y:427
 		{
 			yyVAL.i = int(types.I8)
 		}
 	case 53:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:430
+//line cxparser/cxpartialparsing/cxpartialparsing.y:429
 		{
 			yyVAL.i = int(types.I16)
 		}
 	case 54:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:432
+//line cxparser/cxpartialparsing/cxpartialparsing.y:431
 		{
 			yyVAL.i = int(types.I32)
 		}
 	case 55:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:434
+//line cxparser/cxpartialparsing/cxpartialparsing.y:433
 		{
 			yyVAL.i = int(types.I64)
 		}
 	case 56:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:436
+//line cxparser/cxpartialparsing/cxpartialparsing.y:435
 		{
 			yyVAL.i = int(types.UI8)
 		}
 	case 57:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:438
+//line cxparser/cxpartialparsing/cxpartialparsing.y:437
 		{
 			yyVAL.i = int(types.UI16)
 		}
 	case 58:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:440
+//line cxparser/cxpartialparsing/cxpartialparsing.y:439
 		{
 			yyVAL.i = int(types.UI32)
 		}
 	case 59:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:442
+//line cxparser/cxpartialparsing/cxpartialparsing.y:441
 		{
 			yyVAL.i = int(types.UI64)
 		}
 	case 66:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:470
+//line cxparser/cxpartialparsing/cxpartialparsing.y:469
 		{
 			yyVAL.ints = []int{int(yyDollar[2].i32)}
 		}
 	case 67:
 		yyDollar = yyS[yypt-4 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:474
+//line cxparser/cxpartialparsing/cxpartialparsing.y:473
 		{
 			yyVAL.ints = append(yyDollar[1].ints, int(yyDollar[3].i32))
 		}
 	case 68:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:481
+//line cxparser/cxpartialparsing/cxpartialparsing.y:480
 		{
 			yyVAL.ints = []int{0}
 		}
 	case 69:
 		yyDollar = yyS[yypt-3 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:485
+//line cxparser/cxpartialparsing/cxpartialparsing.y:484
 		{
 			yyVAL.ints = append(yyDollar[1].ints, 0)
 		}
 	case 90:
 		yyDollar = yyS[yypt-1 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:547
+//line cxparser/cxpartialparsing/cxpartialparsing.y:546
 		{
 			yyVAL.i32 = yyDollar[1].i32
 		}
 	case 91:
 		yyDollar = yyS[yypt-2 : yypt+1]
-//line cxparser/cxpartialparsing/cxpartialparsing.y:551
+//line cxparser/cxpartialparsing/cxpartialparsing.y:550
 		{
 			yyVAL.i32 = -yyDollar[2].i32
 		}

--- a/cxparser/cxpartialparsing/cxpartialparsing.y
+++ b/cxparser/cxpartialparsing/cxpartialparsing.y
@@ -245,13 +245,12 @@ function_header:
 
 			if pkg, err := Program.GetCurrentPackage(); err == nil {
 				fn := ast.MakeFunction(fnName, CurrentFileName, lineNo)
-                                fn.AddInput($3[0])
 				_,fnIdx:=pkg.AddFunction(Program,fn)
                                 newFn,err:=Program.GetFunctionFromArray(fnIdx)
                                 if err!=nil{
                                         panic(err)
                                 }
-                                
+                                newFn.AddInput($3[0])
                                 $$ = newFn
 			} else {
 				panic(err)

--- a/cxparser/cxpartialparsing/cxpartialparsing.y
+++ b/cxparser/cxpartialparsing/cxpartialparsing.y
@@ -241,9 +241,10 @@ function_header:
 
 			if pkg, err := Program.GetCurrentPackage(); err == nil {
 				fn := ast.MakeFunction(fnName, CurrentFileName, lineNo)
+                                fn.AddInput($3[0])
 				pkg.AddFunction(fn)
 
-                                fn.AddInput($3[0])
+                                
 
                                 $$ = fn
 			} else {
@@ -311,7 +312,7 @@ direct_declarator:
 				arg := ast.MakeArgument("", actions.CurrentFile, actions.LineNo)
 				arg.AddType(types.UNDEFINED)
 				arg.Name = $1
-				arg.Package = pkg
+				arg.Package = ast.CXPackageIndex(pkg.Index)
 				$$ = arg
 			} else {
 				panic(err)

--- a/cxparser/cxpartialparsing/cxpartialparsing.y
+++ b/cxparser/cxpartialparsing/cxpartialparsing.y
@@ -224,9 +224,13 @@ function_header:
                 {
 			if pkg, err := Program.GetCurrentPackage(); err == nil {
 				fn := ast.MakeFunction($2, CurrentFileName, lineNo)
-				pkg.AddFunction(fn)
+				_,fnIdx:=pkg.AddFunction(Program,fn)
+                                newFn,err:=Program.GetFunctionFromArray(fnIdx)
+                                if err!=nil{
+                                        panic(err)
+                                }
 
-                                $$ = fn
+                                $$ = newFn
 			} else {
 				panic(err)
 			}
@@ -242,11 +246,13 @@ function_header:
 			if pkg, err := Program.GetCurrentPackage(); err == nil {
 				fn := ast.MakeFunction(fnName, CurrentFileName, lineNo)
                                 fn.AddInput($3[0])
-				pkg.AddFunction(fn)
-
+				_,fnIdx:=pkg.AddFunction(Program,fn)
+                                newFn,err:=Program.GetFunctionFromArray(fnIdx)
+                                if err!=nil{
+                                        panic(err)
+                                }
                                 
-
-                                $$ = fn
+                                $$ = newFn
 			} else {
 				panic(err)
 			}

--- a/cxparser/webapi/api.go
+++ b/cxparser/webapi/api.go
@@ -48,7 +48,12 @@ func ProgramMeta(pg *ast.CXProgram) http.HandlerFunc {
 func PackagesOfProgram(pg *ast.CXProgram) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		pkgNames := make([]string, 0, len(pg.Packages))
-		for _, pkg := range pg.Packages {
+		for _, pkgIdx := range pg.Packages {
+			pkg, err := pg.GetPackageFromArray(pkgIdx)
+			if err != nil {
+				panic(err)
+			}
+
 			pkgNames = append(pkgNames, pkg.Name)
 		}
 
@@ -60,7 +65,12 @@ func PackagesOfProgram(pg *ast.CXProgram) http.HandlerFunc {
 // ExportedSymbolsOfPackage returns exported symbols of a given package.
 func ExportedSymbolsOfPackage(pg *ast.CXProgram, pkgName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		for _, pkg := range pg.Packages {
+		for _, pkgIdx := range pg.Packages {
+			pkg, err := pg.GetPackageFromArray(pkgIdx)
+			if err != nil {
+				panic(err)
+			}
+
 			if pkg.Name != pkgName {
 				continue
 			}

--- a/cxparser/webapi/symbols.go
+++ b/cxparser/webapi/symbols.go
@@ -46,7 +46,11 @@ func extractExportedSymbols(prgrm *ast.CXProgram, pkg *ast.CXPackage) ExportedSy
 		Globals:   make([]ExportedSymbol, 0, len(pkg.Globals)),
 	}
 
-	for _, f := range pkg.Functions {
+	for _, fIdx := range pkg.Functions {
+		f, err := prgrm.GetFunctionFromArray(fIdx)
+		if err != nil {
+			panic(err)
+		}
 		if isExported(f.Name) {
 			resp.Functions = append(resp.Functions, displayCXFunction(prgrm, pkg, f))
 		}


### PR DESCRIPTION
Fixes #

Changes:
- Add CXPackages Array
- Use CXPackages array for CXProgram Packages
- Remove pointer from CXArg and CXLine arrays
- Reference CXProgram-ProgramInput with cx arg index
- Reference with pkg index the package property of CXStruct
- Reference all cxpackages with their indexes
- Reference functions in cxpackage with their indexes

Does this change need to be mentioned in CHANGELOG.md?
