### PR TITLE
fix declaration with keyword syntax checking error

### DIFF
--- a/cmd/declaration_extractor/declaration_extractor_test.go
+++ b/cmd/declaration_extractor/declaration_extractor_test.go
@@ -1453,7 +1453,7 @@ func TestDeclarationExtractor_ExtractAllDeclarations(t *testing.T) {
 
 			Imports, Globals, Enums, TypeDefinitions, Structs, Funcs, gotErr := declaration_extractor.ExtractAllDeclarations(files)
 
-			if len(Globals) == 0 && len(Enums) == 0 && len(Structs) == 0 && len(Funcs) == 0 {
+			if len(Imports) == 0 && len(Globals) == 0 && len(Enums) == 0 && len(Structs) == 0 && len(Funcs) == 0 {
 				t.Error("No Declarations found")
 			}
 

--- a/cmd/declaration_extractor/enums.go
+++ b/cmd/declaration_extractor/enums.go
@@ -25,7 +25,7 @@ func ExtractEnums(source []byte, fileName string) ([]EnumDeclaration, error) {
 	var pkg string
 
 	//Regexes
-	rePkg := regexp.MustCompile("package")
+	rePkg := regexp.MustCompile(`^(?:.+\s+|\s*)package(?:\s+[\S\s]+|\s*)$`)
 	rePkgName := regexp.MustCompile(`package\s+([_a-zA-Z][_a-zA-Z0-9]*)`)
 	reEnumInit := regexp.MustCompile(`const\s+\(`)
 	rePrtsClose := regexp.MustCompile(`\)`)

--- a/cmd/declaration_extractor/functions.go
+++ b/cmd/declaration_extractor/functions.go
@@ -23,9 +23,9 @@ func ExtractFuncs(source []byte, fileName string) ([]FuncDeclaration, error) {
 	var pkg string
 
 	// Regexes
-	rePkg := regexp.MustCompile("package")
+	rePkg := regexp.MustCompile(`^(?:.+\s+|\s*)package(?:\s+[\S\s]+|\s*)$`)
 	rePkgName := regexp.MustCompile(`package\s+([_a-zA-Z][_a-zA-Z0-9]*)`)
-	reFunc := regexp.MustCompile(`func`)
+	reFunc := regexp.MustCompile(`^(?:.+\s+|\s*)func(?:\s+[\S\s]+|\([\S\s]+|\s*)$`)
 	reNotSpace := regexp.MustCompile(`\S+`)
 
 	// Func Declaration regex for name extraction and syntax checking

--- a/cmd/declaration_extractor/globals.go
+++ b/cmd/declaration_extractor/globals.go
@@ -25,9 +25,9 @@ func ExtractGlobals(source []byte, fileName string) ([]GlobalDeclaration, error)
 	var pkg string
 
 	//Regexs
-	rePkg := regexp.MustCompile("package")
+	rePkg := regexp.MustCompile(`^(?:.+\s+|\s*)package(?:\s+[\S\s]+|\s*)$`)
 	rePkgName := regexp.MustCompile(`package\s+([_a-zA-Z][_a-zA-Z0-9]*)`)
-	reGlobal := regexp.MustCompile("var")
+	reGlobal := regexp.MustCompile(`^(?:.+\s+|\s*)var(?:\s+[\S\s]+|\s*)$`)
 	reGlobalName := regexp.MustCompile(`var\s+([_a-zA-Z]\w*)\s+\*{0,1}\s*(?:\[(?:[1-9]\d+|[0-9]){0,1}\]){0,1}\s*[_a-zA-Z]\w*(?:\.[_a-zA-Z]\w*)*(?:\s*\=\s*[\s\S]+\S+){0,1}`)
 	reBodyOpen := regexp.MustCompile("{")
 	reBodyClose := regexp.MustCompile("}")
@@ -69,7 +69,7 @@ func ExtractGlobals(source []byte, fileName string) ([]GlobalDeclaration, error)
 		}
 
 		// if match is found and body depth is 0
-		if reGlobal.FindAllIndex(line, -1) != nil {
+		if reGlobal.FindIndex(line) != nil {
 
 			matchGlobal := reGlobalName.FindSubmatch(line)
 			matchGlobalIdx := reGlobalName.FindIndex(line)

--- a/cmd/declaration_extractor/imports.go
+++ b/cmd/declaration_extractor/imports.go
@@ -21,7 +21,7 @@ func ExtractImports(source []byte, fileName string) ([]ImportDeclaration, error)
 	var pkg string
 
 	//Regexs
-	rePkg := regexp.MustCompile(`^(?:.+\s+|)package(?:\s+.+|)$`)
+	rePkg := regexp.MustCompile(`^(?:.+\s+|\s*)package(?:\s+[\S\s]+|\s*)$`)
 	rePkgName := regexp.MustCompile(`^\s*package\s+([_a-zA-Z][_a-zA-Z0-9]*)`)
 
 	reader := bytes.NewReader(source)

--- a/cmd/declaration_extractor/structs.go
+++ b/cmd/declaration_extractor/structs.go
@@ -32,7 +32,7 @@ func ExtractStructs(source []byte, fileName string) ([]StructDeclaration, error)
 
 	// Regexes
 	reNotSpace := regexp.MustCompile(`\S+`)
-	rePkg := regexp.MustCompile("package")
+	rePkg := regexp.MustCompile(`^(?:.+\s+|\s*)package(?:\s+[\S\s]+|\s*)$`)
 	rePkgName := regexp.MustCompile(`package\s+([_a-zA-Z][_a-zA-Z0-9]*)`)
 	reStruct := regexp.MustCompile(`type\s+[_a-zA-Z][_a-zA-Z0-9]*\s+struct`)
 	reStructHeader := regexp.MustCompile(`type\s+([_a-zA-Z][_a-zA-Z0-9]*)\s+struct\s*{`)

--- a/cmd/declaration_extractor/test_files/ExtractAllDeclarations/MultipleFiles/src/helperpackage/helperpackage.cx
+++ b/cmd/declaration_extractor/test_files/ExtractAllDeclarations/MultipleFiles/src/helperpackage/helperpackage.cx
@@ -1,4 +1,4 @@
-package helper
+package helperpackage
 
 type helpUnit struct {
     name str

--- a/cmd/declaration_extractor/test_files/ExtractAllDeclarations/MultipleFiles/src/main.cx
+++ b/cmd/declaration_extractor/test_files/ExtractAllDeclarations/MultipleFiles/src/main.cx
@@ -1,12 +1,12 @@
 package main
 
-import "helper"
+import "helperpackage"
 
 import "program"
 
 var msg str = "Hello World"
 
-var myHelper helper.helpUnit
+var myHelper helperpackage.helpUnit
 
 var number i32 = 19
 

--- a/cmd/declaration_extractor/test_files/ExtractAllDeclarations/SingleFile/src/singleFile.cx
+++ b/cmd/declaration_extractor/test_files/ExtractAllDeclarations/SingleFile/src/singleFile.cx
@@ -1,10 +1,10 @@
 package main
 
-var number i32
+var varnumber i32
 
 var string str = "Hello World"
 
-type fruit i64
+type fruittype i64
 
 const (
     Apple fruit = iota
@@ -16,7 +16,7 @@ type Blender struct {
     fruits str
 }
 
-func (b *Blender) blend () {
+func (b *Blender) funcblend () {
     str.print(b.fruits)
 }
 

--- a/cmd/declaration_extractor/type_definitions.go
+++ b/cmd/declaration_extractor/type_definitions.go
@@ -22,9 +22,9 @@ func ExtractTypeDefinitions(source []byte, fileName string) ([]TypeDefinitionDec
 	var pkg string
 
 	// Regexes
-	rePkg := regexp.MustCompile("package")
+	rePkg := regexp.MustCompile(`^(?:.+\s+|\s*)package(?:\s+[\S\s]+|\s*)$`)
 	rePkgName := regexp.MustCompile(`package\s+([_a-zA-Z][_a-zA-Z0-9]*)`)
-	reType := regexp.MustCompile(`type`)
+	reType := regexp.MustCompile(`(?:.+\s+|\s*)type(?:\s+[\S\s]+|\s*)$`)
 	reTypeDefinition := regexp.MustCompile(`type\s+([_a-zA-Z][_a-zA-Z0-9]*)\s+([_a-zA-Z]\w*(?:\.[_a-zA-Z]\w*)*)`)
 
 	reader := bytes.NewReader(source)


### PR DESCRIPTION
Fixes #

Changes:
-  fix error return with declaration includes a keyword like “packageName”, “funcA” or “variable”

Does this change need to mentioned in CHANGELOG.md?
